### PR TITLE
style: black-and-white mermaid diagrams, syntax-highlighted agent tabs

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -164,6 +164,38 @@ function AmpLogo({ className }: { className?: string }) {
 	);
 }
 
+function highlightBash(command: string) {
+	const parts: { text: string; color?: string }[] = [];
+	let i = 0;
+	let first = true;
+	while (i < command.length) {
+		if (command[i] === '"') {
+			const end = command.indexOf('"', i + 1);
+			const str = end === -1 ? command.slice(i) : command.slice(i, end + 1);
+			parts.push({ text: str, color: "#0a3069" });
+			i += str.length;
+		} else if (command[i] === "-") {
+			let end = i;
+			while (end < command.length && command[end] !== " ") end++;
+			parts.push({ text: command.slice(i, end), color: "#0550ae" });
+			i = end;
+		} else if (command[i] === " ") {
+			parts.push({ text: " " });
+			i++;
+		} else {
+			let end = i;
+			while (end < command.length && command[end] !== " ") end++;
+			parts.push({
+				text: command.slice(i, end),
+				color: first ? "#6639ba" : undefined,
+			});
+			first = false;
+			i = end;
+		}
+	}
+	return parts;
+}
+
 const AGENT_COMMANDS = [
 	{
 		label: "Claude",
@@ -205,9 +237,19 @@ function AgentTabs() {
 				})}
 			</div>
 			<div className="flex items-center gap-3 bg-white px-4 py-3">
-				<pre className="text-sm text-gray-500 select-none flex-1 truncate m-0 p-0 bg-transparent font-mono">
+				<pre className="text-sm select-none flex-1 truncate m-0 p-0 bg-transparent font-mono">
 					<code>
-						<span className="text-gray-400">$</span> {cmd.command}
+						<span style={{ color: "#9ca3af" }}>$</span>{" "}
+						{highlightBash(cmd.command).map((part, i) => (
+							<span
+								key={`${part.text}-${i}`}
+								style={
+									part.color ? { color: part.color } : { color: "#24292f" }
+								}
+							>
+								{part.text}
+							</span>
+						))}
 					</code>
 				</pre>
 				<CopyButton text={cmd.command} />

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -115,3 +115,48 @@ code,
 [data-v-code] {
 	font-family: var(--font-mono) !important;
 }
+
+/* Force mermaid diagrams to black and white */
+[data-v-mermaid] .note {
+	fill: #ffffff !important;
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] .noteText {
+	fill: #000000 !important;
+}
+
+[data-v-mermaid] .messageText {
+	fill: #000000 !important;
+}
+
+[data-v-mermaid] .messageLine0,
+[data-v-mermaid] .messageLine1 {
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] text.actor {
+	fill: #000000 !important;
+}
+
+[data-v-mermaid] rect.actor {
+	fill: #ffffff !important;
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] .actor-line {
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] #arrowhead path {
+	fill: #000000 !important;
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] .loopLine {
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] .loopText {
+	fill: #000000 !important;
+}


### PR DESCRIPTION
## Changes

### Mermaid diagrams → black and white
CSS overrides on `[data-v-mermaid]` to force all diagram elements (notes, actors, lines, arrows) to pure black and white. Removes the default yellow note backgrounds and colored text.

### Agent command tabs → syntax highlighting
Adds a lightweight bash tokenizer to the landing page agent tabs (Claude / Codex / Amp). Tokens are colored for a light background:
- **Purple** — command name (`claude`, `codex`, `amp`)
- **Blue** — flags (`-p`, `--full-auto`)
- **Dark blue** — quoted strings