### PR TITLE
fix: address docs feedback from Slack thread

### DIFF
--- a/src/pages/404.mdx
+++ b/src/pages/404.mdx
@@ -1,10 +1,37 @@
 ---
-title: Page Not Found
+title: "404"
 layout: minimal
 ---
 
-# Page Not Found
+import { AsciiLogo } from '../components/AsciiLogo'
 
-The page you're looking for doesn't exist or has been moved.
+<div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '60vh', textAlign: 'center', gap: '2rem' }}>
+  <div style={{ transform: 'scale(0.6)', opacity: 0.6 }}>
+    <AsciiLogo />
+  </div>
+  
+  <div>
+    <h1 style={{ fontSize: '4rem', fontWeight: 700, margin: 0, color: 'var(--vocs-color-text)' }}>404</h1>
+    <p style={{ fontSize: '1.25rem', color: 'var(--vocs-color-text-2)', marginTop: '0.5rem' }}>
+      Payment not found
+    </p>
+  </div>
 
-[← Back to Home](/)
+  <a 
+    href="/" 
+    style={{ 
+      display: 'inline-flex', 
+      alignItems: 'center', 
+      gap: '0.5rem',
+      padding: '0.75rem 1.5rem', 
+      backgroundColor: '#0166FF', 
+      color: 'white', 
+      borderRadius: '0.5rem', 
+      textDecoration: 'none',
+      fontWeight: 500,
+      transition: 'background-color 0.2s'
+    }}
+  >
+    ← Back to Home
+  </a>
+</div>

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -172,3 +172,11 @@
 [data-layout="minimal"] main > article {
 	max-width: 1400px;
 }
+
+/* Style disabled cards to look non-interactive */
+[data-v-card][aria-disabled="true"],
+.vocs_Card[aria-disabled="true"] {
+	opacity: 0.5;
+	cursor: not-allowed;
+	pointer-events: none;
+}

--- a/src/pages/docs.mdx
+++ b/src/pages/docs.mdx
@@ -1,0 +1,10 @@
+---
+title: Documentation
+layout: minimal
+head:
+  - - meta
+    - http-equiv: refresh
+      content: "0; url=/overview"
+---
+
+Redirecting to [documentation](/overview)...

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -50,7 +50,6 @@ export default defineConfig({
 					{ text: "Overview", link: "/overview" },
 					{ text: "Specifications", link: "https://paymentauth.tempo.xyz/" },
 					{ text: "FAQ", link: "/faq" },
-					{ text: "Brand", link: "/brand" },
 				],
 			},
 			{
@@ -379,6 +378,10 @@ export default defineConfig({
 						],
 					},
 				],
+			},
+			{
+				text: "Resources",
+				items: [{ text: "Brand", link: "/brand" }],
 			},
 		],
 	},


### PR DESCRIPTION
## Changes

Fixes from the product feedback Slack thread:

### Fixed
- **`/docs` redirect**: Added `/docs` page that redirects to `/overview`
- **Brand moved to bottom**: Moved Brand from Introduction section to a new Resources section at the bottom of sidebar
- **Enhanced 404 page**: Added ASCII logo animation and brand styling to 404 page
- **Disabled card styling**: Stream button (and other disabled cards) now visually appear non-interactive with reduced opacity and cursor changes

### Not immediately actionable (needs follow-up)

| Issue | Reason |
|-------|--------|
| Logo tracking looks funny | @jxom says fixed on main - verify |
| CTA too wide | @jxom says fixed on main - verify |
| mpp-docs.tempo.xyz/docs/overview broken | External domain - needs DNS/deployment fix |
| Ask AI deep link issue | Need more details on expected behavior |
| Brand page assets broken | Assets exist with correct fills - may be caching/build issue |
| Dynamic docs demo deleted | Need clarification on what component was deleted |
| Mobile copy MCP URL no confirmation | Vocs framework component - needs upstream change or override |
| Ask AI mobile looks like search box / shows Cmd+I | Vocs framework - needs upstream change |
| Tempo charge spec page doesn't load | External site (paymentauth.tempo.xyz) - not in this repo |
| Favicon looks like fox | Verified icon-dark.png exists - need to check actual favicon generation |
| Demo rate limit error (3ms) | Backend/API issue - not frontend |

cc @brendan @jxom @liam