### PR TITLE
feat: host spec artifacts on /specs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ src/pages.gen.ts
 .dev.vars*
 .env
 worker-configuration.d.ts
+public/specs/*.html
+public/specs/*.txt
+public/specs/*.xml
+public/specs/*.pdf

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
+		"prebuild": "bash scripts/fetch-specs.sh",
 		"build": "vite build && node scripts/patch-cf.ts",
 		"check": "biome check --write",
 		"check:sdk-drift": "npx tsx .github/actions/sdk-drift-check/check-sdk-drift.ts",

--- a/scripts/fetch-specs.sh
+++ b/scripts/fetch-specs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh &>/dev/null; then
+  echo "⚠️  gh CLI not found — skipping spec artifact download."
+  echo "   Install it from https://cli.github.com to fetch spec artifacts."
+  exit 0
+fi
+
+mkdir -p public/specs
+gh release download --repo tempoxyz/payment-auth-spec latest \
+  -D public/specs/ \
+  --clobber
+echo "✓ Spec artifacts downloaded to public/specs/"

--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -13,6 +13,7 @@ type Page =
 | { path: '/overview'; render: 'static' }
 | { path: '/tools/pget'; render: 'static' }
 | { path: '/tools/pget/examples'; render: 'static' }
+| { path: '/specs'; render: 'static' }
 | { path: '/sdk'; render: 'static' }
 | { path: '/sdk/typescript/BodyDigest.compute'; render: 'static' }
 | { path: '/sdk/typescript/BodyDigest.verify'; render: 'static' }

--- a/src/pages/specs/index.mdx
+++ b/src/pages/specs/index.mdx
@@ -1,0 +1,32 @@
+import { Badge, Card, Cards } from 'vocs'
+
+# Specifications [Normative protocol specifications for MPP]
+
+These are the IETF-track Internet-Drafts that define the Machine Payments Protocol. Each specification is available in HTML, plain text, XML, and PDF.
+
+[Source repository](https://github.com/tempoxyz/payment-auth-spec) · [Contributing](https://github.com/tempoxyz/payment-auth-spec/blob/main/CONTRIBUTING.md)
+
+## Core
+
+| Specification | Status | Formats |
+|---------------|--------|---------|
+| **The "Payment" HTTP Authentication Scheme** | <Badge variant="info">Standards Track</Badge> | [HTML](/specs/draft-httpauth-payment-00.html) · [TXT](/specs/draft-httpauth-payment-00.txt) · [XML](/specs/draft-httpauth-payment-00.xml) · [PDF](/specs/draft-httpauth-payment-00.pdf) |
+
+## Extensions
+
+| Specification | Status | Formats |
+|---------------|--------|---------|
+| **Discovery Mechanisms for HTTP Payment Authentication** | <Badge variant="info">Informational</Badge> | [HTML](/specs/draft-payment-discovery-00.html) · [TXT](/specs/draft-payment-discovery-00.txt) · [XML](/specs/draft-payment-discovery-00.xml) · [PDF](/specs/draft-payment-discovery-00.pdf) |
+
+## Intents
+
+| Specification | Status | Formats |
+|---------------|--------|---------|
+| **Charge Intent for HTTP Payment Authentication** | <Badge variant="info">Informational</Badge> | [HTML](/specs/draft-payment-intent-charge-00.html) · [TXT](/specs/draft-payment-intent-charge-00.txt) · [XML](/specs/draft-payment-intent-charge-00.xml) · [PDF](/specs/draft-payment-intent-charge-00.pdf) |
+
+## Payment methods
+
+| Specification | Status | Formats |
+|---------------|--------|---------|
+| **Tempo Charge Intent for HTTP Payment Authentication** | <Badge variant="info">Informational</Badge> | [HTML](/specs/draft-tempo-charge-00.html) · [TXT](/specs/draft-tempo-charge-00.txt) · [XML](/specs/draft-tempo-charge-00.xml) · [PDF](/specs/draft-tempo-charge-00.pdf) |
+| **Stripe Charge Intent for HTTP Payment Authentication** | <Badge variant="info">Informational</Badge> | [HTML](/specs/draft-stripe-charge-00.html) · [TXT](/specs/draft-stripe-charge-00.txt) · [XML](/specs/draft-stripe-charge-00.xml) · [PDF](/specs/draft-stripe-charge-00.pdf) |

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
 				text: "Introduction",
 				items: [
 					{ text: "Overview", link: "/overview" },
-					{ text: "Specifications", link: "https://paymentauth.tempo.xyz/" },
+					{ text: "Specifications", link: "/specs/" },
 					{ text: "FAQ", link: "/faq" },
 				],
 			},
@@ -399,7 +399,7 @@ export default defineConfig({
 	topNav: [
 		{ text: "Docs", link: "/overview", match: (path) => path !== "/" },
 		{ text: "SDKs & Tools", link: "/sdk" },
-		{ text: "Specs", link: "https://paymentauth.tempo.xyz" },
+		{ text: "Specs", link: "/specs/" },
 		{
 			text: "GitHub",
 			items: [


### PR DESCRIPTION
- Add scripts/fetch-specs.sh to download spec artifacts from the payment-auth-spec GitHub Release at build time
- Add prebuild script to package.json to run fetch before build
- Create /specs/ landing page listing all specifications with links to HTML, TXT, XML, and PDF formats
- Update topNav and sidebar links from paymentauth.tempo.xyz to /specs/
- Add public/specs/ artifact patterns to .gitignore