### PR TITLE
fix: sdk drift check should not fail workflow on drift detection

### DIFF
--- a/.github/actions/sdk-drift-check/action.yml
+++ b/.github/actions/sdk-drift-check/action.yml
@@ -79,8 +79,11 @@ runs:
         
         if [ $EXIT_CODE -eq 0 ]; then
           echo "status=passed" >> $GITHUB_OUTPUT
+        elif [ $EXIT_CODE -eq 1 ]; then
+          # Exit code 1 = drift detected (not an error, just informational)
+          echo "status=drift-detected" >> $GITHUB_OUTPUT
         else
-          echo "status=failed" >> $GITHUB_OUTPUT
+          # Exit code 2+ = actual error
+          echo "status=error" >> $GITHUB_OUTPUT
+          exit $EXIT_CODE
         fi
-        
-        exit $EXIT_CODE

--- a/.github/actions/sdk-drift-check/check-sdk-drift.ts
+++ b/.github/actions/sdk-drift-check/check-sdk-drift.ts
@@ -553,7 +553,10 @@ async function main() {
 		console.log(`Results written to: ${config.outputPath}`);
 	}
 
-	// Exit with error code if there are invalid references
+	// Exit codes:
+	// 0 = no drift
+	// 1 = drift detected (informational, not an error)
+	// 2 = actual error (script failure)
 	if (result.summary.invalid > 0) {
 		process.exit(1);
 	}
@@ -567,6 +570,6 @@ const isMain =
 if (isMain) {
 	main().catch((e) => {
 		console.error("Drift check failed:", e);
-		process.exit(1);
+		process.exit(2);
 	});
 }


### PR DESCRIPTION
The SDK drift check workflow was failing when drift was detected, but drift is informational (not an error).

**Changes:**
- Exit code 1 = drift detected (workflow continues)
- Exit code 2 = actual script error (workflow fails)

This ensures the workflow only fails on real errors, not when it successfully detects drift.