### PR TITLE
fix: regenerate lockfile to match patchedDependencies config

### DIFF
--- a/src/pages/brand.mdx
+++ b/src/pages/brand.mdx
@@ -12,7 +12,7 @@ The full MPP logo for use in headers, documentation, and marketing materials.
   <img src="/mpp-logo-light.svg" alt="MPP Logo" style={{ maxWidth: '300px' }} />
 </div>
 
-[Download SVG](/mpp-logo-light.svg)
+<a href="/mpp-logo-light.svg" download>Download SVG</a>
 
 ### Dark background
 
@@ -20,7 +20,7 @@ The full MPP logo for use in headers, documentation, and marketing materials.
   <img src="/mpp-logo-dark.svg" alt="MPP Logo" style={{ maxWidth: '300px' }} />
 </div>
 
-[Download SVG](/mpp-logo-dark.svg)
+<a href="/mpp-logo-dark.svg" download>Download SVG</a>
 
 ## Icon
 
@@ -32,7 +32,7 @@ The square MPP icon for favicons, app icons, and compact spaces.
   <img src="/mpp-icon-dark.svg" alt="MPP Icon" style={{ width: '120px', height: '120px' }} />
 </div>
 
-[Download SVG](/mpp-icon-dark.svg)
+<a href="/mpp-icon-dark.svg" download>Download SVG</a>
 
 ### Dark background
 
@@ -40,7 +40,7 @@ The square MPP icon for favicons, app icons, and compact spaces.
   <img src="/mpp-icon.svg" alt="MPP Icon" style={{ width: '120px', height: '120px' }} />
 </div>
 
-[Download SVG](/mpp-icon.svg)
+<a href="/mpp-icon.svg" download>Download SVG</a>
 
 ## ASCII art
 
@@ -52,7 +52,7 @@ import { AsciiLogo } from '../components/AsciiLogo'
   <AsciiLogo />
 </div>
 
-[Download TXT](/mpp-ascii.txt)
+<a href="/mpp-ascii.txt" download>Download TXT</a>
 
 ### React component
 


### PR DESCRIPTION
CI is failing with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. 
The current "patchedDependencies" configuration doesn't match the value found in the lockfile
```

This regenerates the lockfile via `pnpm install`.