### PR TITLE
docs: update pget CLI commands to match new structure

### DIFF
--- a/src/pages/quickstart/pget.mdx
+++ b/src/pages/quickstart/pget.mdx
@@ -14,12 +14,12 @@ import { Card, Cards } from 'vocs'
 $ curl -fsSL https://pget.tempo.xyz/install.sh | bash
 ```
 
-### Initialize
+### Log in
 
-Run the init wizard to set up your wallet:
+Run the login wizard to set up your wallet:
 
-```bash [init.sh]
-$ pget init
+```bash [login.sh]
+$ pget login
 ```
 
 This creates a new encrypted keystore and saves your configuration to `~/.pget/config.toml`.
@@ -36,7 +36,7 @@ $ export PGET_PRIVATE_KEY="0x..."
 ### Make your first paid request
 
 ```bash [paid-request.sh]
-$ pget -vv https://mpp.tempo.xyz/api/ping/paid
+$ pget query -vv https://mpp.tempo.xyz/api/ping/paid
 ```
 
 :::tip[Live demo server]
@@ -61,7 +61,7 @@ We host a live demo server at `mpp.tempo.xyz` running on **Tempo testnet**. Use 
 Use dry-run mode to see what would happen without actually paying:
 
 ```bash [dry-run.sh]
-$ pget -D https://mpp.tempo.xyz/api/ping/paid
+$ pget query -D https://mpp.tempo.xyz/api/ping/paid
 ```
 
 Or inspect the payment requirements before paying:
@@ -76,7 +76,7 @@ Protect yourself with a maximum payment amount:
 
 ```bash [max-payment.sh]
 # Reject payments over 1 USD
-$ pget -M 1000000 https://mpp.tempo.xyz/api/ping/paid
+$ pget query -M 1000000 https://mpp.tempo.xyz/api/ping/paid
 ```
 
 ### Common flags
@@ -112,7 +112,7 @@ The agent calls pget like any other commandline tool when it detects a `402` Pay
 When an AI agent needs to access a paid resource, it runs:
 
 ```bash [agent-request.sh]
-$ pget https://api.example.com/premium-data
+$ pget query https://api.example.com/premium-data
 ```
 
 The agent receives the response data directly—no manual payment handling required.
@@ -127,7 +127,7 @@ Set a maximum amount the agent can spend per request:
 
 ```bash [spending-limit.sh]
 # Limit to 0.50 USDC per request
-$ pget -M 500000 https://api.example.com/data
+$ pget query -M 500000 https://api.example.com/data
 ```
 
 ### Dry run mode
@@ -135,7 +135,7 @@ $ pget -M 500000 https://api.example.com/data
 Agents can preview costs before committing:
 
 ```bash [preview-cost.sh]
-$ pget -D https://api.example.com/expensive-endpoint
+$ pget query -D https://api.example.com/expensive-endpoint
 ```
 
 ### Network filtering
@@ -143,7 +143,7 @@ $ pget -D https://api.example.com/expensive-endpoint
 Restrict payments to specific networks:
 
 ```bash
-pget -n tempo-moderato https://api.example.com/data
+pget query -n tempo-moderato https://api.example.com/data
 ```
 
 ### Skill configuration
@@ -173,14 +173,14 @@ For AI agent frameworks that support skills, pget can be configured as a tool:
 
 ```bash [query-api.sh]
 # Query a paid data API
-$ pget https://api.data-provider.com/market-data?symbol=BTC
+$ pget query https://api.data-provider.com/market-data?symbol=BTC
 ```
 
 ### Paid compute
 
 ```bash [inference.sh]
 # Run inference on a paid model
-$ pget -X POST \
+$ pget query -X POST \
   --json '{"prompt": "Explain quantum computing"}' \
   https://api.ai-provider.com/generate
 ```
@@ -189,7 +189,7 @@ $ pget -X POST \
 
 ```bash [analyze-repo.sh]
 # Use a paid developer tool
-$ pget https://api.dev-tools.com/analyze?repo=myorg/myrepo
+$ pget query https://api.dev-tools.com/analyze?repo=myorg/myrepo
 ```
 
 ## Next steps

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -183,13 +183,13 @@ After your server is running, test it with [pget](/tools/pget):
 $ pget inspect <your-server>/resource
 
 # Make a paid request (requires funded wallet)
-$ pget <your-server>/resource
+$ pget query <your-server>/resource
 
 # Verbose output to see the full 402 flow
-$ pget -vi <your-server>/resource
+$ pget query -vi <your-server>/resource
 
 # Dry run to preview payment without executing
-$ pget -D <your-server>/resource
+$ pget query -D <your-server>/resource
 ```
 
 :::tip

--- a/src/pages/tools/pget.mdx
+++ b/src/pages/tools/pget.mdx
@@ -23,11 +23,11 @@ $ cargo install --path .
 ## Quick start
 
 ```bash [quickstart.sh]
-# Initialize (first time only)
-$ pget init
+# Log in (first time only)
+$ pget login
 
 # Make a paid request
-$ pget https://mpp.tempo.xyz/api/ping/paid
+$ pget query https://mpp.tempo.xyz/api/ping/paid
 ```
 
 :::tip[Live demo server]
@@ -49,32 +49,31 @@ keystore = "/Users/you/.pget/keystores/my-wallet.json"
 tempo = "https://my-private-rpc.com"
 ```
 
-## Payment method management
+## Key management
 
-```bash [manage-methods.sh]
-# List all payment methods
-$ pget method list
+```bash [key-management.sh]
+# List all access keys
+$ pget keys list
 
-# Create a new wallet
-$ pget method new my-wallet --generate
+# Switch to a different access key
+$ pget keys switch 1
 
-# Import an existing private key
-$ pget method import my-wallet
-
-# Check balance on specific network
-$ pget balance -n tempo
+# Delete an access key
+$ pget keys delete 2
 ```
 
 ## Command reference
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `pget init` | `pget i` | Initialize configuration |
-| `pget config` | `pget c` | View/manage configuration |
-| `pget method` | `pget m` | Manage payment methods |
-| `pget balance` | `pget b` | Check wallet balance |
-| `pget networks` | `pget n` | List supported networks |
-| `pget inspect` | — | Inspect payment requirements |
+| Command | Description |
+|---------|-------------|
+| `pget query <url>` | Make an HTTP request with automatic payment |
+| `pget login` | Log in and set up your wallet |
+| `pget logout` | Log out and clear credentials |
+| `pget whoami` | Show the current authenticated identity |
+| `pget inspect <url>` | Inspect payment requirements |
+| `pget balance` | Check wallet balance |
+| `pget config` | View/manage configuration |
+| `pget networks` | List supported networks |
 
 ## Learn more
 

--- a/src/pages/tools/pget/examples.mdx
+++ b/src/pages/tools/pget/examples.mdx
@@ -6,19 +6,19 @@ We host a live demo server at `mpp.tempo.xyz` running on **Tempo testnet** that 
 
 ```bash [try-demo.sh]
 # Free endpoint - no payment required
-$ pget https://mpp.tempo.xyz/api/ping
+$ pget query https://mpp.tempo.xyz/api/ping
 
 # Paid endpoint - requires 0.10 pathUSD payment
-$ pget https://mpp.tempo.xyz/api/ping/paid
+$ pget query https://mpp.tempo.xyz/api/ping/paid
 
 # Inspect the payment requirements first
 $ pget inspect https://mpp.tempo.xyz/api/ping/paid
 
 # Dry run to preview what happens
-$ pget -D https://mpp.tempo.xyz/api/ping/paid
+$ pget query -D https://mpp.tempo.xyz/api/ping/paid
 
 # Verbose output to see the full 402 flow
-$ pget -vi https://mpp.tempo.xyz/api/ping/paid
+$ pget query -vi https://mpp.tempo.xyz/api/ping/paid
 ```
 
 ### Set up with a private key
@@ -30,7 +30,7 @@ For testing, you can use a private key directly using an environment variable:
 $ export PGET_PRIVATE_KEY="0x..."
 
 # Make paid requests
-$ pget https://mpp.tempo.xyz/api/ping/paid
+$ pget query https://mpp.tempo.xyz/api/ping/paid
 ```
 
 :::tip[Get testnet funds]
@@ -41,32 +41,32 @@ The demo server runs on Tempo testnet. Fund your wallet at [faucet.tempo.xyz](ht
 
 ```bash [basic-requests.sh]
 # Make a payment request
-$ pget https://mpp.tempo.xyz/api/ping/paid
+$ pget query https://mpp.tempo.xyz/api/ping/paid
 
 # Verbose output with headers
-$ pget -vi https://mpp.tempo.xyz/api/ping/paid
+$ pget query -vi https://mpp.tempo.xyz/api/ping/paid
 
 # Save output to file
-$ pget -o output.json https://mpp.tempo.xyz/api/ping/paid
+$ pget query -o output.json https://mpp.tempo.xyz/api/ping/paid
 
 # JSON output format
-$ pget --json-output https://mpp.tempo.xyz/api/ping/paid
+$ pget query --json-output https://mpp.tempo.xyz/api/ping/paid
 ```
 
 ## Payment controls
 
 ```bash [payment-controls.sh]
 # Preview payment without executing (dry run)
-$ pget -D https://mpp.tempo.xyz/api/ping/paid
+$ pget query -D https://mpp.tempo.xyz/api/ping/paid
 
 # Require confirmation before payment
-$ pget -y https://mpp.tempo.xyz/api/ping/paid
+$ pget query -y https://mpp.tempo.xyz/api/ping/paid
 
 # Set maximum payment amount (in atomic units)
-$ pget -M 10000 https://mpp.tempo.xyz/api/ping/paid
+$ pget query -M 10000 https://mpp.tempo.xyz/api/ping/paid
 
 # Filter to specific networks
-$ pget -n tempo-moderato https://mpp.tempo.xyz/api/ping/paid
+$ pget query -n tempo-moderato https://mpp.tempo.xyz/api/ping/paid
 ```
 
 ## Wallet management
@@ -79,10 +79,10 @@ $ pget balance
 $ pget balance -n tempo-moderato
 
 # Use specific account by name
-$ pget -a my-wallet https://mpp.tempo.xyz/api/ping/paid
+$ pget query -a my-wallet https://mpp.tempo.xyz/api/ping/paid
 
 # Use specific sender address
-$ pget --from 0x1234... https://mpp.tempo.xyz/api/ping/paid
+$ pget query --from 0x1234... https://mpp.tempo.xyz/api/ping/paid
 ```
 
 ## Inspecting payments
@@ -102,30 +102,30 @@ $ pget config --output-format json
 
 ```bash [http-options.sh]
 # Custom headers
-$ pget -H "X-Custom: value" https://mpp.tempo.xyz/api/ping/paid
+$ pget query -H "X-Custom: value" https://mpp.tempo.xyz/api/ping/paid
 
 # POST with data
-$ pget -X POST -d '{"key": "value"}' https://mpp.tempo.xyz/api/ping/paid
+$ pget query -X POST -d '{"key": "value"}' https://mpp.tempo.xyz/api/ping/paid
 
 # POST with JSON (sets Content-Type automatically)
-$ pget --json '{"key": "value"}' https://mpp.tempo.xyz/api/ping/paid
+$ pget query --json '{"key": "value"}' https://mpp.tempo.xyz/api/ping/paid
 
 # Follow redirects
-$ pget -L https://mpp.tempo.xyz/api/ping/paid
+$ pget query -L https://mpp.tempo.xyz/api/ping/paid
 
 # Set timeout
-$ pget -m 30 https://mpp.tempo.xyz/api/ping/paid
+$ pget query -m 30 https://mpp.tempo.xyz/api/ping/paid
 ```
 
 ## Output control
 
 ```bash [output-control.sh]
 # Quiet mode (suppress non-essential output)
-$ pget -q https://mpp.tempo.xyz/api/ping/paid
+$ pget query -q https://mpp.tempo.xyz/api/ping/paid
 
 # Show only HTTP headers
-$ pget -I https://mpp.tempo.xyz/api/ping/paid
+$ pget query -I https://mpp.tempo.xyz/api/ping/paid
 
 # Disable colors
-$ pget --color never https://mpp.tempo.xyz/api/ping/paid
+$ pget query --color never https://mpp.tempo.xyz/api/ping/paid
 ```


### PR DESCRIPTION
## Summary

Update pget docs to reflect the CLI restructure from tempoxyz/pget#93.

## Changes

- `pget <url>` → `pget query <url>` across all doc pages
- `pget init` → `pget login`
- Removed `pget method` subcommands section (no longer exists)
- Added `pget logout` and `pget whoami` to command reference table
- Updated files: `tools/pget.mdx`, `tools/pget/examples.mdx`, `quickstart/pget.mdx`, `quickstart/server.mdx`