### PR TITLE
Landing page polish: reorder CTA, fix specs link, remove badges

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -170,21 +170,21 @@ const AGENT_COMMANDS = [
 		label: "Claude",
 		bin: "claude",
 		args: "-p",
-		str: '"implement an mpp client"',
+		str: '"charge $0.01 per api call with MPP"',
 		icon: ClaudeLogo,
 	},
 	{
 		label: "Codex",
 		bin: "codex",
 		args: "--full-auto",
-		str: '"implement an mpp client"',
+		str: '"charge $0.01 per api call with MPP"',
 		icon: CodexLogo,
 	},
 	{
 		label: "Amp",
 		bin: "amp",
 		args: null,
-		str: '"implement an mpp client"',
+		str: '"charge $0.01 per api call with MPP"',
 		icon: AmpLogo,
 	},
 ];
@@ -281,12 +281,15 @@ export function LandingPage() {
 									href="https://stripe.com"
 									target="_blank"
 									rel="noopener noreferrer"
-									className="no-underline text-gray-400 hover:text-gray-600 transition-colors"
+									className="no-underline text-gray-400 hover:text-[#635BFF] transition-colors"
 								>
 									<StripeLogo style={{ width: "55px" }} />
 								</a>
 							</div>
 						</div>
+
+						{/* Copy-to-agent line */}
+						<AgentTabs />
 
 						{/* CTA buttons */}
 						<div className="flex flex-wrap gap-3">
@@ -310,15 +313,12 @@ export function LandingPage() {
 								</svg>
 							</a>
 							<a
-								href="/specifications"
+								href="/specs/"
 								className="inline-flex items-center gap-2 px-5 py-2.5 border border-gray-200 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50 transition-colors no-underline"
 							>
 								Read the specs
 							</a>
 						</div>
-
-						{/* Copy-to-agent line */}
-						<AgentTabs />
 					</div>
 
 					{/* Left pane — interactive demo */}

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -1,4 +1,4 @@
-import { Badge, Card, Cards } from 'vocs'
+import { Card, Cards } from 'vocs'
 import { PaymentDemo } from '../components/PaymentDemo'
 
 # Machine Payments Protocol [The internet-native payments protocol]
@@ -66,21 +66,18 @@ All SDKs implement similar interfaces and are interoperable with one another.
 
 <Cards>
   <Card
-    topRight={<Badge variant="info">Reference</Badge>}
     description="Get started with `mpay`, the reference implementation of the MPP SDKs"
     icon="simple-icons:typescript"
     title="TypeScript"
     to="/sdk/typescript"
   />
   <Card
-    topRight={<Badge variant="warning">Beta</Badge>}
     description="Get started with `pympay`, the official MPP SDK for Python"
     icon="simple-icons:python"
     title="Python"
     to="/sdk/python"
   />
   <Card
-    topRight={<Badge variant="warning">Beta</Badge>}
     description="Get started with `mpay-rs`, the official MPP SDK for Rust"
     icon="simple-icons:rust"
     title="Rust"

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -98,7 +98,7 @@ Anyone can define new payment methods. The protocol requires that methods define
 | Method | Description | Status |
 |--------|-------------|--------|
 | [Tempo](/payment-methods/tempo) | Native stablecoin payments on Tempo Network | <Badge variant="success">Production</Badge> |
-| Stripe | Traditional card and bank payments via Stripe | <Badge variant="info">Beta</Badge> |
+| Stripe | Traditional card and bank payments via Stripe | <Badge variant="warning">Coming soon</Badge> |
 
 Each payment method specifies its own `request` and `payload` schemas while sharing the common challenge/credential flow.
 

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -1,4 +1,4 @@
-import { Badge, Card, Cards } from 'vocs'
+import { Card, Cards } from 'vocs'
 
 # SDKs & Tools [Official implementations in TypeScript, Python, and Rust]
 
@@ -6,21 +6,18 @@ The Machine Payments Protocol (MPP) has official SDKs in multiple languages. At 
 
 <Cards>
   <Card
-    topRight={<Badge variant="info">Reference</Badge>}
     description="Get started with `mpay`, the reference implementation of the MPP SDKs"
     icon="simple-icons:typescript"
     title="TypeScript"
     to="/sdk/typescript"
   />
   <Card
-    topRight={<Badge variant="warning">Beta</Badge>}
     description="Get started with `pympay`, the official MPP SDK for Python"
     icon="simple-icons:python"
     title="Python"
     to="/sdk/python"
   />
   <Card
-    topRight={<Badge variant="warning">Beta</Badge>}
     description="Get started with `mpay-rs`, the official MPP SDK for Rust"
     icon="simple-icons:rust"
     title="Rust"

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -13,7 +13,10 @@ export default defineConfig({
 	accentColor: "#0166FF",
 	colorScheme: "light",
 	baseUrl,
-	redirects: [{ source: "/docs", destination: "/overview" }],
+	redirects: [
+		{ source: "/docs", destination: "/overview" },
+		{ source: "/specifications", destination: "/specs/" },
+	],
 	description:
 		"Machine Payments Protocol - Machine-native payments for machine-to-machine transactions",
 	checkDeadlinks: "warn",


### PR DESCRIPTION
- Move agent tabs (Claude/Codex/Amp) above Get Started button
- Stripe logo hovers to brand purple (#635BFF)
- Fix /specifications link → /specs/ with redirect
- Update agent command text to "charge $0.01 per api call with MPP"
- Remove Reference/Beta badges from SDK cards (overview + SDK index)
- Change Stripe status from Beta → Coming soon in protocol page