### PR TITLE
Add mpp.tempo.xyz custom domain route

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -29,5 +29,11 @@
 			"enabled": true,
 			"invocation_logs": true
 		}
-	}
+	},
+	"routes": [
+		{
+			"pattern": "mpp.tempo.xyz",
+			"custom_domain": true
+		}
+	]
 }


### PR DESCRIPTION
Adds the `mpp.tempo.xyz` custom domain route to `wrangler.jsonc`.

The basic auth middleware is already being picked up automatically by Vocs from `src/middleware/basic-auth.ts` via the Waku/Cloudflare adapter - no config changes needed for that.

The auth wasn't working because `AUTH_CREDENTIALS` secret wasn't deployed properly or the DNS wasn't pointed to Cloudflare.