### PR TITLE
fix: read AUTH_CREDENTIALS at request time, not module load time

### DIFF
--- a/src/middleware/basic-auth.ts
+++ b/src/middleware/basic-auth.ts
@@ -1,16 +1,16 @@
 import { env } from "cloudflare:workers";
 import type { MiddlewareHandler } from "vocs/server";
 
-const [AUTH_USER, AUTH_PASS] = (env.AUTH_CREDENTIALS ?? "user:pass")!.split(
-	":",
-);
-
 export function middleware(): MiddlewareHandler {
 	return async (context, next) => {
 		const url = new URL(context.req.url);
 		if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
 			return next();
 		}
+
+		const [AUTH_USER, AUTH_PASS] = (env.AUTH_CREDENTIALS ?? "user:pass").split(
+			":",
+		);
 
 		if (!AUTH_PASS) {
 			return next();


### PR DESCRIPTION
## Problem

Password protection wasn't working on the deployed version of https://mpp.tempo.xyz/

## Root Cause

The `env.AUTH_CREDENTIALS` was being evaluated at **module load time** (top-level), before Cloudflare's env was populated by `INTERNAL_setAllEnv()`. This caused `AUTH_PASS` to always be `undefined` or the default value, bypassing password protection entirely.

```ts
// Before: evaluated at module load (env not yet populated)
const [AUTH_USER, AUTH_PASS] = (env.AUTH_CREDENTIALS ?? "user:pass").split(":");
```

## Fix

Move the credential parsing inside the middleware handler so it's evaluated at **request time** when env has been properly set:

```ts
// After: evaluated per-request (env is populated)
export function middleware(): MiddlewareHandler {
  return async (context, next) => {
    const [AUTH_USER, AUTH_PASS] = (env.AUTH_CREDENTIALS ?? "user:pass").split(":");
    // ...
  };
}
```