### PR TITLE
fix: add cache headers for font and asset files

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
Fonts were being re-downloaded on every page navigation because static assets were served with `cache-control: public, max-age=0, must-revalidate`.

Adds a `_headers` file that sets `Cache-Control: public, max-age=31536000, immutable` on `/fonts/*` and `/assets/*` responses.