### PR TITLE
fix: use tempoModerato chain in CliDemo to fix payment verification

### DIFF
--- a/src/components/CliDemo.tsx
+++ b/src/components/CliDemo.tsx
@@ -319,7 +319,7 @@ export function CliDemo() {
 					"viem/accounts"
 				);
 				const { createClient, http } = await import("viem");
-				type Chain = import("viem").Chain;
+				const { tempoModerato } = await import("viem/chains");
 
 				// Initial terminal output
 				addLines([
@@ -448,7 +448,7 @@ export function CliDemo() {
 							account: acc,
 							client: () =>
 								createClient({
-									chain: { id: 42431, name: "Tempo Testnet" } as Chain,
+									chain: tempoModerato,
 									transport: http("/api/rpc"),
 								}),
 						}),


### PR DESCRIPTION
The CliDemo was creating a viem client with a bare chain object `{ id: 42431, name: "Tempo Testnet" }` that lacked Tempo's custom transaction serializers/formatters. This caused `signTransaction` to produce standard EIP-1559 transactions that dropped the `calls` array, making server-side payment verification fail with "no matching payment call found".

**Fix:** Import `tempoModerato` from `viem/chains` and use it instead of the bare chain object.