### PR TITLE
fix: footer links only blue/underlined on hover

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -171,11 +171,14 @@ export function LandingPage() {
 				<div className="flex items-center gap-4">
 					<a
 						href="https://github.com/tempoxyz/payment-auth-spec"
-						className="text-[#0166ff] underline"
+						className="text-gray-400 no-underline hover:text-[#0166ff] hover:underline transition-colors"
 					>
 						GitHub
 					</a>
-					<a href="https://x.com/mpp" className="text-[#0166ff] underline">
+					<a
+						href="https://x.com/mpp"
+						className="text-gray-400 no-underline hover:text-[#0166ff] hover:underline transition-colors"
+					>
 						X
 					</a>
 				</div>


### PR DESCRIPTION
Footer links (GitHub, X) were permanently blue and underlined. Changed to gray by default, with blue color and underline appearing only on hover.