### PR TITLE
Redesign landing page based on Georgios feedback

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { AsciiLogo } from "./AsciiLogo";
 import { CliDemo } from "./CliDemo";
 
 // Tempo logo SVG
@@ -73,48 +72,6 @@ function StripeLogo({
 	);
 }
 
-// Viem logo SVG
-function ViemLogo({
-	className,
-	style,
-}: {
-	className?: string;
-	style?: React.CSSProperties;
-}) {
-	return (
-		<svg
-			className={className}
-			style={style}
-			viewBox="0 0 615 224"
-			fill="none"
-			xmlns="http://www.w3.org/2000/svg"
-			role="img"
-			aria-label="Viem"
-		>
-			<title>Viem</title>
-			<path
-				d="M83.3 220.4L135.66 96.98C142.8 79.64 145.52 77.94 160.14 77.94V70.8H107.1V77.94C120.7 77.94 127.16 78.62 127.16 85.76C127.16 88.48 126.48 91.88 124.44 96.98L94.18 172.46L61.54 95.96C59.84 91.2 58.82 87.8 58.82 85.42C58.82 78.62 65.28 77.94 76.84 77.94V70.8H1.02V77.94C14.96 77.94 17 80.66 23.8 95.62L81.26 220.4H83.3ZM171.915 22.52C171.915 34.08 181.775 43.26 193.335 43.26C204.895 43.26 214.415 34.08 214.415 22.52C214.415 10.62 204.895 1.77999 193.335 1.77999C181.775 1.77999 171.915 10.62 171.915 22.52ZM175.995 96.3V191.5C175.995 208.16 172.595 209.86 157.295 209.86V217H231.075V209.86C215.775 209.86 212.375 208.16 212.375 191.5V70.8H157.295V77.94C172.595 77.94 175.995 79.64 175.995 96.3ZM298.103 76.58C316.123 76.58 324.623 93.92 325.643 118.06H264.783C267.503 90.86 280.423 76.58 298.103 76.58ZM359.303 187.76L354.883 183.68C345.703 195.92 334.483 201.36 320.203 201.36C287.223 201.36 264.103 171.44 264.103 130.3C264.103 128.94 264.103 127.58 264.103 126.56H356.923C356.923 98.34 338.223 67.4 299.123 67.4C263.763 67.4 229.763 101.06 229.763 145.94C229.763 189.8 262.743 220.4 302.863 220.4C324.623 220.4 346.043 209.18 359.303 187.76ZM434.132 209.86C418.832 209.86 415.432 208.16 415.432 191.5V104.8C421.212 93.92 430.732 86.78 442.292 86.78C459.972 86.78 468.812 98.34 468.812 122.82V191.5C468.812 208.16 465.412 209.86 450.112 209.86V217H523.892V209.86C508.252 209.86 504.852 208.16 504.852 191.5V117.04C504.852 113.64 504.512 109.9 504.172 106.84C508.932 95.96 519.132 86.78 531.712 86.78C549.732 86.78 558.572 98.34 558.572 122.82V191.5C558.572 208.16 555.172 209.86 539.872 209.86V217H613.652V209.86C598.012 209.86 594.612 208.16 594.612 191.5V117.04C594.612 89.84 581.692 67.4 550.752 67.4C525.932 67.4 509.272 86.44 503.152 100.38C498.392 81.34 485.472 67.4 460.992 67.4C438.212 67.4 422.232 83.72 415.432 97.32V70.8H360.352V77.94C375.652 77.94 379.052 79.64 379.052 96.3V191.5C379.052 208.16 375.652 209.86 360.352 209.86V217H434.132V209.86Z"
-				fill="currentColor"
-			/>
-		</svg>
-	);
-}
-
-// GitHub icon
-function GitHubIcon({ className }: { className?: string }) {
-	return (
-		<svg
-			className={className}
-			viewBox="0 0 24 24"
-			fill="currentColor"
-			xmlns="http://www.w3.org/2000/svg"
-			aria-hidden="true"
-		>
-			<path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-		</svg>
-	);
-}
-
 // Arrow icon for CTAs
 function ArrowRightIcon({ className }: { className?: string }) {
 	return (
@@ -133,8 +90,8 @@ function ArrowRightIcon({ className }: { className?: string }) {
 	);
 }
 
-// Feature icons
-function GlobeIcon({ className }: { className?: string }) {
+// Stream icon for the streaming feature highlight
+function StreamIcon({ className }: { className?: string }) {
 	return (
 		<svg
 			className={className}
@@ -146,95 +103,8 @@ function GlobeIcon({ className }: { className?: string }) {
 			strokeLinejoin="round"
 			aria-hidden="true"
 		>
-			<circle cx="12" cy="12" r="10" />
-			<path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+			<path d="M2 12h4l3-9 6 18 3-9h4" />
 		</svg>
-	);
-}
-
-function LayersIcon({ className }: { className?: string }) {
-	return (
-		<svg
-			className={className}
-			viewBox="0 0 24 24"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
-		</svg>
-	);
-}
-
-function ZapIcon({ className }: { className?: string }) {
-	return (
-		<svg
-			className={className}
-			viewBox="0 0 24 24"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
-		</svg>
-	);
-}
-
-// Status badge component with proper theming
-function StatusBadge({
-	status,
-}: {
-	status: "production" | "beta" | "available" | "planned";
-}) {
-	const styles: Record<
-		typeof status,
-		{ bg: string; border: string; text: string; label: string }
-	> = {
-		production: {
-			bg: "rgba(34, 197, 94, 0.1)",
-			border: "rgba(34, 197, 94, 0.3)",
-			text: "#4ade80",
-			label: "Production",
-		},
-		beta: {
-			bg: "rgba(59, 130, 246, 0.1)",
-			border: "rgba(59, 130, 246, 0.3)",
-			text: "#60a5fa",
-			label: "Beta",
-		},
-		available: {
-			bg: "rgba(255, 255, 255, 0.05)",
-			border: "rgba(255, 255, 255, 0.1)",
-			text: "var(--vocs-color-text-2)",
-			label: "Available",
-		},
-		planned: {
-			bg: "rgba(255, 255, 255, 0.05)",
-			border: "rgba(255, 255, 255, 0.1)",
-			text: "var(--vocs-color-text-3)",
-			label: "Planned",
-		},
-	};
-
-	const { bg, border, text, label } = styles[status];
-
-	return (
-		<span
-			className="text-[10px] font-medium uppercase tracking-wider px-2.5 py-1 rounded-full"
-			style={{
-				backgroundColor: bg,
-				border: `1px solid ${border}`,
-				color: text,
-			}}
-		>
-			{label}
-		</span>
 	);
 }
 
@@ -243,8 +113,8 @@ function CodeTabs() {
 	const [activeTab, setActiveTab] = useState<"client" | "server">("client");
 
 	return (
-		<div className="w-full bg-[var(--vocs-color-background-2)] rounded-xl overflow-hidden border border-white/20">
-			<div className="flex items-center gap-0 border-b border-white/20">
+		<div className="w-full bg-[#1e1e1e] rounded-xl overflow-hidden border border-white/10">
+			<div className="flex items-center gap-0 border-b border-white/10">
 				<button
 					type="button"
 					onClick={() => setActiveTab("client")}
@@ -278,14 +148,10 @@ function CodeTabs() {
 					Server
 				</button>
 			</div>
-			<div className="p-3 md:p-4 font-mono text-xs md:text-sm overflow-x-auto">
+			<div className="p-4 font-mono text-sm overflow-x-auto">
 				{activeTab === "client" ? (
 					<pre className="m-0 leading-relaxed">
 						<code>
-							<span className="text-[var(--vocs-color-text-3)]">
-								{"// Polyfill fetch once at startup"}
-							</span>
-							{"\n"}
 							<span className="text-[#c678dd]">import</span>
 							<span className="text-[var(--vocs-color-text)]">
 								{" "}
@@ -309,32 +175,20 @@ function CodeTabs() {
 							{"\n"}
 							<span className="text-[var(--vocs-color-text)]">{"}"})</span>
 							{"\n\n"}
-							<span className="text-[var(--vocs-color-text-3)]">
-								{"// Now all fetch calls handle 402 automatically"}
-							</span>
-							{"\n"}
 							<span className="text-[#c678dd]">const</span>
 							<span className="text-[var(--vocs-color-text)]">
 								{" "}
-								response ={" "}
+								res ={" "}
 							</span>
 							<span className="text-[#c678dd]">await</span>
 							<span className="text-[var(--vocs-color-text)]"> </span>
 							<span className="text-[#61afef]">fetch</span>
-							<span className="text-[var(--vocs-color-text)]">(</span>
-							<span className="text-[#98c379]">
-								'https://api.example.com/resource'
-							</span>
-							<span className="text-[var(--vocs-color-text)]">)</span>
+							<span className="text-[var(--vocs-color-text)]">(url)</span>
 						</code>
 					</pre>
 				) : (
 					<pre className="m-0 leading-relaxed">
 						<code>
-							<span className="text-[var(--vocs-color-text-3)]">
-								{"// Add payment middleware to your server"}
-							</span>
-							{"\n"}
 							<span className="text-[#c678dd]">import</span>
 							<span className="text-[var(--vocs-color-text)]">
 								{" "}
@@ -360,20 +214,12 @@ function CodeTabs() {
 							{"\n"}
 							<span className="text-[var(--vocs-color-text)]">{"}"})</span>
 							{"\n\n"}
-							<span className="text-[var(--vocs-color-text-3)]">
-								{"// Return 402 with payment challenge"}
-							</span>
-							{"\n"}
 							<span className="text-[#c678dd]">return</span>
 							<span className="text-[var(--vocs-color-text)]"> mpay.</span>
 							<span className="text-[#61afef]">challenge</span>
 							<span className="text-[var(--vocs-color-text)]">({"{"} </span>
 							<span className="text-[var(--vocs-color-text)]">amount: </span>
 							<span className="text-[#d19a66]">0.01</span>
-							<span className="text-[var(--vocs-color-text)]">
-								, currency:{" "}
-							</span>
-							<span className="text-[#98c379]">'USD'</span>
 							<span className="text-[var(--vocs-color-text)]"> {"}"})</span>
 						</code>
 					</pre>
@@ -383,51 +229,58 @@ function CodeTabs() {
 	);
 }
 
+// MPP Logo component
+function MppLogo({ className }: { className?: string }) {
+	return (
+		<img
+			src="/mpp-logo-dark.svg"
+			alt="MPP"
+			className={className}
+			style={{ height: "48px" }}
+		/>
+	);
+}
+
 export function LandingPage() {
 	return (
 		<div className="not-prose">
-			{/* Hero Section */}
-			<section className="relative py-12 md:py-24 border-b border-white/[0.06]">
+			{/* Hero Section - Simplified per feedback */}
+			<section className="relative py-16 md:py-24 border-b border-white/[0.06]">
 				<div className="mx-auto px-4 sm:px-6 lg:px-20">
-					<div className="flex flex-col lg:flex-row gap-8 lg:gap-20 items-center">
-						{/* Left side - Copy */}
-						<div className="flex-1 space-y-6 md:space-y-8">
-							{/* ASCII Logo as title */}
-							<AsciiLogo />
+					<div className="flex flex-col lg:flex-row gap-12 lg:gap-20 items-center">
+						{/* Left side - Logo, tagline, links */}
+						<div className="flex-1 space-y-6">
+							<MppLogo />
 
-							{/* Subtitle */}
-							<p className="text-base sm:text-lg md:text-xl text-[var(--vocs-color-text-2)] leading-relaxed max-w-xl">
-								The machine-native payments protocol. Accept payments from
-								humans, software, or AI agents using standard HTTP—no billing
-								accounts or manual signup required.
+							<p className="text-lg md:text-xl text-[var(--vocs-color-text-2)] leading-relaxed max-w-lg">
+								HTTP payments for humans, software, and AI agents.
 							</p>
 
-							{/* CTAs */}
-							<div className="flex flex-col sm:flex-row flex-wrap gap-3 sm:gap-4">
+							{/* Primary links */}
+							<div className="flex flex-wrap gap-4">
 								<a
-									href="/quickstart/server"
-									className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-[#0166FF] text-white font-medium rounded-lg transition-all hover:bg-[#0052CC] no-underline"
+									href="/overview"
+									className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#0166FF] text-white font-medium rounded-lg transition-all hover:bg-[#0052CC] no-underline"
 								>
-									Get started
+									Docs
 									<ArrowRightIcon className="w-4 h-4" />
 								</a>
 								<a
-									href="https://github.com/tempoxyz/payment-auth-spec"
+									href="https://paymentauth.tempo.xyz"
 									target="_blank"
 									rel="noopener noreferrer"
-									className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-[var(--vocs-color-border)] text-[var(--vocs-color-text)] font-medium rounded-lg transition-all hover:bg-[var(--vocs-color-background-2)] no-underline"
+									className="inline-flex items-center gap-2 px-5 py-2.5 border border-[var(--vocs-color-border)] text-[var(--vocs-color-text)] font-medium rounded-lg transition-all hover:bg-[var(--vocs-color-background-2)] no-underline"
 								>
-									<GitHubIcon className="w-5 h-5" />
-									View on GitHub
+									IETF Spec
 								</a>
 							</div>
 
-							{/* Co-authors badge */}
-							<div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-4">
-								<span className="text-[13px] text-[var(--vocs-color-text-3)] uppercase tracking-wider font-medium opacity-50">
+							{/* Co-authors */}
+							<div className="flex items-center gap-4 pt-4">
+								<span className="text-[12px] text-[var(--vocs-color-text-3)] uppercase tracking-wider">
 									Co-authored by
 								</span>
-								<div className="flex items-center gap-4 sm:gap-6">
+								<div className="flex items-center gap-5">
 									<a
 										href="https://tempo.xyz"
 										target="_blank"
@@ -436,22 +289,7 @@ export function LandingPage() {
 									>
 										<TempoLogo
 											className="text-[var(--vocs-color-text-2)]"
-											style={{ width: "70px" }}
-										/>
-									</a>
-									<a
-										href="https://viem.sh"
-										target="_blank"
-										rel="noopener noreferrer"
-										className="no-underline hover:opacity-80 transition-opacity"
-									>
-										<ViemLogo
-											className="text-[var(--vocs-color-text-2)]"
-											style={{
-												width: "60px",
-												position: "relative",
-												top: "-2px",
-											}}
+											style={{ width: "60px" }}
 										/>
 									</a>
 									<a
@@ -462,281 +300,104 @@ export function LandingPage() {
 									>
 										<StripeLogo
 											className="text-[var(--vocs-color-text-2)]"
-											style={{ width: "60px" }}
+											style={{ width: "50px" }}
 										/>
 									</a>
 								</div>
 							</div>
 						</div>
 
-						{/* Right side - Demo (hidden on mobile) */}
-						<div className="hidden lg:block flex-1 min-w-0 relative">
-							<div className="absolute -inset-4 bg-gradient-to-r from-[#0166FF]/10 to-[#0166FF]/5 rounded-2xl blur-xl" />
-							<div className="relative">
-								<CliDemo />
-							</div>
+						{/* Right side - Interactive demo */}
+						<div className="flex-1 w-full min-w-0">
+							<CliDemo />
 						</div>
 					</div>
 				</div>
 			</section>
 
-			{/* Feature 1: Open Standard */}
-			<section className="relative py-12 md:py-20 border-b border-white/[0.06]">
+			{/* Streaming - Key differentiator, highlighted prominently */}
+			<section className="relative py-16 md:py-20 border-b border-white/[0.06] bg-gradient-to-b from-[#0166FF]/5 to-transparent">
 				<div className="mx-auto px-4 sm:px-6 lg:px-20">
-					<div className="flex flex-col lg:flex-row gap-8 lg:gap-20 items-center">
+					<div className="flex flex-col lg:flex-row gap-12 lg:gap-20 items-center">
 						{/* Left - Copy */}
-						<div className="flex-1 space-y-4 md:space-y-6">
-							<div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-[#0166FF]/10">
-								<GlobeIcon className="w-6 h-6 text-[#0166FF]" />
+						<div className="flex-1 space-y-5">
+							<div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#0166FF]/10 border border-[#0166FF]/20">
+								<StreamIcon className="w-4 h-4 text-[#0166FF]" />
+								<span className="text-[12px] font-medium text-[#0166FF] uppercase tracking-wider">
+									What makes MPP different
+								</span>
 							</div>
 							<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--vocs-color-text)]">
-								Open standard built for the internet
+								Off-chain streaming payments
 							</h2>
 							<p className="text-base md:text-lg text-[var(--vocs-color-text-2)] leading-relaxed">
-								MPP standardizes HTTP 402 "Payment Required" with an IETF-track
-								specification. No proprietary APIs or vendor lock-in—just HTTP
-								headers and standard authentication flows.
+								Pay per request, per token, or per second—without hitting the chain every time.
+								MPP streams payments off-chain and settles on-chain when you want.
+								Web-scale throughput, blockchain finality.
 							</p>
-							<ul className="space-y-3">
-								{[
-									"Challenge → Credential → Receipt flow",
-									"Works with any HTTP client or server",
-									"Idempotency and replay protection built-in",
-								].map((item) => (
-									<li
-										key={item}
-										className="flex items-center gap-3 text-sm md:text-base text-[var(--vocs-color-text-2)]"
-									>
-										<span className="w-1.5 h-1.5 rounded-full bg-[#0166FF] flex-shrink-0" />
-										{item}
-									</li>
-								))}
-							</ul>
 						</div>
 
-						{/* Right - Protocol Flow Diagram */}
-						<div className="flex-1 w-full bg-[var(--vocs-color-background-2)] rounded-xl overflow-hidden border border-white/20">
-							{/* Step 1: Initial Request */}
-							<div className="px-4 py-3 border-b border-white/20">
-								<div className="flex items-center gap-2 mb-1">
-									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-color-text-3)]">
-										1. Request
-									</span>
-								</div>
-								<code className="font-mono text-xs sm:text-sm">
-									<span className="text-[#0166FF]">GET</span>
-									<span className="text-[var(--vocs-color-text)]">
-										{" "}
-										/resource
-									</span>
-								</code>
-							</div>
-
-							{/* Step 2: 402 Challenge */}
-							<div className="px-4 py-3 border-b border-white/20">
-								<div className="flex items-center gap-2 mb-1">
-									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-color-text-3)]">
-										2. Challenge
-									</span>
-								</div>
-								<div className="font-mono text-xs sm:text-sm space-y-0.5">
-									<div>
-										<span className="text-[var(--vocs-color-destructive)]">
-											402
-										</span>
-										<span className="text-[var(--vocs-color-text-2)]">
-											{" "}
-											Payment Required
-										</span>
-									</div>
-									<div className="text-[var(--vocs-color-text-3)] break-all">
-										WWW-Authenticate: Payment method="tempo" ...
-									</div>
-								</div>
-							</div>
-
-							{/* Step 3: Retry with Credential */}
-							<div className="px-4 py-3 border-b border-white/20">
-								<div className="flex items-center gap-2 mb-1">
-									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-color-text-3)]">
-										3. Retry with credential
-									</span>
-								</div>
-								<div className="font-mono text-xs sm:text-sm space-y-0.5">
-									<div>
-										<span className="text-[#0166FF]">GET</span>
-										<span className="text-[var(--vocs-color-text)]">
-											{" "}
-											/resource
-										</span>
-									</div>
-									<div className="text-[var(--vocs-color-text-3)] break-all">
-										Authorization: Payment {"<credential>"}
-									</div>
-								</div>
-							</div>
-
-							{/* Step 4: Success with Receipt */}
-							<div className="px-4 py-3">
-								<div className="flex items-center gap-2 mb-1">
-									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-color-text-3)]">
-										4. Success
-									</span>
-								</div>
-								<div className="font-mono text-xs sm:text-sm space-y-0.5">
-									<div>
-										<span className="text-[#16a34a]">200</span>
-										<span className="text-[var(--vocs-color-text-2)]"> OK</span>
-									</div>
-									<div className="text-[var(--vocs-color-text-3)] break-all">
-										Payment-Receipt: {"<receipt>"}
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</section>
-
-			{/* Feature 2: Multi-Rail (reversed layout) */}
-			<section className="relative py-12 md:py-20 border-b border-white/[0.06]">
-				<div className="mx-auto px-4 sm:px-6 lg:px-20">
-					<div className="flex flex-col-reverse lg:flex-row gap-8 lg:gap-20 items-center">
-						{/* Left - Payment Methods Grid */}
+						{/* Right - Visual */}
 						<div className="flex-1 w-full">
-							<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4">
-								{/* Tempo Card */}
-								<div className="bg-[var(--vocs-color-background-2)] rounded-xl p-4 md:p-5 space-y-3 border border-white/20">
-									<div className="flex items-center justify-between gap-2">
-										<TempoLogo
-											className="text-[var(--vocs-color-text)]"
-											style={{ width: "60px", height: "auto" }}
-										/>
-										<StatusBadge status="production" />
-									</div>
-									<p className="text-xs md:text-sm text-[var(--vocs-color-text-2)] leading-relaxed">
-										Instant stablecoin settlement on Tempo. Sub-second finality
-										with USDC payments directly to your wallet—no invoices or
-										delayed payouts.
-									</p>
-								</div>
-
-								{/* Stripe Card */}
-								<div className="bg-[var(--vocs-color-background-2)] rounded-xl p-4 md:p-5 space-y-3 border border-white/20">
-									<div className="flex items-center justify-between gap-2">
-										<StripeLogo
-											className="text-[var(--vocs-color-text)]"
-											style={{ width: "48px", height: "auto" }}
-										/>
-										<StatusBadge status="beta" />
-									</div>
-									<p className="text-xs md:text-sm text-[var(--vocs-color-text-2)] leading-relaxed">
-										Accept cards, bank transfers, and invoices through Stripe.
-										Leverage existing Stripe infrastructure with MPP's
-										standardized protocol layer.
-									</p>
-								</div>
-
-								{/* Custom Card */}
-								<div className="bg-[var(--vocs-color-background-2)] rounded-xl p-4 md:p-5 space-y-3 border border-white/20">
-									<div className="flex items-center justify-between gap-2">
-										<span className="font-semibold text-[var(--vocs-color-text)]">
-											Custom
+							<div className="bg-[#1e1e1e] rounded-xl p-6 border border-white/10">
+								<div className="space-y-4">
+									<div className="flex items-center gap-3">
+										<div className="w-2 h-2 rounded-full bg-[#98c379] animate-pulse" />
+										<span className="font-mono text-sm text-[var(--vocs-color-text-2)]">
+											Streaming $0.001/request
 										</span>
-										<StatusBadge status="available" />
 									</div>
-									<p className="text-xs md:text-sm text-[var(--vocs-color-text-2)] leading-relaxed">
-										Build your own payment method. MPP's extensible architecture
-										lets you integrate any payment rail—internal credits,
-										loyalty points, or custom currencies.
-									</p>
-								</div>
-
-								{/* More Coming Card */}
-								<div className="bg-[var(--vocs-color-background-2)] rounded-xl p-4 md:p-5 space-y-3 border border-white/20">
-									<div className="flex items-center justify-between gap-2">
-										<span className="font-semibold text-[var(--vocs-color-text)]">
-											More coming
-										</span>
-										<StatusBadge status="planned" />
+									<div className="h-px bg-white/10" />
+									<div className="grid grid-cols-3 gap-4 text-center">
+										<div>
+											<div className="text-2xl font-semibold text-[var(--vocs-color-text)]">1M+</div>
+											<div className="text-xs text-[var(--vocs-color-text-3)]">requests/sec</div>
+										</div>
+										<div>
+											<div className="text-2xl font-semibold text-[var(--vocs-color-text)]">&lt;1ms</div>
+											<div className="text-xs text-[var(--vocs-color-text-3)]">payment latency</div>
+										</div>
+										<div>
+											<div className="text-2xl font-semibold text-[#98c379]">1</div>
+											<div className="text-xs text-[var(--vocs-color-text-3)]">settlement tx</div>
+										</div>
 									</div>
-									<p className="text-xs md:text-sm text-[var(--vocs-color-text-2)] leading-relaxed">
-										Lightning Network for instant Bitcoin micropayments, ACH for
-										low-cost bank transfers, and more payment rails on the
-										roadmap.
-									</p>
 								</div>
 							</div>
-						</div>
-
-						{/* Right - Copy */}
-						<div className="flex-1 space-y-4 md:space-y-6">
-							<div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-[#0166FF]/10">
-								<LayersIcon className="w-6 h-6 text-[#0166FF]" />
-							</div>
-							<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--vocs-color-text)]">
-								Multi-rail, multi-currency
-							</h2>
-							<p className="text-base md:text-lg text-[var(--vocs-color-text-2)] leading-relaxed">
-								MPP is payment method agnostic. Crypto, cards, bank transfers,
-								invoices—all payment methods work through one protocol. Support
-								USD, EUR, BTC, USDC, or any currency.
-							</p>
-							<ul className="space-y-3">
-								{[
-									"Single integration, multiple payment rails",
-									"Currency agnostic—from fiat to crypto",
-									"Extensible: define your own payment methods",
-								].map((item) => (
-									<li
-										key={item}
-										className="flex items-center gap-3 text-sm md:text-base text-[var(--vocs-color-text-2)]"
-									>
-										<span className="w-1.5 h-1.5 rounded-full bg-[#0166FF] flex-shrink-0" />
-										{item}
-									</li>
-								))}
-							</ul>
 						</div>
 					</div>
 				</div>
 			</section>
 
-			{/* Feature 3: Developer Experience */}
-			<section className="relative py-12 md:py-20 border-b border-white/[0.06]">
+			{/* Code Examples - Moved up per feedback */}
+			<section className="relative py-16 md:py-20 border-b border-white/[0.06]">
 				<div className="mx-auto px-4 sm:px-6 lg:px-20">
-					<div className="flex flex-col lg:flex-row gap-8 lg:gap-20 items-center">
+					<div className="flex flex-col lg:flex-row gap-12 lg:gap-20 items-center">
 						{/* Left - Copy */}
-						<div className="flex-1 space-y-4 md:space-y-6">
-							<div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-[#0166FF]/10">
-								<ZapIcon className="w-6 h-6 text-[#0166FF]" />
-							</div>
+						<div className="flex-1 space-y-5">
 							<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--vocs-color-text)]">
-								Developer-first experience
+								Add payments in minutes
 							</h2>
 							<p className="text-base md:text-lg text-[var(--vocs-color-text-2)] leading-relaxed">
-								Official SDKs for TypeScript, Python, and Rust. Polyfill fetch
-								or go low-level—MPP works the way you work. Add payments with
-								minimal code changes.
+								Polyfill fetch on the client. Return a 402 on the server. Done.
 							</p>
-							<ul className="space-y-3">
-								{[
-									"Client: Polyfill fetch for automatic 402 handling",
-									"Server: Works with Hono, Express, Next.js, and more",
-									"CLI: Test with pget, a curl for paid resources",
-								].map((item) => (
-									<li
-										key={item}
-										className="flex items-center gap-3 text-sm md:text-base text-[var(--vocs-color-text-2)]"
-									>
-										<span className="w-1.5 h-1.5 rounded-full bg-[#0166FF] flex-shrink-0" />
-										{item}
-									</li>
-								))}
-							</ul>
+							<div className="flex flex-wrap gap-3">
+								<a
+									href="/quickstart/server"
+									className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-[#0166FF] text-white font-medium rounded-lg transition-all hover:bg-[#0052CC] no-underline"
+								>
+									Server quickstart
+								</a>
+								<a
+									href="/quickstart/client"
+									className="inline-flex items-center gap-2 px-4 py-2 text-sm border border-[var(--vocs-color-border)] text-[var(--vocs-color-text)] font-medium rounded-lg transition-all hover:bg-[var(--vocs-color-background-2)] no-underline"
+								>
+									Client quickstart
+								</a>
+							</div>
 						</div>
 
-						{/* Right - Code Snippet with Tabs */}
+						{/* Right - Interactive code tabs */}
 						<div className="flex-1 w-full">
 							<CodeTabs />
 						</div>
@@ -744,30 +405,87 @@ export function LandingPage() {
 				</div>
 			</section>
 
-			{/* CTA Section */}
-			<section className="relative py-12 md:py-20">
-				<div className="max-w-[900px] mx-auto px-4 sm:px-6 lg:px-20 text-center">
-					<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--vocs-color-text)] mb-4">
-						Start accepting payments today
-					</h2>
-					<p className="text-base md:text-lg text-[var(--vocs-color-text-2)] mb-6 md:mb-8 max-w-2xl mx-auto">
-						Add payments to your API in minutes. No signup required—just install
-						the SDK and start charging for your resources.
-					</p>
-					<div className="flex flex-col sm:flex-row flex-wrap justify-center gap-3 sm:gap-4">
-						<a
-							href="/quickstart/server"
-							className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-[#0166FF] text-white font-medium rounded-lg transition-all hover:bg-[#0052CC] no-underline"
-						>
-							Server quickstart
-							<ArrowRightIcon className="w-4 h-4" />
-						</a>
-						<a
-							href="/quickstart/client"
-							className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-[var(--vocs-color-border)] text-[var(--vocs-color-text)] font-medium rounded-lg transition-all hover:bg-[var(--vocs-color-background-2)] no-underline"
-						>
-							Client quickstart
-						</a>
+			{/* Protocol Flow - Simplified */}
+			<section className="relative py-16 md:py-20 border-b border-white/[0.06]">
+				<div className="mx-auto px-4 sm:px-6 lg:px-20">
+					<div className="max-w-3xl mx-auto text-center space-y-6">
+						<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--vocs-color-text)]">
+							Standard HTTP, standard auth
+						</h2>
+						<p className="text-base md:text-lg text-[var(--vocs-color-text-2)]">
+							MPP extends HTTP 402 with a challenge-credential-receipt flow.
+							No proprietary APIs. Works with any HTTP client.
+						</p>
+					</div>
+
+					{/* Protocol flow diagram */}
+					<div className="mt-12 max-w-2xl mx-auto">
+						<div className="bg-[#1e1e1e] rounded-xl overflow-hidden border border-white/10">
+							<div className="grid grid-cols-4 divide-x divide-white/10">
+								<div className="p-4 text-center">
+									<div className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-color-text-3)] mb-2">1</div>
+									<code className="text-sm text-[#0166FF]">GET</code>
+								</div>
+								<div className="p-4 text-center">
+									<div className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-color-text-3)] mb-2">2</div>
+									<code className="text-sm text-[var(--vocs-color-destructive)]">402</code>
+								</div>
+								<div className="p-4 text-center">
+									<div className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-color-text-3)] mb-2">3</div>
+									<code className="text-sm text-[#e5c07b]">Pay</code>
+								</div>
+								<div className="p-4 text-center">
+									<div className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-color-text-3)] mb-2">4</div>
+									<code className="text-sm text-[#98c379]">200</code>
+								</div>
+							</div>
+							<div className="border-t border-white/10 p-4 text-center">
+								<span className="text-xs text-[var(--vocs-color-text-3)]">
+									Request → Challenge → Credential → Receipt
+								</span>
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			{/* Payment Methods - Compact */}
+			<section className="relative py-16 md:py-20">
+				<div className="mx-auto px-4 sm:px-6 lg:px-20">
+					<div className="max-w-3xl mx-auto text-center space-y-6 mb-12">
+						<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--vocs-color-text)]">
+							Any payment method
+						</h2>
+						<p className="text-base md:text-lg text-[var(--vocs-color-text-2)]">
+							Crypto, cards, or custom. One protocol, every rail.
+						</p>
+					</div>
+
+					<div className="grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-3xl mx-auto">
+						<div className="bg-[var(--vocs-color-background-2)] rounded-xl p-5 border border-white/10">
+							<TempoLogo
+								className="text-[var(--vocs-color-text)] mb-3"
+								style={{ width: "50px" }}
+							/>
+							<p className="text-sm text-[var(--vocs-color-text-2)]">
+								Instant USDC settlement
+							</p>
+						</div>
+						<div className="bg-[var(--vocs-color-background-2)] rounded-xl p-5 border border-white/10">
+							<StripeLogo
+								className="text-[var(--vocs-color-text)] mb-3"
+								style={{ width: "42px" }}
+							/>
+							<p className="text-sm text-[var(--vocs-color-text-2)]">
+								Cards and bank transfers
+							</p>
+						</div>
+						<div className="bg-[var(--vocs-color-background-2)] rounded-xl p-5 border border-white/10">
+							<span className="font-semibold text-[var(--vocs-color-text)] text-lg">+</span>
+							<p className="text-sm text-[var(--vocs-color-text-2)] mt-3">
+								Build your own
+							</p>
+						</div>
 					</div>
 				</div>
 			</section>

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,6 +1,7 @@
 ---
 layout: minimal
 showSidebar: false
+colorScheme: dark
 ---
 
 import { LandingPage } from "../components/LandingPage";


### PR DESCRIPTION
## Summary

Addresses feedback from Georgios in #product-machine-payments-protocol:

### Changes

1. **Simplified hero section**
   - MPP logo on left with concise tagline
   - Two primary CTAs: Docs and IETF Spec
   - Interactive CLI demo on the right

2. **Rewrote copy**
   - Removed AI-sounding text
   - Made copy more direct and technical

3. **Co-authored by**
   - Removed Viem, now only shows Tempo & Stripe

4. **Highlighted streaming extension**
   - New prominent section showcasing off-chain streaming as key differentiator
   - Shows web-scale throughput stats

5. **Moved code examples up**
   - Interactive tabbed code examples now higher on page
   - Simplified client/server snippets

6. **Simplified protocol flow**
   - Visual 4-step diagram instead of verbose text

7. **Reduced text throughout**
   - Payment methods section is now 3 compact cards

8. **Fixed dark mode bug**
   - Added `colorScheme: dark` to landing page frontmatter to prevent theme switching when navigating back from Docs

---
Slack thread: https://tempoxyz.slack.com/archives/C0A8YB63Q91/p1770243046463089