### PR TITLE
Add Checkpoint AI fix workflow

### DIFF
--- a/.github/workflows/fix-workflow.yml
+++ b/.github/workflows/fix-workflow.yml
@@ -1,0 +1,199 @@
+name: Checkpoint AI Fix
+
+on:
+  repository_dispatch:
+    types: [checkpoint-fix]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Notify running
+        run: |
+          curl -s -X POST "${{ github.event.client_payload.callbackUrl }}" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.CHECKPOINT_SECRET }}" \
+            -d '{
+              "reportId": "${{ github.event.client_payload.reportId }}",
+              "status": "running"
+            }'
+
+      - name: Setup branch
+        id: branch
+        run: |
+          SESSION_BRANCH="${{ github.event.client_payload.sessionBranch }}"
+          if [ -n "$SESSION_BRANCH" ] && git ls-remote --exit-code --heads origin "$SESSION_BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$SESSION_BRANCH"
+            git checkout "$SESSION_BRANCH"
+            echo "name=$SESSION_BRANCH" >> $GITHUB_OUTPUT
+            echo "is_new=false" >> $GITHUB_OUTPUT
+          else
+            BRANCH="checkpoint/${{ github.event.client_payload.reportId }}"
+            git checkout -b "$BRANCH"
+            echo "name=$BRANCH" >> $GITHUB_OUTPUT
+            echo "is_new=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Write context
+        run: |
+          cat > /tmp/checkpoint-context.json << 'CONTEXT_EOF'
+          ${{ toJSON(github.event.client_payload) }}
+          CONTEXT_EOF
+
+      - name: Download screenshots
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p /tmp/checkpoint-screenshots
+          URLS=$(echo '${{ toJSON(github.event.client_payload.screenshotUrls) }}' | jq -r '.[]? | .rawUrl // empty')
+          NAMES=$(echo '${{ toJSON(github.event.client_payload.screenshotUrls) }}' | jq -r '.[]? | .name // empty')
+          if [ -n "$URLS" ]; then
+            i=1
+            while IFS= read -r url && IFS= read -r name <&3; do
+              # Gist raw URLs need auth for secret gists
+              curl -sL -H "Authorization: token $GH_TOKEN" "$url" | base64 -d > "/tmp/checkpoint-screenshots/$name" 2>/dev/null || true
+              echo "Downloaded screenshot $i: $name"
+              i=$((i+1))
+            done <<< "$URLS" 3<<< "$NAMES"
+            ls -la /tmp/checkpoint-screenshots/
+          else
+            echo "No screenshots to download"
+          fi
+
+      - name: Install Amp
+        run: curl -fsSL https://ampcode.com/install.sh | bash
+
+      - name: Run AI Agent
+        env:
+          AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
+        run: |
+          SCREENSHOT_FILES=$(ls /tmp/checkpoint-screenshots/ 2>/dev/null | head -5)
+          SCREENSHOT_NOTE=""
+          if [ -n "$SCREENSHOT_FILES" ]; then
+            SCREENSHOT_NOTE="Screenshots of the element/area are in /tmp/checkpoint-screenshots/. Look at these images first to understand visually what needs to change."
+          fi
+
+          amp -x --dangerously-allow-all "You are an AI agent implementing a change requested via Checkpoint (a QA/feedback tool). The request may be a bug fix, a UI change, a feature tweak, content update, or any other code modification.
+
+          Request: ${{ github.event.client_payload.title }}
+          Details: ${{ github.event.client_payload.description }}
+          Page URL: ${{ github.event.client_payload.url }}
+
+          ${SCREENSHOT_NOTE}
+
+          The full context (element selectors, React component names, computed styles, console errors, failed requests, DOM snapshots, screenshot annotations) is in /tmp/checkpoint-context.json. Read that file first.
+
+          Use the CSS selectors and React component names from the context to locate the relevant source files. Implement exactly what was requested - whether that is fixing a bug, removing an element, changing text, adjusting styles, or any other modification. Do not add comments explaining the change - just make it."
+
+      - name: Commit and push
+        id: commit
+        run: |
+          git config user.name "checkpoint-bot"
+          git config user.email "checkpoint@tempo.xyz"
+          if git diff --quiet; then
+            echo "No changes to commit"
+            curl -s -X POST "${{ github.event.client_payload.callbackUrl }}" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ secrets.CHECKPOINT_SECRET }}" \
+              -d '{
+                "reportId": "${{ github.event.client_payload.reportId }}",
+                "status": "failed",
+                "error": "Agent produced no changes"
+              }'
+            exit 0
+          fi
+          git add -A
+          git commit -m "checkpoint: ${{ github.event.client_payload.title }}
+
+          Checkpoint Report: ${{ github.event.client_payload.reportId }}
+          Linear: ${{ github.event.client_payload.issueId }}"
+          git push origin ${{ steps.branch.outputs.name }}
+          echo "pushed=true" >> $GITHUB_OUTPUT
+
+      - name: Create PR
+        id: create_pr
+        if: steps.commit.outputs.pushed == 'true' && steps.branch.outputs.is_new == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr create \
+            --title "checkpoint: ${{ github.event.client_payload.title }}" \
+            --body "## Checkpoint AI Change
+
+          **Linear:** [${{ github.event.client_payload.issueId }}](${{ github.event.client_payload.issueUrl }})
+          **Report ID:** \`${{ github.event.client_payload.reportId }}\`
+          **URL:** ${{ github.event.client_payload.url }}
+
+          ---
+
+          This PR was automatically generated by [Checkpoint](https://tempo-qa.vercel.app) in response to a request.
+
+          ### Request
+          ${{ github.event.client_payload.description }}
+
+          ### Context
+          See the linked Linear issue for screenshots and element context." \
+            --head "${{ steps.branch.outputs.name }}" \
+            --base main)
+
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Notify PR opened
+        if: steps.create_pr.outputs.pr_url
+        run: |
+          curl -s -X POST "${{ github.event.client_payload.callbackUrl }}" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.CHECKPOINT_SECRET }}" \
+            -d '{
+              "reportId": "${{ github.event.client_payload.reportId }}",
+              "status": "pr_opened",
+              "prUrl": "${{ steps.create_pr.outputs.pr_url }}",
+              "prNumber": ${{ steps.create_pr.outputs.pr_number }},
+              "branch": "${{ steps.branch.outputs.name }}"
+            }'
+
+      - name: Notify commit added
+        if: steps.commit.outputs.pushed == 'true' && steps.branch.outputs.is_new == 'false'
+        run: |
+          curl -s -X POST "${{ github.event.client_payload.callbackUrl }}" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.CHECKPOINT_SECRET }}" \
+            -d '{
+              "reportId": "${{ github.event.client_payload.reportId }}",
+              "status": "committed",
+              "branch": "${{ steps.branch.outputs.name }}"
+            }'
+
+      - name: Cleanup screenshot gist
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          GIST_ID=$(echo '${{ toJSON(github.event.client_payload.screenshotUrls) }}' | jq -r '.[0]?.gistId // empty')
+          if [ -n "$GIST_ID" ]; then
+            curl -s -X DELETE "https://api.github.com/gists/$GIST_ID" \
+              -H "Authorization: token $GH_TOKEN" || true
+            echo "Deleted gist $GIST_ID"
+          fi
+
+      - name: Notify failure
+        if: failure()
+        run: |
+          curl -s -X POST "${{ github.event.client_payload.callbackUrl }}" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.CHECKPOINT_SECRET }}" \
+            -d '{
+              "reportId": "${{ github.event.client_payload.reportId }}",
+              "status": "failed",
+              "error": "Workflow failed"
+            }'


### PR DESCRIPTION
Adds the GitHub Actions workflow that enables Checkpoint's AI dev mode for this repo.

When someone uses Checkpoint's dev mode on mpp.tempo.xyz, it triggers this workflow to:
- Check out the repo
- Download annotated screenshots
- Run an AI agent (Amp) with full element context
- Open a PR with the requested change

Requires `AMP_API_KEY` and `CHECKPOINT_SECRET` repo secrets.