### PR TITLE
fix: resolve type errors in CliDemo, LandingPage, and wallet API

### DIFF
--- a/src/components/CliDemo.tsx
+++ b/src/components/CliDemo.tsx
@@ -229,6 +229,25 @@ const QUERY_PRESETS: QueryPreset[] = [
 // Explorer base URL for Moderato testnet
 const EXPLORER_URL = "https://explore.moderato.tempo.xyz";
 
+// API response types
+interface BalanceResponse {
+	balance?: string;
+}
+
+interface FundResponse {
+	error?: string;
+}
+
+interface ApiDataResponse {
+	location?: { city: string; region: string };
+	results?: { name: string }[];
+	summary?: string;
+	sentiment?: string;
+	steps?: unknown[];
+	duration?: string;
+	distance?: string;
+}
+
 // Format balance for display
 const formatBalance = (value: number): string => {
 	const truncated = Math.floor(value * 10000) / 10000;
@@ -330,8 +349,8 @@ export function CliDemo() {
 				]);
 
 				// Check for cached wallet in sessionStorage
-				let acc: ReturnType<typeof privateKeyToAccount>;
-				let privateKey: `0x${string}`;
+				let acc: ReturnType<typeof privateKeyToAccount> | undefined;
+				let privateKey: `0x${string}` | undefined;
 				let needsFunding = true;
 
 				const cached = sessionStorage.getItem(WALLET_STORAGE_KEY);
@@ -349,7 +368,8 @@ export function CliDemo() {
 						});
 
 						if (balRes.ok) {
-							const { balance: bal } = await balRes.json();
+							const { balance: bal } =
+								(await balRes.json()) as BalanceResponse;
 							if (bal && bal !== "0") {
 								const balNum = Number(bal) / 1e6;
 								setBalance(balNum);
@@ -400,7 +420,7 @@ export function CliDemo() {
 					});
 
 					if (!fundRes.ok) {
-						const err = await fundRes.json();
+						const err = (await fundRes.json()) as FundResponse;
 						throw new Error(err.error || "Faucet request failed");
 					}
 
@@ -419,7 +439,8 @@ export function CliDemo() {
 						});
 
 						if (balRes.ok) {
-							const { balance: bal } = await balRes.json();
+							const { balance: bal } =
+								(await balRes.json()) as BalanceResponse;
 							if (bal && bal !== "0") {
 								const balNum = Number(bal) / 1e6;
 								setBalance(balNum);
@@ -436,6 +457,10 @@ export function CliDemo() {
 					if (!funded) {
 						throw new Error("Funding timeout - please refresh");
 					}
+				}
+
+				if (!acc || !privateKey) {
+					throw new Error("Wallet initialization failed");
 				}
 
 				setAccount({ address: acc.address, privateKey });
@@ -535,7 +560,7 @@ export function CliDemo() {
 						throw new Error(`API returned ${res.status}`);
 					}
 
-					const data = await res.json();
+					const data = (await res.json()) as ApiDataResponse;
 					spent += call.priceNum;
 
 					// Show receipt info if available
@@ -699,7 +724,8 @@ export function CliDemo() {
 					body: JSON.stringify({ action: "balance", address: account.address }),
 				});
 				if (res.ok) {
-					const { balance: bal } = await res.json();
+					const { balance: bal } =
+						(await res.json()) as BalanceResponse;
 					if (bal) {
 						setBalance(Number(bal) / 1e6);
 					}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -399,6 +399,18 @@ function CodeTabs() {
 	);
 }
 
+// Reusable styles for full-width sections
+const fullWidthStyle: React.CSSProperties = {
+	width: "100vw",
+	marginLeft: "calc(-50vw + 50%)",
+};
+
+const containerStyle: React.CSSProperties = {
+	maxWidth: "1600px",
+	margin: "0 auto",
+	padding: "0 80px",
+};
+
 export function LandingPage() {
 	return (
 		<div className="vocs:not-prose">

--- a/src/pages/_api/api/wallet.ts
+++ b/src/pages/_api/api/wallet.ts
@@ -18,9 +18,19 @@ async function rpcCall(method: string, params: unknown[]) {
 	return response.json();
 }
 
+interface WalletRequest {
+	action: string;
+	address?: string;
+}
+
+interface RpcResult {
+	error?: { message?: string };
+	result?: string;
+}
+
 export async function POST(request: Request) {
 	try {
-		const body = await request.json();
+		const body = (await request.json()) as WalletRequest;
 		const { action, address } = body;
 
 		if (action === "fund") {
@@ -29,7 +39,7 @@ export async function POST(request: Request) {
 			}
 
 			// Call the Tempo faucet RPC method
-			const result = await rpcCall("tempo_fundAddress", [address]);
+			const result = (await rpcCall("tempo_fundAddress", [address])) as RpcResult;
 
 			if (result.error) {
 				console.error("[Wallet API] Faucet error:", result.error);
@@ -45,13 +55,13 @@ export async function POST(request: Request) {
 			}
 
 			// Get token balance via eth_call
-			const result = await rpcCall("eth_call", [
+			const result = (await rpcCall("eth_call", [
 				{
 					to: DEFAULT_CURRENCY,
 					data: `0x70a08231000000000000000000000000${address.slice(2)}`, // balanceOf(address)
 				},
 				"latest",
-			]);
+			])) as RpcResult;
 
 			if (result.error) {
 				if (result.error.message?.includes("Uninitialized")) {


### PR DESCRIPTION
## Summary

Fixes TypeScript type errors introduced in #31 that broke CI.

## Changes

**src/components/CliDemo.tsx**
- Added `BalanceResponse`, `FundResponse`, and `ApiDataResponse` interfaces
- Added type assertions to all `res.json()` calls
- Made wallet variables optional and added null check before use

**src/components/LandingPage.tsx**
- Added missing `fullWidthStyle` and `containerStyle` CSS property objects

**src/pages/_api/api/wallet.ts**
- Added `WalletRequest` and `RpcResult` interfaces
- Added type assertions to request body and RPC results

## Testing

```bash
pnpm check:types  # passes
```

---
🤖 Generated with [Amp](https://ampcode.com)