### PR TITLE
Enable full static render for docs

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
 	titleTemplate: "%s | MPP",
 	description:
 		"Machine Payments Protocol - Internet-native payments for machine-to-machine transactions",
+	renderStrategy: "full-static",
 	ogImageUrl:
 		"https://vocs.dev/api/og?logo=%logo&title=%title&description=%description",
 


### PR DESCRIPTION
Adds renderStrategy: "full-static" to ensure index.html and static pages are generated for preview/prod deployments.