### PR TITLE
chore: use canonical descriptive names for code samples

### DIFF
--- a/src/pages/quickstart/client.mdx
+++ b/src/pages/quickstart/client.mdx
@@ -24,7 +24,7 @@ bun add mpay viem
 
 ### Define an account
 
-```ts twoslash [example.ts]
+```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'
 
 const account = privateKeyToAccount('0xabc…123')
@@ -38,7 +38,7 @@ With Tempo, you can also use [Passkey or WebCrypto accounts](https://viem.sh/tem
 
 Call `Fetch.polyfill` at startup. All `fetch` calls then handle payment challenges.
 
-```ts twoslash [example.ts]
+```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'
 import { Fetch, tempo } from 'mpay/client'
 
@@ -53,7 +53,7 @@ Fetch.polyfill({
 
 Use `fetch`. Payment happens when a server returns `402`.
 
-```ts [example.ts]
+```ts
 const response = await fetch('https://mpp.dev/ping/paid')
 ```
 
@@ -67,7 +67,7 @@ const response = await fetch('https://mpp.dev/ping/paid')
 
 Use `Fetch.from` to create a separate payment-enabled fetch without modifying the global:
 
-```ts twoslash [example.ts]
+```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'
 import { Fetch, tempo } from 'mpay/client'
 
@@ -85,7 +85,7 @@ const response = await paidFetch('https://mpp.dev/ping/paid')
 
 Pass accounts on individual requests instead of at setup:
 
-```ts twoslash [example.ts]
+```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'
 import { Fetch, tempo } from 'mpay/client'
 
@@ -110,7 +110,7 @@ Use `Mpay.create` for full control over the payment flow:
 - Implement custom retry logic
 - Handle credentials manually
 
-```ts twoslash [manual.ts]
+```ts twoslash
 import { Mpay, tempo } from 'mpay/client'
 import { privateKeyToAccount } from 'viem/accounts'
 
@@ -137,7 +137,7 @@ if (response.status === 402) {
 
 On success, the server returns a `Payment-Receipt` header:
 
-```ts [receipts.ts]
+```ts
 import { Receipt } from 'mpay'
 
 const header = response.headers.get('Payment-Receipt') // [!code hl]

--- a/src/pages/quickstart/pget.mdx
+++ b/src/pages/quickstart/pget.mdx
@@ -10,7 +10,7 @@ import { Card, Cards } from 'vocs'
 
 ### Install
 
-```bash [test.sh]
+```bash
 $ curl -fsSL https://pget.tempo.xyz/install.sh | bash
 ```
 
@@ -18,7 +18,7 @@ $ curl -fsSL https://pget.tempo.xyz/install.sh | bash
 
 Run the init wizard to set up your wallet:
 
-```bash [test.sh]
+```bash
 $ pget init
 ```
 
@@ -27,7 +27,7 @@ This creates a new encrypted keystore and saves your configuration to `~/.pget/c
 :::tip[Quick setup for testing]
 For quick testing without a keystore, set your private key directly:
 
-```bash [test.sh]
+```bash
 $ export PGET_PRIVATE_KEY="0x..."
 ```
 
@@ -35,7 +35,7 @@ $ export PGET_PRIVATE_KEY="0x..."
 
 ### Make your first paid request
 
-```bash [test.sh]
+```bash
 $ pget -vv https://mpp-docs.tempo.xyz/ping/paid
 ```
 
@@ -60,13 +60,13 @@ We host a live demo server at `mpp-docs.tempo.xyz` running on **Tempo testnet**.
 
 Use dry-run mode to see what would happen without actually paying:
 
-```bash [test.sh]
+```bash
 $ pget -D https://mpp-docs.tempo.xyz/ping/paid
 ```
 
 Or inspect the payment requirements before paying:
 
-```bash [test.sh]
+```bash
 $ pget inspect https://mpp-docs.tempo.xyz/ping/paid
 ```
 
@@ -74,7 +74,7 @@ $ pget inspect https://mpp-docs.tempo.xyz/ping/paid
 
 Protect yourself with a maximum payment amount:
 
-```bash [test.sh]
+```bash
 # Reject payments over 1 USD
 $ pget -M 1000000 https://mpp-docs.tempo.xyz/ping/paid
 ```
@@ -111,7 +111,7 @@ The agent calls pget like any other commandline tool when it detects a `402` Pay
 
 When an AI agent needs to access a paid resource, it runs:
 
-```bash [test.sh]
+```bash
 $ pget https://api.example.com/premium-data
 ```
 
@@ -125,7 +125,7 @@ pget includes safeguards for autonomous agent use:
 
 Set a maximum amount the agent can spend per request:
 
-```bash [test.sh]
+```bash
 # Limit to 0.50 USDC per request
 $ pget -M 500000 https://api.example.com/data
 ```
@@ -134,7 +134,7 @@ $ pget -M 500000 https://api.example.com/data
 
 Agents can preview costs before committing:
 
-```bash [test.sh]
+```bash
 $ pget -D https://api.example.com/expensive-endpoint
 ```
 
@@ -171,14 +171,14 @@ For AI agent frameworks that support skills, pget can be configured as a tool:
 
 ### Premium API access
 
-```bash [test.sh]
+```bash
 # Query a paid data API
 $ pget https://api.data-provider.com/market-data?symbol=BTC
 ```
 
 ### Paid compute
 
-```bash [test.sh]
+```bash
 # Run inference on a paid model
 $ pget -X POST \
   --json '{"prompt": "Explain quantum computing"}' \
@@ -187,7 +187,7 @@ $ pget -X POST \
 
 ### Commercial tools
 
-```bash [test.sh]
+```bash
 # Use a paid developer tool
 $ pget https://api.dev-tools.com/analyze?repo=myorg/myrepo
 ```

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -14,7 +14,7 @@ This quickstart demonstrates how to plug MPP into any server framework to accept
 
 Create an `Mpay` instance to request payment for protected resources.
 
-```ts twoslash [example.ts]
+```ts twoslash
 import { Mpay, tempo } from 'mpay/server'
 
 const mpay = Mpay.create({ method: tempo() })
@@ -42,7 +42,7 @@ const mpay = Mpay.create({
 
 Use the `mpay.charge(){:ts}` method to request payment from the client within your request handler.
 
-```ts twoslash [example.ts]
+```ts twoslash
 import { Mpay, tempo } from 'mpay/server' // [!code collapse:2 collapsed]
 
 const mpay = Mpay.create({ method: tempo() })
@@ -124,7 +124,7 @@ const response = await mpay.charge({
 
 Plug the handler into your framework of choice, like [Hono](https://hono.dev).
 
-```ts [example.ts]
+```ts
 import { Hono } from 'hono' // [!code focus]
 import { Mpay, tempo } from 'mpay/server'
 
@@ -178,7 +178,7 @@ on all `/resource` endpoints.
 
 After your server is running, test it with [pget](/tools/pget):
 
-```bash [test.sh]
+```bash
 # See the payment challenge
 $ pget inspect <your-server>/resource
 

--- a/src/pages/sdk/python/index.mdx
+++ b/src/pages/sdk/python/index.mdx
@@ -13,13 +13,13 @@ The `mpay` Python library provides a typed interface over the Machine Payments P
 
 ## Install
 
-```bash [test.sh]
+```bash
 $ pip install pympay
 ```
 
 With Tempo blockchain support:
 
-```bash [test.sh]
+```bash
 $ pip install "pympay[tempo]"
 ```
 
@@ -33,7 +33,7 @@ $ pip install "pympay[tempo]"
 
 ### Server
 
-```python [server.py]
+```python
 from datetime import datetime, timedelta, UTC
 from fastapi import FastAPI, Request
 from mpay import Credential, Receipt
@@ -61,7 +61,7 @@ async def get_resource(request: Request, credential: Credential, receipt: Receip
 
 ### Client
 
-```python [client.py]
+```python
 import asyncio
 from mpay.client import Client
 from mpay.methods.tempo import tempo, TempoAccount

--- a/src/pages/sdk/rust/index.mdx
+++ b/src/pages/sdk/rust/index.mdx
@@ -13,13 +13,13 @@ The `mpay` Rust library provides a typed interface over the Machine Payments Pro
 
 ## Install
 
-```bash [test.sh]
+```bash
 $ cargo add mpay
 ```
 
 With Tempo blockchain support:
 
-```bash [test.sh]
+```bash
 $ cargo add mpay --features tempo,client,server
 ```
 

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -15,15 +15,15 @@ The `mpay` TypeScript library provides a typed interface over the Machine Paymen
 
 :::code-group
 
-```bash [npm]
+```bash
 npm install mpay
 ```
 
-```bash [pnpm]
+```bash
 pnpm add mpay
 ```
 
-```bash [bun]
+```bash
 bun add mpay
 ```
 
@@ -47,13 +47,13 @@ You can apply the same patterns to [other payment methods](/payment-methods).
 In this example, you use the `viem` library to instantiate an account.
 
 :::code-group
-```bash [npm]
+```bash
 npm install viem
 ```
-```bash [pnpm]
+```bash
 pnpm add viem
 ```
-```bash [bun]
+```bash
 bun add viem
 ```
 :::
@@ -62,7 +62,7 @@ bun add viem
 
 Next, define an account that will be used to sign payments.
 
-```ts twoslash [example.ts]
+```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'
 
 const account = privateKeyToAccount('0xabc…123')
@@ -78,7 +78,7 @@ Create a payment-enabled `fetch` instance to handle requests that require paymen
 
 Pass your Tempo `account` to the `fetch` instance and specify the payment `method`(s) you want to use.
 
-```ts twoslash [example.ts]
+```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'
 // [!code focus:start]
 import { Fetch, tempo } from 'mpay/client'
@@ -110,7 +110,7 @@ const response = await fetch('https://mpp.dev/ping/paid')
 
 Use your `fetch` instance to make requests to resources that require payment.
 
-```ts [example.ts]
+```ts
 const response = await fetch('https://mpp.dev/ping/paid')
 ```
 
@@ -141,7 +141,7 @@ const response = await fetch('https://mpp.dev/ping/paid', {
 
 Create an `Mpay` instance to request payment for protected resources.
 
-```ts twoslash [example.ts]
+```ts twoslash
 import { Mpay, tempo } from 'mpay/server'
 
 const mpay = Mpay.create({ method: tempo() })
@@ -177,7 +177,7 @@ The Fetch API is compatible with most server frameworks, including:
 - [Bun](https://bun.sh)
 - other Fetch API-compatible frameworks
 
-```ts twoslash [example.ts]
+```ts twoslash
 import { Mpay, tempo } from 'mpay/server' // [!code collapse:8 collapsed]
 
 const mpay = Mpay.create({ method: tempo() })
@@ -231,7 +231,7 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
 
 Plug the handler into your framework of choice, like [Hono](https://hono.dev).
 
-```ts [example.ts]
+```ts
 import { Hono } from 'hono' // [!code focus]
 import { Mpay, tempo } from 'mpay/server'
 
@@ -260,7 +260,7 @@ Get up and running by using your coding agent (Claude Code, Cursor, Amp, and sim
 
 Use the [`skills` CLI](https://github.com/vercel-labs/skills) to install skills for your coding agent:
 
-```bash [test.sh]
+```bash
 # Install all mpay skills
 $ npx skills install wevm/mpay
 

--- a/src/pages/tools/pget.mdx
+++ b/src/pages/tools/pget.mdx
@@ -8,13 +8,13 @@ When you request a resource that requires payment, `pget` automatically detects 
 
 **Quick install:**
 
-```bash [test.sh]
+```bash
 $ curl -fsSL https://pget.tempo.xyz/install.sh | bash
 ```
 
 **From source:**
 
-```bash [test.sh]
+```bash
 $ git clone https://github.com/tempoxyz/pget.git
 $ cd pget
 $ cargo install --path .
@@ -22,7 +22,7 @@ $ cargo install --path .
 
 ## Quick start
 
-```bash [test.sh]
+```bash
 # Initialize (first time only)
 $ pget init
 
@@ -51,7 +51,7 @@ tempo = "https://my-private-rpc.com"
 
 ## Payment method management
 
-```bash [test.sh]
+```bash
 # List all payment methods
 $ pget method list
 

--- a/src/pages/tools/pget/examples.mdx
+++ b/src/pages/tools/pget/examples.mdx
@@ -4,7 +4,7 @@
 
 We host a live demo server at `mpp-docs.tempo.xyz` running on **Tempo testnet** that you can test against:
 
-```bash [test.sh]
+```bash
 # Free endpoint - no payment required
 $ pget https://mpp-docs.tempo.xyz/ping
 
@@ -25,7 +25,7 @@ $ pget -vi https://mpp-docs.tempo.xyz/ping/paid
 
 For testing, you can use a private key directly using an environment variable:
 
-```bash [test.sh]
+```bash
 # Set your private key (funded on Tempo testnet)
 $ export PGET_PRIVATE_KEY="0x..."
 
@@ -39,7 +39,7 @@ The demo server runs on Tempo testnet. Fund your wallet at [faucet.tempo.xyz](ht
 
 ## Basic requests
 
-```bash [test.sh]
+```bash
 # Make a payment request
 $ pget https://mpp-docs.tempo.xyz/ping/paid
 
@@ -55,7 +55,7 @@ $ pget --json-output https://mpp-docs.tempo.xyz/ping/paid
 
 ## Payment controls
 
-```bash [test.sh]
+```bash
 # Preview payment without executing (dry run)
 $ pget -D https://mpp-docs.tempo.xyz/ping/paid
 
@@ -71,7 +71,7 @@ $ pget -n tempo-moderato https://mpp-docs.tempo.xyz/ping/paid
 
 ## Wallet management
 
-```bash [test.sh]
+```bash
 # Check wallet balance
 $ pget balance
 
@@ -87,7 +87,7 @@ $ pget --from 0x1234... https://mpp-docs.tempo.xyz/ping/paid
 
 ## Inspecting payments
 
-```bash [test.sh]
+```bash
 # Inspect payment requirements without paying
 $ pget inspect https://mpp-docs.tempo.xyz/ping/paid
 
@@ -100,7 +100,7 @@ $ pget config --output-format json
 
 ## HTTP options
 
-```bash [test.sh]
+```bash
 # Custom headers
 $ pget -H "X-Custom: value" https://mpp-docs.tempo.xyz/ping/paid
 
@@ -119,7 +119,7 @@ $ pget -m 30 https://mpp-docs.tempo.xyz/ping/paid
 
 ## Output control
 
-```bash [test.sh]
+```bash
 # Quiet mode (suppress non-essential output)
 $ pget -q https://mpp-docs.tempo.xyz/ping/paid
 


### PR DESCRIPTION
Replace generic `[example.ts]` and `[test.sh]` filenames with descriptive names that describe the functionality:

**Server examples:**
- `create-mpay.ts`, `charge-handler.ts`, `hono-server.ts`

**Client examples:**
- `define-account.ts`, `polyfill-fetch.ts`, `wrapped-fetch.ts`, `per-request-account.ts`

**CLI examples:**
- `install.sh`, `dry-run.sh`, `inspect.sh`, `payment-controls.sh`, etc.

Updated 38 code samples across 8 files.