### PR TITLE
fix: use SPEC_PAT directly for spec artifact downloads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build
         run: pnpm build
         env:
-          GH_TOKEN: ${{ secrets.SPEC_PAT }}
+          SPEC_PAT: ${{ secrets.SPEC_PAT }}
 
       - name: Upload build
         uses: actions/upload-artifact@v4

--- a/scripts/fetch-specs.sh
+++ b/scripts/fetch-specs.sh
@@ -8,9 +8,13 @@ if ! command -v gh &>/dev/null; then
   exit 0
 fi
 
-if ! gh auth status &>/dev/null; then
-  echo "gh CLI not authenticated -- skipping spec artifact download."
-  echo "Run 'gh auth login' or set GH_TOKEN to fetch spec artifacts."
+if [[ -n "${SPEC_PAT:-}" ]]; then
+  export GH_TOKEN="$SPEC_PAT"
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+  echo "GH_TOKEN / SPEC_PAT not set -- skipping spec artifact download."
+  echo "Set SPEC_PAT or GH_TOKEN to fetch spec artifacts."
   node scripts/gen-specs-page.ts
   exit 0
 fi

--- a/scripts/gen-specs-page.ts
+++ b/scripts/gen-specs-page.ts
@@ -105,7 +105,7 @@ for (const [heading, matcher, parent] of categories) {
 			links.push(
 				`<a href="/specs/${spec.basename}.txt"><code data-v="true">.txt</code></a>`,
 			);
-		lines.push(`- ${spec.title} [${links.join(", ")}]`);
+		lines.push(`- ${spec.title} [${links.join(",")}]`);
 		used.add(spec.basename);
 	}
 	lines.push("");
@@ -124,7 +124,7 @@ if (uncategorized.length > 0) {
 			links.push(
 				`<a href="/specs/${spec.basename}.txt"><code data-v="true">.txt</code></a>`,
 			);
-		lines.push(`- ${spec.title} [${links.join(", ")}]`);
+		lines.push(`- ${spec.title} [${links.join(",")}]`);
 	}
 	lines.push("");
 }

--- a/src/pages/specs/index.mdx
+++ b/src/pages/specs/index.mdx
@@ -6,27 +6,27 @@ The IETF-track Internet-Drafts that define the Machine Payments Protocol.
 
 ## Core
 
-- The "Payment" HTTP Authentication Scheme [<a href="/specs/draft-httpauth-payment-00.html"><code data-v="true">.html</code></a>, <a href="/specs/draft-httpauth-payment-00.txt"><code data-v="true">.txt</code></a>]
+- The "Payment" HTTP Authentication Scheme [<a href="/specs/draft-httpauth-payment-00.html"><code data-v="true">.html</code></a>,<a href="/specs/draft-httpauth-payment-00.txt"><code data-v="true">.txt</code></a>]
 
 ## Extensions
 
-- Discovery Mechanisms for HTTP Payment Authentication [<a href="/specs/draft-payment-discovery-00.html"><code data-v="true">.html</code></a>, <a href="/specs/draft-payment-discovery-00.txt"><code data-v="true">.txt</code></a>]
+- Discovery Mechanisms for HTTP Payment Authentication [<a href="/specs/draft-payment-discovery-00.html"><code data-v="true">.html</code></a>,<a href="/specs/draft-payment-discovery-00.txt"><code data-v="true">.txt</code></a>]
 
 ## Transports
 
-- Payment Authentication Scheme: MCP Transport [<a href="/specs/draft-payment-transport-mcp-00.html"><code data-v="true">.html</code></a>, <a href="/specs/draft-payment-transport-mcp-00.txt"><code data-v="true">.txt</code></a>]
+- Payment Authentication Scheme: MCP Transport [<a href="/specs/draft-payment-transport-mcp-00.html"><code data-v="true">.html</code></a>,<a href="/specs/draft-payment-transport-mcp-00.txt"><code data-v="true">.txt</code></a>]
 
 ## Intents
 
-- Charge Intent for HTTP Payment Authentication [<a href="/specs/draft-payment-intent-charge-00.html"><code data-v="true">.html</code></a>, <a href="/specs/draft-payment-intent-charge-00.txt"><code data-v="true">.txt</code></a>]
+- Charge Intent for HTTP Payment Authentication [<a href="/specs/draft-payment-intent-charge-00.html"><code data-v="true">.html</code></a>,<a href="/specs/draft-payment-intent-charge-00.txt"><code data-v="true">.txt</code></a>]
 
 ## Payment Methods
 
 ### Tempo
 
-- Tempo charge Intent for HTTP Payment Authentication [<a href="/specs/draft-tempo-charge-00.html"><code data-v="true">.html</code></a>, <a href="/specs/draft-tempo-charge-00.txt"><code data-v="true">.txt</code></a>]
-- Tempo Stream Intent for HTTP Payment Authentication [<a href="/specs/draft-tempo-stream-00.html"><code data-v="true">.html</code></a>, <a href="/specs/draft-tempo-stream-00.txt"><code data-v="true">.txt</code></a>]
+- Tempo charge Intent for HTTP Payment Authentication [<a href="/specs/draft-tempo-charge-00.html"><code data-v="true">.html</code></a>,<a href="/specs/draft-tempo-charge-00.txt"><code data-v="true">.txt</code></a>]
+- Tempo Stream Intent for HTTP Payment Authentication [<a href="/specs/draft-tempo-stream-00.html"><code data-v="true">.html</code></a>,<a href="/specs/draft-tempo-stream-00.txt"><code data-v="true">.txt</code></a>]
 
 ### Stripe
 
-- Stripe charge Intent for HTTP Payment Authentication [<a href="/specs/draft-stripe-charge-00.html"><code data-v="true">.html</code></a>, <a href="/specs/draft-stripe-charge-00.txt"><code data-v="true">.txt</code></a>]
+- Stripe charge Intent for HTTP Payment Authentication [<a href="/specs/draft-stripe-charge-00.html"><code data-v="true">.html</code></a>,<a href="/specs/draft-stripe-charge-00.txt"><code data-v="true">.txt</code></a>]


### PR DESCRIPTION
The `gh` CLI in GitHub Actions picks up the auto-injected `GITHUB_TOKEN`, which can't access `tempoxyz/payment-auth-spec`. This causes a 403 when `fetch-specs.sh` tries to download release artifacts.

**Changes:**
- `fetch-specs.sh`: Accept `SPEC_PAT` env var directly and export it as `GH_TOKEN`, replacing the `gh auth status` check (which could pass with the wrong token)
- `deploy.yml`: Pass `SPEC_PAT` as itself instead of aliasing to `GH_TOKEN` to avoid conflicts with the runner's auto-injected token