### PR TITLE
docs: swap Overview and Problem sections on homepage

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -2,16 +2,6 @@ import { Badge, Card, Cards } from 'vocs'
 
 # Machine Payments Protocol [The internet native payments protocol]
 
-## The problem with payments on the internet
-
-You have no shortage of ways to pay for things on the internet. Hundreds of payment methods give you ample space for personal preference, and optimized payment forms with one-click checkout ensure that the act of paying is low-friction and highly secure.
-
-However, the very things that make these payment flows familiar and fast for human purchasers are structural headwinds for programmatic consumption. Many have tried, but it is a consistent uphill battle to fight browser automation pipelines, visual captchas, and ever changing payment forms—all of which reduce reliability.
-
-This is not the fault of any individual payment method or credential. This is a global problem which exists at the _interface_ level: how buyer and seller negotiate cost, supported payment methods, and ultimately transact. 
-
-The Machine Payment Protocol addresses this issue, providing an internet native means of paying which strips away the complexity of rich checkout flows, while still providing robust security and reliability.
-
 ## Overview
 
 The Machine Payments Protocol (MPP) lets you accept payments from any client—humans, software, or AI agents—using standard HTTP control flows. Clients pay inline with their request, and you receive payment confirmation before delivering the response.
@@ -23,6 +13,16 @@ MPP is built around a simple core and is designed to be neutral to the implement
 - **Composable and designed for extension**—A core allows advanced flows like disputes or additional primitives like identity to be gradually introduced 
 - **Multi rail**—Crypto, cards, bank transfers, invoices. All payment methods can be supported through one protocol and flexible control flow
 - **Multi currency**—The protocol is currency agnostic, allowing for transactions in USD, EUR, BRL, USDC, BTC, or any other asset
+
+## The problem with payments on the internet
+
+You have no shortage of ways to pay for things on the internet. Hundreds of payment methods give you ample space for personal preference, and optimized payment forms with one-click checkout ensure that the act of paying is low-friction and highly secure.
+
+However, the very things that make these payment flows familiar and fast for human purchasers are structural headwinds for programmatic consumption. Many have tried, but it is a consistent uphill battle to fight browser automation pipelines, visual captchas, and ever changing payment forms—all of which reduce reliability.
+
+This is not the fault of any individual payment method or credential. This is a global problem which exists at the _interface_ level: how buyer and seller negotiate cost, supported payment methods, and ultimately transact. 
+
+The Machine Payment Protocol addresses this issue, providing an internet native means of paying which strips away the complexity of rich checkout flows, while still providing robust security and reliability.
 
 ## Use cases
 


### PR DESCRIPTION
Moves the Overview section before the Problem section on the homepage. Consumers might want to just know the BLUF first?