### PR TITLE
add machinepayments.dev as custom domain

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -36,6 +36,10 @@
 		{
 			"pattern": "mpp.tempo.xyz",
 			"custom_domain": true
+		},
+		{
+			"pattern": "machinepayments.dev",
+			"custom_domain": true
 		}
 	]
 }


### PR DESCRIPTION
Adds `machinepayments.dev` as a second custom domain route for the mpp-docs Cloudflare Worker, alongside the existing `mpp.tempo.xyz`.

Requires `machinepayments.dev` to be added as a zone in Cloudflare — the `custom_domain: true` setting will handle DNS record creation on deploy.