### PR TITLE
feat: host spec artifacts on /specs/

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Build
         run: pnpm build
+        env:
+          GH_TOKEN: ${{ secrets.SPEC_PAT }}
 
   deploy:
     needs: ci
@@ -79,6 +81,8 @@ jobs:
 
       - name: Build site
         run: pnpm run build
+        env:
+          GH_TOKEN: ${{ secrets.SPEC_PAT }}
 
       - name: Sanitize branch name
         if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ src/pages.gen.ts
 .dev.vars*
 .env
 worker-configuration.d.ts
+public/specs/
+src/pages/specs/index.mdx

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
+		"prebuild": "bash scripts/fetch-specs.sh",
 		"build": "vite build && node scripts/patch-cf.ts",
 		"check": "biome check --write",
 		"check:sdk-drift": "npx tsx .github/actions/sdk-drift-check/check-sdk-drift.ts",

--- a/scripts/fetch-specs.sh
+++ b/scripts/fetch-specs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh &>/dev/null; then
+  echo "gh CLI not found -- skipping spec artifact download."
+  echo "Install it from https://cli.github.com to fetch spec artifacts."
+  node scripts/gen-specs-page.ts
+  exit 0
+fi
+
+if ! gh auth status &>/dev/null; then
+  echo "gh CLI not authenticated -- skipping spec artifact download."
+  echo "Run 'gh auth login' or set GH_TOKEN to fetch spec artifacts."
+  node scripts/gen-specs-page.ts
+  exit 0
+fi
+
+mkdir -p public/specs
+if gh release download --repo tempoxyz/payment-auth-spec latest \
+  -D public/specs/ \
+  --clobber 2>&1; then
+  echo "Spec artifacts downloaded to public/specs/"
+else
+  echo "Failed to download spec artifacts -- skipping."
+  echo "Ensure GH_TOKEN has access to tempoxyz/payment-auth-spec."
+fi
+
+node scripts/gen-specs-page.ts

--- a/scripts/gen-specs-page.ts
+++ b/scripts/gen-specs-page.ts
@@ -1,0 +1,130 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const specsDir = path.resolve(process.cwd(), "public/specs");
+const outputFile = path.resolve(process.cwd(), "src/pages/specs/index.mdx");
+
+function writeFallback(reason: string) {
+	const fallback = [
+		"# Specifications [Normative protocol specifications for MPP]",
+		"",
+		"Spec artifacts are not available in this build.",
+		"",
+		`View the specifications at [paymentauth.tempo.xyz](https://paymentauth.tempo.xyz) or in the [source repository](https://github.com/tempoxyz/payment-auth-spec).`,
+		"",
+	];
+	fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+	fs.writeFileSync(outputFile, `${fallback.join("\n").trimEnd()}\n`);
+	console.log(`${reason} -- wrote fallback specs page.`);
+	process.exit(0);
+}
+
+if (!fs.existsSync(specsDir)) {
+	writeFallback("public/specs/ not found");
+}
+
+const xmlFiles = fs
+	.readdirSync(specsDir)
+	.filter((f) => f.startsWith("draft-") && f.endsWith(".xml"))
+	.sort();
+
+if (xmlFiles.length === 0) {
+	writeFallback("No spec artifacts found");
+}
+
+interface Spec {
+	title: string;
+	basename: string;
+	category: string;
+}
+
+function parseXml(file: string): Spec {
+	const content = fs.readFileSync(path.join(specsDir, file), "utf-8");
+	const basename = file.replace(/\.xml$/, "");
+
+	const rfcMatch = content.match(/<rfc[^>]*category="([^"]+)"/);
+	const category = rfcMatch?.[1] ?? "info";
+
+	const frontIdx = content.indexOf("<front>");
+	const afterFront = frontIdx >= 0 ? content.slice(frontIdx) : content;
+	const titleMatch = afterFront.match(/<title[^>]*>(.*?)<\/title>/);
+	const title = titleMatch
+		? titleMatch[1]
+				.replace(/&amp;/g, "&")
+				.replace(/&lt;/g, "<")
+				.replace(/&gt;/g, ">")
+				.replace(/&#34;/g, '"')
+				.replace(/&quot;/g, '"')
+		: basename;
+
+	return { title, basename, category };
+}
+
+const specs = xmlFiles.map(parseXml);
+
+const categories: [string, (b: string) => boolean, string | null][] = [
+	["Core", (b) => b.startsWith("draft-httpauth-"), null],
+	["Extensions", (b) => b.startsWith("draft-payment-discovery"), null],
+	["Transports", (b) => b.startsWith("draft-payment-transport"), null],
+	["Intents", (b) => b.startsWith("draft-payment-intent"), null],
+	["Tempo", (b) => b.startsWith("draft-tempo-"), "Payment Methods"],
+	["Stripe", (b) => b.startsWith("draft-stripe-"), "Payment Methods"],
+];
+
+const lines: string[] = [
+	"# Specifications [Normative protocol specifications for MPP]",
+	"",
+	"The IETF-track Internet-Drafts that define the Machine Payments Protocol.",
+	"",
+	"[Source repository](https://github.com/tempoxyz/payment-auth-spec) · [Contributing](https://github.com/tempoxyz/payment-auth-spec/blob/main/CONTRIBUTING.md)",
+	"",
+];
+
+const used = new Set<string>();
+let lastParent: string | null = null;
+
+for (const [heading, matcher, parent] of categories) {
+	const matched = specs.filter((s) => matcher(s.basename));
+	if (matched.length === 0) continue;
+
+	if (parent && parent !== lastParent) {
+		lines.push(`## ${parent}`);
+		lines.push("");
+		lastParent = parent;
+	}
+
+	const prefix = parent ? "###" : "##";
+	lines.push(`${prefix} ${heading}`);
+	lines.push("");
+	for (const spec of matched) {
+		const hasTxt = fs.existsSync(path.join(specsDir, `${spec.basename}.txt`));
+		const txtLink = hasTxt
+			? ` <a href="/specs/${spec.basename}.txt"><code data-v="true">.txt</code></a>`
+			: "";
+		lines.push(
+			`- ${spec.title} <a href="/specs/${spec.basename}.html"><code data-v="true">.html</code></a>${txtLink}`,
+		);
+		used.add(spec.basename);
+	}
+	lines.push("");
+}
+
+const uncategorized = specs.filter((s) => !used.has(s.basename));
+if (uncategorized.length > 0) {
+	lines.push("## Other");
+	lines.push("");
+	for (const spec of uncategorized) {
+		const hasTxt = fs.existsSync(path.join(specsDir, `${spec.basename}.txt`));
+		const txtLink = hasTxt
+			? ` <a href="/specs/${spec.basename}.txt"><code data-v="true">.txt</code></a>`
+			: "";
+		lines.push(
+			`- ${spec.title} <a href="/specs/${spec.basename}.html"><code data-v="true">.html</code></a>${txtLink}`,
+		);
+	}
+	lines.push("");
+}
+
+fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+fs.writeFileSync(outputFile, `${lines.join("\n").trimEnd()}\n`);
+console.log(`Generated ${path.relative(process.cwd(), outputFile)}`);

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -167,15 +167,25 @@ function AmpLogo({ className }: { className?: string }) {
 const AGENT_COMMANDS = [
 	{
 		label: "Claude",
-		command: 'claude -p "implement an mpp client"',
+		bin: "claude",
+		args: "-p",
+		str: '"implement an mpp client"',
 		icon: ClaudeLogo,
 	},
 	{
 		label: "Codex",
-		command: 'codex --full-auto "implement an mpp client"',
+		bin: "codex",
+		args: "--full-auto",
+		str: '"implement an mpp client"',
 		icon: CodexLogo,
 	},
-	{ label: "Amp", command: 'amp "implement an mpp client"', icon: AmpLogo },
+	{
+		label: "Amp",
+		bin: "amp",
+		args: null,
+		str: '"implement an mpp client"',
+		icon: AmpLogo,
+	},
 ];
 
 function AgentTabs() {
@@ -205,12 +215,17 @@ function AgentTabs() {
 				})}
 			</div>
 			<div className="flex items-center gap-3 bg-white px-4 py-3">
-				<pre className="text-sm text-gray-500 select-none flex-1 truncate m-0 p-0 bg-transparent font-mono">
+				<pre className="text-sm select-none flex-1 truncate m-0 p-0 bg-transparent font-mono">
 					<code>
-						<span className="text-gray-400">$</span> {cmd.command}
+						<span className="text-gray-400">$ </span>
+						<span className="text-gray-800">{cmd.bin}</span>
+						{cmd.args && <span className="text-gray-500"> {cmd.args}</span>}
+						<span className="text-green-700"> {cmd.str}</span>
 					</code>
 				</pre>
-				<CopyButton text={cmd.command} />
+				<CopyButton
+					text={[cmd.bin, cmd.args, cmd.str].filter(Boolean).join(" ")}
+				/>
 			</div>
 		</div>
 	);

--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -125,7 +125,7 @@ export function NotFoundPage() {
 
 	useEffect(() => {
 		let animationId: number;
-		const MORPH_DURATION = 800;
+		const MORPH_DURATION = 3000;
 
 		const animate = () => {
 			const now = Date.now();

--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -13,6 +13,7 @@ type Page =
 | { path: '/overview'; render: 'static' }
 | { path: '/tools/pget'; render: 'static' }
 | { path: '/tools/pget/examples'; render: 'static' }
+| { path: '/specs'; render: 'static' }
 | { path: '/sdk'; render: 'static' }
 | { path: '/sdk/typescript/BodyDigest.compute'; render: 'static' }
 | { path: '/sdk/typescript/BodyDigest.verify'; render: 'static' }

--- a/src/pages/404.mdx
+++ b/src/pages/404.mdx
@@ -2,6 +2,7 @@
 title: Page Not Found
 layout: minimal
 showAskAi: false
+showLogo: false
 showOutline: false
 showSearch: false
 showSidebar: false

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -115,3 +115,48 @@ code,
 [data-v-code] {
 	font-family: var(--font-mono) !important;
 }
+
+/* Force mermaid diagrams to black and white */
+[data-v-mermaid] .note {
+	fill: #ffffff !important;
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] .noteText {
+	fill: #000000 !important;
+}
+
+[data-v-mermaid] .messageText {
+	fill: #000000 !important;
+}
+
+[data-v-mermaid] .messageLine0,
+[data-v-mermaid] .messageLine1 {
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] text.actor {
+	fill: #000000 !important;
+}
+
+[data-v-mermaid] rect.actor {
+	fill: #ffffff !important;
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] .actor-line {
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] #arrowhead path {
+	fill: #000000 !important;
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] .loopLine {
+	stroke: #000000 !important;
+}
+
+[data-v-mermaid] .loopText {
+	fill: #000000 !important;
+}

--- a/src/pages/specs/index.mdx
+++ b/src/pages/specs/index.mdx
@@ -1,0 +1,32 @@
+# Specifications [Normative protocol specifications for MPP]
+
+The IETF-track Internet-Drafts that define the Machine Payments Protocol.
+
+[Source repository](https://github.com/tempoxyz/payment-auth-spec) · [Contributing](https://github.com/tempoxyz/payment-auth-spec/blob/main/CONTRIBUTING.md)
+
+## Core
+
+- The "Payment" HTTP Authentication Scheme <a href="/specs/draft-httpauth-payment-00.html"><code data-v="true">.html</code></a> <a href="/specs/draft-httpauth-payment-00.txt"><code data-v="true">.txt</code></a>
+
+## Extensions
+
+- Discovery Mechanisms for HTTP Payment Authentication <a href="/specs/draft-payment-discovery-00.html"><code data-v="true">.html</code></a> <a href="/specs/draft-payment-discovery-00.txt"><code data-v="true">.txt</code></a>
+
+## Transports
+
+- Payment Authentication Scheme: MCP Transport <a href="/specs/draft-payment-transport-mcp-00.html"><code data-v="true">.html</code></a> <a href="/specs/draft-payment-transport-mcp-00.txt"><code data-v="true">.txt</code></a>
+
+## Intents
+
+- Charge Intent for HTTP Payment Authentication <a href="/specs/draft-payment-intent-charge-00.html"><code data-v="true">.html</code></a> <a href="/specs/draft-payment-intent-charge-00.txt"><code data-v="true">.txt</code></a>
+
+## Payment Methods
+
+### Tempo
+
+- Tempo charge Intent for HTTP Payment Authentication <a href="/specs/draft-tempo-charge-00.html"><code data-v="true">.html</code></a> <a href="/specs/draft-tempo-charge-00.txt"><code data-v="true">.txt</code></a>
+- Tempo Stream Intent for HTTP Payment Authentication <a href="/specs/draft-tempo-stream-00.html"><code data-v="true">.html</code></a> <a href="/specs/draft-tempo-stream-00.txt"><code data-v="true">.txt</code></a>
+
+### Stripe
+
+- Stripe charge Intent for HTTP Payment Authentication <a href="/specs/draft-stripe-charge-00.html"><code data-v="true">.html</code></a> <a href="/specs/draft-stripe-charge-00.txt"><code data-v="true">.txt</code></a>

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
 				text: "Introduction",
 				items: [
 					{ text: "Overview", link: "/overview" },
-					{ text: "Specifications", link: "https://paymentauth.tempo.xyz/" },
+					{ text: "Specifications", link: "/specs/" },
 					{ text: "FAQ", link: "/faq" },
 				],
 			},
@@ -399,7 +399,7 @@ export default defineConfig({
 	topNav: [
 		{ text: "Docs", link: "/overview", match: (path) => path !== "/" },
 		{ text: "SDKs & Tools", link: "/sdk" },
-		{ text: "Specs", link: "https://paymentauth.tempo.xyz" },
+		{ text: "Specs", link: "/specs/" },
 		{
 			text: "GitHub",
 			items: [


### PR DESCRIPTION
Hosts MPP specification artifacts inline on the docs site at `/specs/` instead of linking externally to paymentauth.tempo.xyz.

## What this does

- **`scripts/fetch-specs.sh`** — Downloads spec artifacts (HTML, TXT, XML, PDF) from the `latest` GitHub Release of `tempoxyz/payment-auth-spec` into `public/specs/`. Falls back gracefully if the `gh` CLI is unavailable.
- **`prebuild` script** — Runs the fetch script before every build so artifacts are always up to date.
- **`/specs/` landing page** — Lists all specifications organized by category (Core, Extensions, Intents, Payment Methods) with links to all four formats.
- **Config updates** — Changes topNav and sidebar links from `https://paymentauth.tempo.xyz` to the internal `/specs/` path.
- **`.gitignore`** — Excludes downloaded artifact files from version control.

## Depends on

This requires the parallel change in `tempoxyz/payment-auth-spec` that adds a GitHub Release step to publish spec artifacts under the `latest` tag.