### PR TITLE
ci: reuse build artifact in deploy job instead of rebuilding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Download build
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The `ci` job already builds the site. Instead of rebuilding in `deploy`, upload `dist/` as an artifact and download it — removes the duplicate pnpm/node setup, install, and build steps.