### PR TITLE
fix: landing page dark/light mode theme switching

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -219,15 +219,15 @@ function StatusBadge({
 			label: "Beta",
 		},
 		available: {
-			bg: "var(--vocs-background-color-surface)",
-			border: "var(--vocs-border-color-primary)",
-			text: "var(--vocs-text-color-secondary)",
+			bg: "var(--background-color-surface)",
+			border: "var(--border-color-primary)",
+			text: "var(--text-color-secondary)",
 			label: "Available",
 		},
 		planned: {
-			bg: "var(--vocs-background-color-surface)",
-			border: "var(--vocs-border-color-primary)",
-			text: "var(--vocs-text-color-muted)",
+			bg: "var(--background-color-surface)",
+			border: "var(--border-color-primary)",
+			text: "var(--text-color-muted)",
 			label: "Planned",
 		},
 	};
@@ -253,15 +253,15 @@ function CodeTabs() {
 	const [activeTab, setActiveTab] = useState<"client" | "server">("client");
 
 	return (
-		<div className="w-full bg-[var(--vocs-background-color-surface)] rounded-xl overflow-hidden border border-[var(--vocs-border-color-primary)]">
-			<div className="flex items-center gap-0 border-b border-[var(--vocs-border-color-primary)]">
+		<div className="w-full bg-[var(--background-color-surface)] rounded-xl overflow-hidden border border-[var(--border-color-primary)]">
+			<div className="flex items-center gap-0 border-b border-[var(--border-color-primary)]">
 				<button
 					type="button"
 					onClick={() => setActiveTab("client")}
 					className={`text-[13px] font-medium px-4 py-3 transition-colors border-b-2 ${
 						activeTab === "client"
-							? "text-[var(--vocs-text-color-primary)] border-[#0166FF]"
-							: "text-[var(--vocs-text-color-muted)] border-transparent hover:text-[var(--vocs-text-color-secondary)]"
+							? "text-[var(--text-color-primary)] border-[#0166FF]"
+							: "text-[var(--text-color-muted)] border-transparent hover:text-[var(--text-color-secondary)]"
 					}`}
 					style={{
 						background: "none",
@@ -276,8 +276,8 @@ function CodeTabs() {
 					onClick={() => setActiveTab("server")}
 					className={`text-[13px] font-medium px-4 py-3 transition-colors border-b-2 ${
 						activeTab === "server"
-							? "text-[var(--vocs-text-color-primary)] border-[#0166FF]"
-							: "text-[var(--vocs-text-color-muted)] border-transparent hover:text-[var(--vocs-text-color-secondary)]"
+							? "text-[var(--text-color-primary)] border-[#0166FF]"
+							: "text-[var(--text-color-muted)] border-transparent hover:text-[var(--text-color-secondary)]"
 					}`}
 					style={{
 						background: "none",
@@ -292,12 +292,12 @@ function CodeTabs() {
 				{activeTab === "client" ? (
 					<pre className="m-0 leading-relaxed">
 						<code>
-							<span className="text-[var(--vocs-text-color-muted)]">
+							<span className="text-[var(--text-color-muted)]">
 								{"// Polyfill fetch once at startup"}
 							</span>
 							{"\n"}
 							<span className="text-[#c678dd]">import</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								{" "}
 								{"{"} Fetch, tempo {"}"}{" "}
 							</span>
@@ -305,50 +305,50 @@ function CodeTabs() {
 							<span className="text-[#98c379]"> 'mpay/client'</span>
 							{"\n\n"}
 							<span className="text-[#e5c07b]">Fetch</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								.polyfill({"{"}
 							</span>
 							{"\n"}
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								{"  "}methods: [
 							</span>
 							<span className="text-[#e5c07b]">tempo</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								({"{"} account {"}"})]
 							</span>
 							{"\n"}
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								{"}"})
 							</span>
 							{"\n\n"}
-							<span className="text-[var(--vocs-text-color-muted)]">
+							<span className="text-[var(--text-color-muted)]">
 								{"// Now all fetch calls handle 402 automatically"}
 							</span>
 							{"\n"}
 							<span className="text-[#c678dd]">const</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								{" "}
 								response ={" "}
 							</span>
 							<span className="text-[#c678dd]">await</span>
-							<span className="text-[var(--vocs-text-color-primary)]"> </span>
+							<span className="text-[var(--text-color-primary)]"> </span>
 							<span className="text-[#61afef]">fetch</span>
-							<span className="text-[var(--vocs-text-color-primary)]">(</span>
+							<span className="text-[var(--text-color-primary)]">(</span>
 							<span className="text-[#98c379]">
 								'https://api.example.com/resource'
 							</span>
-							<span className="text-[var(--vocs-text-color-primary)]">)</span>
+							<span className="text-[var(--text-color-primary)]">)</span>
 						</code>
 					</pre>
 				) : (
 					<pre className="m-0 leading-relaxed">
 						<code>
-							<span className="text-[var(--vocs-text-color-muted)]">
+							<span className="text-[var(--text-color-muted)]">
 								{"// Add payment middleware to your server"}
 							</span>
 							{"\n"}
 							<span className="text-[#c678dd]">import</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								{" "}
 								{"{"} Mpay, tempo {"}"}{" "}
 							</span>
@@ -356,49 +356,49 @@ function CodeTabs() {
 							<span className="text-[#98c379]"> 'mpay/server'</span>
 							{"\n\n"}
 							<span className="text-[#c678dd]">const</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								{" "}
 								mpay ={" "}
 							</span>
 							<span className="text-[#e5c07b]">Mpay</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								.create({"{"}
 							</span>
 							{"\n"}
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								{"  "}methods: [
 							</span>
 							<span className="text-[#e5c07b]">tempo</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								({"{"} recipient {"}"})]
 							</span>
 							{"\n"}
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								{"}"})
 							</span>
 							{"\n\n"}
-							<span className="text-[var(--vocs-text-color-muted)]">
+							<span className="text-[var(--text-color-muted)]">
 								{"// Return 402 with payment challenge"}
 							</span>
 							{"\n"}
 							<span className="text-[#c678dd]">return</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								{" "}
 								mpay.
 							</span>
 							<span className="text-[#61afef]">challenge</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								({"{"}{" "}
 							</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								amount:{" "}
 							</span>
 							<span className="text-[#d19a66]">0.01</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								, currency:{" "}
 							</span>
 							<span className="text-[#98c379]">'USD'</span>
-							<span className="text-[var(--vocs-text-color-primary)]">
+							<span className="text-[var(--text-color-primary)]">
 								{" "}
 								{"}"})
 							</span>
@@ -417,7 +417,7 @@ export function LandingPage() {
 	return (
 		<div className="not-prose">
 			{/* Hero Section */}
-			<section className="relative py-12 md:py-24 border-b border-[var(--vocs-border-color-primary)]">
+			<section className="relative py-12 md:py-24 border-b border-[var(--border-color-primary)]">
 				<div className="mx-auto px-4 sm:px-6 lg:px-20">
 					<div className="flex flex-col lg:flex-row gap-8 lg:gap-20 items-center">
 						{/* Left side - Copy */}
@@ -426,7 +426,7 @@ export function LandingPage() {
 							<AsciiLogo />
 
 							{/* Subtitle */}
-							<p className="text-base sm:text-lg md:text-xl text-[var(--vocs-text-color-secondary)] leading-relaxed max-w-xl">
+							<p className="text-base sm:text-lg md:text-xl text-[var(--text-color-secondary)] leading-relaxed max-w-xl">
 								The machine-native payments protocol. Accept payments from
 								humans, software, or AI agents using standard HTTP—no billing
 								accounts or manual signup required.
@@ -445,7 +445,7 @@ export function LandingPage() {
 									href="https://github.com/tempoxyz/payment-auth-spec"
 									target="_blank"
 									rel="noopener noreferrer"
-									className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-[var(--vocs-border-color-primary)] text-[var(--vocs-text-color-primary)] font-medium rounded-lg transition-all hover:bg-[var(--vocs-background-color-surface)] no-underline"
+									className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-[var(--border-color-primary)] text-[var(--text-color-primary)] font-medium rounded-lg transition-all hover:bg-[var(--background-color-surface)] no-underline"
 								>
 									<GitHubIcon className="w-5 h-5" />
 									View on GitHub
@@ -454,7 +454,7 @@ export function LandingPage() {
 
 							{/* Co-authors badge */}
 							<div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-4">
-								<span className="text-[13px] text-[var(--vocs-text-color-muted)] uppercase tracking-wider font-medium opacity-50">
+								<span className="text-[13px] text-[var(--text-color-muted)] uppercase tracking-wider font-medium opacity-50">
 									Co-authored by
 								</span>
 								<div className="flex items-center gap-4 sm:gap-6">
@@ -465,7 +465,7 @@ export function LandingPage() {
 										className="no-underline hover:opacity-80 transition-opacity"
 									>
 										<TempoLogo
-											className="text-[var(--vocs-text-color-secondary)]"
+											className="text-[var(--text-color-secondary)]"
 											style={{ width: "70px" }}
 										/>
 									</a>
@@ -476,7 +476,7 @@ export function LandingPage() {
 										className="no-underline hover:opacity-80 transition-opacity"
 									>
 										<StripeLogo
-											className="text-[var(--vocs-text-color-secondary)]"
+											className="text-[var(--text-color-secondary)]"
 											style={{ width: "60px" }}
 										/>
 									</a>
@@ -496,7 +496,7 @@ export function LandingPage() {
 			</section>
 
 			{/* Feature 1: Open Standard */}
-			<section className="relative py-12 md:py-20 border-b border-[var(--vocs-border-color-primary)]">
+			<section className="relative py-12 md:py-20 border-b border-[var(--border-color-primary)]">
 				<div className="mx-auto px-4 sm:px-6 lg:px-20">
 					<div className="flex flex-col lg:flex-row gap-8 lg:gap-20 items-center">
 						{/* Left - Copy */}
@@ -504,10 +504,10 @@ export function LandingPage() {
 							<div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-[#0166FF]/10">
 								<GlobeIcon className="w-6 h-6 text-[#0166FF]" />
 							</div>
-							<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--vocs-text-color-primary)]">
+							<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--text-color-primary)]">
 								Open standard built for the internet
 							</h2>
-							<p className="text-base md:text-lg text-[var(--vocs-text-color-secondary)] leading-relaxed">
+							<p className="text-base md:text-lg text-[var(--text-color-secondary)] leading-relaxed">
 								MPP standardizes HTTP 402 "Payment Required" with an IETF-track
 								specification. No proprietary APIs or vendor lock-in—just HTTP
 								headers and standard authentication flows.
@@ -520,7 +520,7 @@ export function LandingPage() {
 								].map((item) => (
 									<li
 										key={item}
-										className="flex items-center gap-3 text-sm md:text-base text-[var(--vocs-text-color-secondary)]"
+										className="flex items-center gap-3 text-sm md:text-base text-[var(--text-color-secondary)]"
 									>
 										<span className="w-1.5 h-1.5 rounded-full bg-[#0166FF] flex-shrink-0" />
 										{item}
@@ -530,17 +530,17 @@ export function LandingPage() {
 						</div>
 
 						{/* Right - Protocol Flow Diagram */}
-						<div className="flex-1 w-full bg-[var(--vocs-background-color-surface)] rounded-xl overflow-hidden border border-[var(--vocs-border-color-primary)]">
+						<div className="flex-1 w-full bg-[var(--background-color-surface)] rounded-xl overflow-hidden border border-[var(--border-color-primary)]">
 							{/* Step 1: Initial Request */}
-							<div className="px-4 py-3 border-b border-[var(--vocs-border-color-primary)]">
+							<div className="px-4 py-3 border-b border-[var(--border-color-primary)]">
 								<div className="flex items-center gap-2 mb-1">
-									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-text-color-muted)]">
+									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--text-color-muted)]">
 										1. Request
 									</span>
 								</div>
 								<code className="font-mono text-xs sm:text-sm">
 									<span className="text-[#0166FF]">GET</span>
-									<span className="text-[var(--vocs-text-color-primary)]">
+									<span className="text-[var(--text-color-primary)]">
 										{" "}
 										/resource
 									</span>
@@ -548,9 +548,9 @@ export function LandingPage() {
 							</div>
 
 							{/* Step 2: 402 Challenge */}
-							<div className="px-4 py-3 border-b border-[var(--vocs-border-color-primary)]">
+							<div className="px-4 py-3 border-b border-[var(--border-color-primary)]">
 								<div className="flex items-center gap-2 mb-1">
-									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-text-color-muted)]">
+									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--text-color-muted)]">
 										2. Challenge
 									</span>
 								</div>
@@ -559,33 +559,33 @@ export function LandingPage() {
 										<span className="text-[var(--vocs-color-destructive)]">
 											402
 										</span>
-										<span className="text-[var(--vocs-text-color-secondary)]">
+										<span className="text-[var(--text-color-secondary)]">
 											{" "}
 											Payment Required
 										</span>
 									</div>
-									<div className="text-[var(--vocs-text-color-muted)] break-all">
+									<div className="text-[var(--text-color-muted)] break-all">
 										WWW-Authenticate: Payment method="tempo" ...
 									</div>
 								</div>
 							</div>
 
 							{/* Step 3: Retry with Credential */}
-							<div className="px-4 py-3 border-b border-[var(--vocs-border-color-primary)]">
+							<div className="px-4 py-3 border-b border-[var(--border-color-primary)]">
 								<div className="flex items-center gap-2 mb-1">
-									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-text-color-muted)]">
+									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--text-color-muted)]">
 										3. Retry with credential
 									</span>
 								</div>
 								<div className="font-mono text-xs sm:text-sm space-y-0.5">
 									<div>
 										<span className="text-[#0166FF]">GET</span>
-										<span className="text-[var(--vocs-text-color-primary)]">
+										<span className="text-[var(--text-color-primary)]">
 											{" "}
 											/resource
 										</span>
 									</div>
-									<div className="text-[var(--vocs-text-color-muted)] break-all">
+									<div className="text-[var(--text-color-muted)] break-all">
 										Authorization: Payment {"<credential>"}
 									</div>
 								</div>
@@ -594,19 +594,19 @@ export function LandingPage() {
 							{/* Step 4: Success with Receipt */}
 							<div className="px-4 py-3">
 								<div className="flex items-center gap-2 mb-1">
-									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--vocs-text-color-muted)]">
+									<span className="text-[10px] font-medium uppercase tracking-wider text-[var(--text-color-muted)]">
 										4. Success
 									</span>
 								</div>
 								<div className="font-mono text-xs sm:text-sm space-y-0.5">
 									<div>
 										<span className="text-[#16a34a]">200</span>
-										<span className="text-[var(--vocs-text-color-secondary)]">
+										<span className="text-[var(--text-color-secondary)]">
 											{" "}
 											OK
 										</span>
 									</div>
-									<div className="text-[var(--vocs-text-color-muted)] break-all">
+									<div className="text-[var(--text-color-muted)] break-all">
 										Payment-Receipt: {"<receipt>"}
 									</div>
 								</div>
@@ -617,22 +617,22 @@ export function LandingPage() {
 			</section>
 
 			{/* Feature 2: Multi-Rail (reversed layout) */}
-			<section className="relative py-12 md:py-20 border-b border-[var(--vocs-border-color-primary)]">
+			<section className="relative py-12 md:py-20 border-b border-[var(--border-color-primary)]">
 				<div className="mx-auto px-4 sm:px-6 lg:px-20">
 					<div className="flex flex-col-reverse lg:flex-row gap-8 lg:gap-20 items-center">
 						{/* Left - Payment Methods Grid */}
 						<div className="flex-1 w-full">
 							<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:gap-4">
 								{/* Tempo Card */}
-								<div className="bg-[var(--vocs-background-color-surface)] rounded-xl p-4 md:p-5 space-y-3 border border-[var(--vocs-border-color-primary)]">
+								<div className="bg-[var(--background-color-surface)] rounded-xl p-4 md:p-5 space-y-3 border border-[var(--border-color-primary)]">
 									<div className="flex items-center justify-between gap-2">
 										<TempoLogo
-											className="text-[var(--vocs-text-color-primary)]"
+											className="text-[var(--text-color-primary)]"
 											style={{ width: "60px", height: "auto" }}
 										/>
 										<StatusBadge status="production" />
 									</div>
-									<p className="text-xs md:text-sm text-[var(--vocs-text-color-secondary)] leading-relaxed">
+									<p className="text-xs md:text-sm text-[var(--text-color-secondary)] leading-relaxed">
 										Instant stablecoin settlement on Tempo. Sub-second finality
 										with USDC payments directly to your wallet—no invoices or
 										delayed payouts.
@@ -640,15 +640,15 @@ export function LandingPage() {
 								</div>
 
 								{/* Stripe Card */}
-								<div className="bg-[var(--vocs-background-color-surface)] rounded-xl p-4 md:p-5 space-y-3 border border-[var(--vocs-border-color-primary)]">
+								<div className="bg-[var(--background-color-surface)] rounded-xl p-4 md:p-5 space-y-3 border border-[var(--border-color-primary)]">
 									<div className="flex items-center justify-between gap-2">
 										<StripeLogo
-											className="text-[var(--vocs-text-color-primary)]"
+											className="text-[var(--text-color-primary)]"
 											style={{ width: "48px", height: "auto" }}
 										/>
 										<StatusBadge status="beta" />
 									</div>
-									<p className="text-xs md:text-sm text-[var(--vocs-text-color-secondary)] leading-relaxed">
+									<p className="text-xs md:text-sm text-[var(--text-color-secondary)] leading-relaxed">
 										Accept cards, bank transfers, and invoices through Stripe.
 										Leverage existing Stripe infrastructure with MPP's
 										standardized protocol layer.
@@ -656,14 +656,14 @@ export function LandingPage() {
 								</div>
 
 								{/* Custom Card */}
-								<div className="bg-[var(--vocs-background-color-surface)] rounded-xl p-4 md:p-5 space-y-3 border border-[var(--vocs-border-color-primary)]">
+								<div className="bg-[var(--background-color-surface)] rounded-xl p-4 md:p-5 space-y-3 border border-[var(--border-color-primary)]">
 									<div className="flex items-center justify-between gap-2">
-										<span className="font-semibold text-[var(--vocs-text-color-primary)]">
+										<span className="font-semibold text-[var(--text-color-primary)]">
 											Custom
 										</span>
 										<StatusBadge status="available" />
 									</div>
-									<p className="text-xs md:text-sm text-[var(--vocs-text-color-secondary)] leading-relaxed">
+									<p className="text-xs md:text-sm text-[var(--text-color-secondary)] leading-relaxed">
 										Build your own payment method. MPP's extensible architecture
 										lets you integrate any payment rail—internal credits,
 										loyalty points, or custom currencies.
@@ -671,14 +671,14 @@ export function LandingPage() {
 								</div>
 
 								{/* More Coming Card */}
-								<div className="bg-[var(--vocs-background-color-surface)] rounded-xl p-4 md:p-5 space-y-3 border border-[var(--vocs-border-color-primary)]">
+								<div className="bg-[var(--background-color-surface)] rounded-xl p-4 md:p-5 space-y-3 border border-[var(--border-color-primary)]">
 									<div className="flex items-center justify-between gap-2">
-										<span className="font-semibold text-[var(--vocs-text-color-primary)]">
+										<span className="font-semibold text-[var(--text-color-primary)]">
 											More coming
 										</span>
 										<StatusBadge status="planned" />
 									</div>
-									<p className="text-xs md:text-sm text-[var(--vocs-text-color-secondary)] leading-relaxed">
+									<p className="text-xs md:text-sm text-[var(--text-color-secondary)] leading-relaxed">
 										Lightning Network for instant Bitcoin micropayments, ACH for
 										low-cost bank transfers, and more payment rails on the
 										roadmap.
@@ -692,10 +692,10 @@ export function LandingPage() {
 							<div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-[#0166FF]/10">
 								<LayersIcon className="w-6 h-6 text-[#0166FF]" />
 							</div>
-							<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--vocs-text-color-primary)]">
+							<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--text-color-primary)]">
 								Multi-rail, multi-currency
 							</h2>
-							<p className="text-base md:text-lg text-[var(--vocs-text-color-secondary)] leading-relaxed">
+							<p className="text-base md:text-lg text-[var(--text-color-secondary)] leading-relaxed">
 								MPP is payment method agnostic. Crypto, cards, bank transfers,
 								invoices—all payment methods work through one protocol. Support
 								USD, EUR, BTC, USDC, or any currency.
@@ -708,7 +708,7 @@ export function LandingPage() {
 								].map((item) => (
 									<li
 										key={item}
-										className="flex items-center gap-3 text-sm md:text-base text-[var(--vocs-text-color-secondary)]"
+										className="flex items-center gap-3 text-sm md:text-base text-[var(--text-color-secondary)]"
 									>
 										<span className="w-1.5 h-1.5 rounded-full bg-[#0166FF] flex-shrink-0" />
 										{item}
@@ -721,7 +721,7 @@ export function LandingPage() {
 			</section>
 
 			{/* Feature 3: Developer Experience */}
-			<section className="relative py-12 md:py-20 border-b border-[var(--vocs-border-color-primary)]">
+			<section className="relative py-12 md:py-20 border-b border-[var(--border-color-primary)]">
 				<div className="mx-auto px-4 sm:px-6 lg:px-20">
 					<div className="flex flex-col lg:flex-row gap-8 lg:gap-20 items-center">
 						{/* Left - Copy */}
@@ -729,10 +729,10 @@ export function LandingPage() {
 							<div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-[#0166FF]/10">
 								<ZapIcon className="w-6 h-6 text-[#0166FF]" />
 							</div>
-							<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--vocs-text-color-primary)]">
+							<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--text-color-primary)]">
 								Developer-first experience
 							</h2>
-							<p className="text-base md:text-lg text-[var(--vocs-text-color-secondary)] leading-relaxed">
+							<p className="text-base md:text-lg text-[var(--text-color-secondary)] leading-relaxed">
 								Official SDKs for TypeScript, Python, and Rust. Polyfill fetch
 								or go low-level—MPP works the way you work. Add payments with
 								minimal code changes.
@@ -745,7 +745,7 @@ export function LandingPage() {
 								].map((item) => (
 									<li
 										key={item}
-										className="flex items-center gap-3 text-sm md:text-base text-[var(--vocs-text-color-secondary)]"
+										className="flex items-center gap-3 text-sm md:text-base text-[var(--text-color-secondary)]"
 									>
 										<span className="w-1.5 h-1.5 rounded-full bg-[#0166FF] flex-shrink-0" />
 										{item}
@@ -765,10 +765,10 @@ export function LandingPage() {
 			{/* CTA Section */}
 			<section className="relative py-12 md:py-20">
 				<div className="max-w-[900px] mx-auto px-4 sm:px-6 lg:px-20 text-center">
-					<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--vocs-text-color-primary)] mb-4">
+					<h2 className="text-2xl sm:text-3xl md:text-4xl font-semibold tracking-tight text-[var(--text-color-primary)] mb-4">
 						Start accepting payments today
 					</h2>
-					<p className="text-base md:text-lg text-[var(--vocs-text-color-secondary)] mb-6 md:mb-8 max-w-2xl mx-auto">
+					<p className="text-base md:text-lg text-[var(--text-color-secondary)] mb-6 md:mb-8 max-w-2xl mx-auto">
 						Add payments to your API in minutes. No signup required—just install
 						the SDK and start charging for your resources.
 					</p>
@@ -782,7 +782,7 @@ export function LandingPage() {
 						</a>
 						<a
 							href="/quickstart/client"
-							className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-[var(--vocs-border-color-primary)] text-[var(--vocs-text-color-primary)] font-medium rounded-lg transition-all hover:bg-[var(--vocs-background-color-surface)] no-underline"
+							className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-[var(--border-color-primary)] text-[var(--text-color-primary)] font-medium rounded-lg transition-all hover:bg-[var(--background-color-surface)] no-underline"
 						>
 							Client quickstart
 						</a>

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -52,8 +52,7 @@
 	max-width: 1400px;
 }
 
-/* Landing page layout - inherit theme from root */
+/* Landing page layout */
 [data-layout="minimal"] {
-	color-scheme: inherit;
-	background-color: var(--vocs-background-color-primary);
+	background-color: var(--background-color-primary);
 }


### PR DESCRIPTION
## Summary
- Remove hardcoded `colorScheme: "dark"` that prevented light mode from working
- Replace hardcoded `border-white/[0.06]` and `border-white/20` classes with theme-aware `border-[var(--vocs-border-color-primary)]`
- Update `StatusBadge` component to use theme-aware background and border CSS variables instead of hardcoded `rgba(255, 255, 255, ...)` values

## Test plan
- [ ] Toggle between dark and light mode on the landing page
- [ ] Verify borders are visible in both modes
- [ ] Verify StatusBadge badges render correctly in both modes
- [ ] Check all sections of the landing page in both themes