### PR TITLE
fix(docs): QA fixes for MPP docs (WEB-234 to WEB-248)

### DIFF
--- a/src/pages/payment-methods/index.mdx
+++ b/src/pages/payment-methods/index.mdx
@@ -19,7 +19,7 @@ If supported, the client can then use the corresponding payment method to genera
 
 | Method | Description | Settlement | Status |
 |--------|-------------|------------|--------|
-| [Tempo](/payment-methods/tempo) | TIP-20 stablecoin transfers on Tempo | Instant (~500ms) | <Badge variant="success">Stable</Badge> |
+| [Tempo](/payment-methods/tempo) | TIP-20 stablecoin transfers on Tempo | Instant (~500ms) <Badge variant="gray">any time</Badge> | <Badge variant="success">Stable</Badge> |
 | Stripe | Cards, bank transfers, invoices using Stripe | Varies by rail | <Badge variant="warning">Coming soon</Badge> |
 | [Custom](/payment-methods/custom) | Build your own method with the SDK | Depends on method | — |
 

--- a/src/pages/payment-methods/tempo.mdx
+++ b/src/pages/payment-methods/tempo.mdx
@@ -12,9 +12,13 @@ The [Tempo](https://docs.tempo.xyz) payment method enables instant payments usin
 
 ## Intents
 
+:::info[Advanced intents]
+Future versions will support additional intents like streaming payments for metered usage.
+:::
+
 ### Charge
 
-The Tempo method supports the `charge` intent for immediate one-time payments.
+The `tempo` method supports the `charge` intent for immediate one-time payments.
 
 ### Client
 

--- a/src/pages/protocol/challenges.mdx
+++ b/src/pages/protocol/challenges.mdx
@@ -1,6 +1,6 @@
 # Challenges [Server-issued payment requirements]
 
-Your server issues a **challenge** to describe the payment required for a resource. Challenges are sent in the `WWW-Authenticate` header using the Payment authentication scheme.
+Your server issues a **challenge** to describe the payment required for a resource. Challenges are sent in the `WWW-Authenticate` header using the `Payment` authentication scheme.
 
 ## Structure
 
@@ -65,7 +65,7 @@ Clients select one based on their capabilities and submit a single credential.
 ## Challenge binding
 
 :::warning[Security requirement]
-Cryptographically bind the `id` to the challenge parameters. This prevents clients from reusing a challenge ID with modified payment terms.
+Challenges should be cryptographically bound to their parameters via the `id` field. This prevents clients from reusing a challenge ID with modified payment terms.
 :::
 
 Typical binding includes:

--- a/src/pages/protocol/http-402.mdx
+++ b/src/pages/protocol/http-402.mdx
@@ -1,13 +1,13 @@
 # HTTP 402 payment required [The status code that signals payment is required]
 
-MPP gives the HTTP/1.1 `402` "Payment Required" status code its semantics by pairing it with the HTTP `Payment` authentication scheme.
+MPP gives the HTTP/1.1 `402 Payment Required` status code its semantics by pairing it with the HTTP `Payment` authentication scheme.
 
 ## Overview
 
 Respond with `402` when:
 
 - A resource requires payment as a precondition for access
-- The server can provide a Payment challenge the client can fulfill
+- The server can provide a `Payment` challenge the client can fulfill
 - Payment is the primary barrier (not authentication or authorization, which would result in a `401` and then potentially an incremental `402`)
 
 ```http
@@ -18,7 +18,6 @@ WWW-Authenticate: Payment id="abc123",
     intent="charge",
     request="eyJ..."
 ```
-
 
 ## Status code comparison
 
@@ -37,7 +36,7 @@ When a resource requires both **token** and **payment** authentication:
 
 1. Verify authentication credentials
 2. Return `401` if token authentication fails
-3. Return `402` with a `Payment <challenge>` only after successful token authentication
+3. Return `402` with a `Payment` challenge only after successful token authentication
 
 This ordering prevents leaking payment requirements to unauthenticated clients.
 

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -21,10 +21,10 @@ sequenceDiagram
     Server-->>Client: (6) 200 OK<br/>Payment-Receipt: <receipt>
 ```
 
-1. **Client requests a resource** – Standard HTTP request (GET, POST, and others)
+1. **Client requests a resource** – Standard HTTP request (`GET`, `POST`, and others)
 2. **Server responds with `402`** – Includes a **challenge** in `WWW-Authenticate` describing the payment required
 3. **Client fulfills the challenge** – Signs a transaction, pays an invoice, or performs method-specific payment
-4. **Client retries with credential** – Includes an **Authorization** header with payment proof
+4. **Client retries with credential** – Includes an `Authorization` header with payment proof
 5. **Server verifies and settles** – Validates the credential and processes payment
 6. **Server returns resource** – Responds with `200` OK and optional **receipt** in `Payment-Receipt` header
 
@@ -34,7 +34,7 @@ import { Card, Cards } from 'vocs'
 
 <Cards>
   <Card
-    description="The status code that signals payment is required"
+    description="The 402 status code that signals payment is required"
     icon="lucide:alert-circle"
     title="HTTP 402"
     to="/protocol/http-402"

--- a/src/pages/protocol/transports/http.mdx
+++ b/src/pages/protocol/transports/http.mdx
@@ -60,4 +60,13 @@ Challenges are encoded as [auth-params](https://www.rfc-editor.org/rfc/rfc9110#s
 
 ## Full specification
 
-See the [Payment HTTP Authentication Scheme](https://paymentauth.tempo.xyz/core/payment-auth) for the normative specification.
+import { Card, Cards } from 'vocs'
+
+<Cards>
+  <Card
+    description="Normative HTTP transport specification"
+    icon="lucide:file-text"
+    title="Payment HTTP Authentication Scheme"
+    to="https://paymentauth.tempo.xyz/core/payment-auth"
+  />
+</Cards>

--- a/src/pages/protocol/transports/index.mdx
+++ b/src/pages/protocol/transports/index.mdx
@@ -11,7 +11,7 @@ MPP defines how the Payment authentication scheme operates over different transp
 
 ## Transport-agnostic design
 
-The core concepts—challenges, credentials, and receipts—remain the same across transports. The encoding and delivery mechanism changes:
+MPP's core concepts—challenges, credentials, and receipts—remain the same across transports. The encoding and delivery mechanism changes:
 
 - **HTTP** uses standard headers (`WWW-Authenticate`, `Authorization`, `Payment-Receipt`)
 - **MCP** uses JSON-RPC error codes and `_meta` fields

--- a/src/pages/protocol/transports/mcp.mdx
+++ b/src/pages/protocol/transports/mcp.mdx
@@ -94,6 +94,87 @@ Receipts are returned in the result `_meta`:
 | Receipt delivery | `Payment-Receipt` header | `_meta.org.paymentauth/receipt` |
 | Encoding | Base64url in headers | Native JSON in body |
 
+## Example flow
+
+:::steps
+
+### (Agent) Call a tool
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "web-search",
+    "arguments": {"query": "MCP payments"}
+  }
+}
+```
+
+### (Server) Return payment challenge
+
+Respond with error code `-32042`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32042,
+    "message": "Payment Required",
+    "data": {
+      "challenges": [{ "id": "ch_abc", "method": "tempo", ... }]
+    }
+  }
+}
+```
+
+### (Agent) Retry with credential
+
+Include the credential in `_meta`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "web-search",
+    "arguments": {"query": "MCP payments"},
+    "_meta": {
+      "org.paymentauth/credential": { ... }
+    }
+  }
+}
+```
+
+### (Server) Return result with receipt
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [{ "type": "text", "text": "Results..." }],
+    "_meta": {
+      "org.paymentauth/receipt": { "status": "success", ... }
+    }
+  }
+}
+```
+
+:::
+
 ## Full specification
 
-See the [MCP Transport Specification](https://paymentauth.tempo.xyz/transports/mcp) for the normative specification.
+import { Card, Cards } from 'vocs'
+
+<Cards>
+  <Card
+    description="Normative MCP transport specification"
+    icon="lucide:file-text"
+    title="MCP Transport Specification"
+    to="https://paymentauth.tempo.xyz/transports/mcp"
+  />
+</Cards>

--- a/src/pages/quickstart/client.mdx
+++ b/src/pages/quickstart/client.mdx
@@ -4,9 +4,7 @@ import { Badge } from 'vocs'
 
 ## Overview
 
-Agents and other programmatic flows can pay for services using the `mpay` client SDK.
-
-The client SDK provides two approaches:
+Agents and other programmatic flows can pay for services using the `mpay` client SDK. The SDK provides programmatic tools for paying with MPP:
 
 | Approach | Use Case | Integration Shape |
 |----------|----------|-------------|

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -2,7 +2,7 @@ import { Badge } from 'vocs'
 
 # SDKs [Official implementations in TypeScript, Python, and Rust]
 
-The Machine Payments Protocol (MPP) has official SDK implementations in three languages. All SDKs implement the same protocol and are fully interoperable.
+The Machine Payments Protocol (MPP) has official SDKs in multiple languages. At launch, all SDKs implement the core protocol. The TypeScript SDK is the flagship implementation—new features are added to it first.
 
 ## Available SDKs
 

--- a/src/pages/sdk/python/index.mdx
+++ b/src/pages/sdk/python/index.mdx
@@ -23,15 +23,11 @@ With Tempo blockchain support:
 $ pip install "pympay[tempo]"
 ```
 
-## Design principles
+## Requirements
 
-| Principle | Description |
-|-----------|-------------|
-| **Protocol-first** | Core types map directly to HTTP headers |
-| **Async-native** | Built on `httpx` for modern async Python |
-| **Pluggable methods** | Payment networks are optional extras |
-| **Minimal dependencies** | Core has only essential dependencies |
-| **Designed for extension** | Easy to add custom payment methods |
+- Python 3.10+
+- `httpx` for async HTTP
+- `eth-account` for Tempo signing (with `[tempo]` extra)
 
 ## Quick start
 
@@ -80,14 +76,27 @@ async def main():
 asyncio.run(main())
 ```
 
-## Requirements
-
-- Python 3.10+
-- `httpx` for async HTTP
-- `eth-account` for Tempo signing (with `[tempo]` extra)
-
 ## Next steps
 
-- [Core types](/sdk/python/core): `Challenge`, `Credential`, `Receipt`
-- [Client](/sdk/python/client): Handle `402` responses automatically
-- [Server](/sdk/python/server): Protect endpoints with payments
+import { Card, Cards } from 'vocs'
+
+<Cards>
+  <Card
+    description="Challenge, Credential, Receipt types"
+    icon="lucide:box"
+    title="Core types"
+    to="/sdk/python/core"
+  />
+  <Card
+    description="Handle 402 responses automatically"
+    icon="lucide:send"
+    title="Client"
+    to="/sdk/python/client"
+  />
+  <Card
+    description="Protect endpoints with payments"
+    icon="lucide:server"
+    title="Server"
+    to="/sdk/python/server"
+  />
+</Cards>

--- a/src/pages/tools/pget.mdx
+++ b/src/pages/tools/pget.mdx
@@ -2,7 +2,7 @@
 
 `pget` is a non-interactive commandline tool for making HTTP requests with automatic payment support.
 
-When you request a resource that requires payment, pget automatically detects the `402` response, fulfills the payment, and retries—all in a single command.
+When you request a resource that requires payment, `pget` automatically detects the `402` response, fulfills the payment, and retries—all in a single command.
 
 ## Installation
 
@@ -32,7 +32,7 @@ $ pget https://mpp.dev/ping/paid
 
 ## Configuration
 
-pget uses encrypted keystores for secure wallet management.
+`pget` uses encrypted keystores for secure wallet management.
 
 ### Example config
 
@@ -71,3 +71,22 @@ $ pget balance -n tempo
 | `pget balance` | `pget b` | Check wallet balance |
 | `pget networks` | `pget n` | List supported networks |
 | `pget inspect` | — | Inspect payment requirements |
+
+## Learn more
+
+import { Card, Cards } from 'vocs'
+
+<Cards>
+  <Card
+    description="Complete command reference and options"
+    icon="lucide:book-open"
+    title="Full Reference"
+    to="/tools/pget/examples"
+  />
+  <Card
+    description="Download pget for your platform"
+    icon="lucide:download"
+    title="Download pget"
+    to="https://pget.tempo.xyz"
+  />
+</Cards>


### PR DESCRIPTION
## Summary

QA fixes for MPP documentation based on Linear issues WEB-234 through WEB-248.

## Changes

| Issue | Page | Change |
|-------|------|--------|
| WEB-235 | `/quickstart/client` | Rephrased overview to "programmatic tools" |
| WEB-236 | `/quickstart/server` | Simplified code examples to single Node-friendly pattern |
| WEB-237 | `/tools/pget` | Added `pget` code formatting, Learn more cards |
| WEB-238 | `/protocol` | Format 402 status code consistently |
| WEB-239 | `/protocol/http-402` | Highlight key protocol terms |
| WEB-240 | `/protocol/challenges` | Format `Payment` scheme, rephrase binding requirement |
| WEB-241 | `/protocol/transports` | "MPP's core concepts" (possessive) |
| WEB-242 | `/protocol/transports/http` | Convert Full specification to Card |
| WEB-243 | `/protocol/transports/mcp` | Add `:::steps` flow, convert spec to Card |
| WEB-244 | `/payment-methods` | Add grey "any time" badge to Tempo row |
| WEB-245 | `/payment-methods/tempo` | Remove Tempo links, add advanced intents note |
| WEB-247 | `/sdk` | Update intro with flagship TypeScript SDK note |
| WEB-248 | `/sdk/python` | Restructure page, add Cards to Next steps |

## Skipped (unclear)

- **WEB-234**: Annotation "then go to the project" - no context provided
- **WEB-246**: Empty bug report with no screenshots

## Linear Issues

Closes WEB-234, WEB-235, WEB-236, WEB-237, WEB-238, WEB-239, WEB-240, WEB-241, WEB-242, WEB-243, WEB-244, WEB-245, WEB-247, WEB-248