### PR TITLE
chore: update spec links from paymentauth.tempo.xyz to specs.tempo.xyz

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Use this guidance when creating or updating documentation for MPP.
 
 When writing docs, reference these sites for patterns and APIs:
 
-- **MPP Spec**: <https://paymentauth.tempo.xyz> — Normative Payment Auth specs
+- **MPP Spec**: `/specs` — Normative Payment Auth specs
 - **Vocs**: <https://vocs.dev> — Documentation framework (MDX, callouts, Cards)
 - **Viem**: <https://viem.sh> — Ethereum library used in examples
 - **Wagmi**: <https://wagmi.sh> — React hooks for Ethereum (style reference)
@@ -14,7 +14,7 @@ When writing docs, reference these sites for patterns and APIs:
 
 ## Source of Truth
 
-Prefer the normative Payment Auth specs at <https://paymentauth.tempo.xyz> for protocol-level details:
+Prefer the normative Payment Auth specs at `/specs` for protocol-level details:
 
 - Core Payment HTTP Authentication Scheme
 - Payment methods

--- a/scripts/gen-specs-page.ts
+++ b/scripts/gen-specs-page.ts
@@ -10,7 +10,7 @@ function writeFallback(reason: string) {
 		"",
 		"Spec artifacts are not available in this build.",
 		"",
-		`View the specifications at [paymentauth.tempo.xyz](https://paymentauth.tempo.xyz) or in the [source repository](https://github.com/tempoxyz/payment-auth-spec).`,
+		`View the specifications at [/specs](/specs) or in the [source repository](https://github.com/tempoxyz/payment-auth-spec).`,
 		"",
 	];
 	fs.mkdirSync(path.dirname(outputFile), { recursive: true });

--- a/src/pages/intents/charge.mdx
+++ b/src/pages/intents/charge.mdx
@@ -79,5 +79,5 @@ Each payment method defines how charge is fulfilled, verified, and settled on it
 ## Specification
 
 <Cards>
-  <SpecCard to="https://paymentauth.tempo.xyz/draft-payment-intent-charge-00" />
+  <SpecCard to="/specs/draft-payment-intent-charge-00" />
 </Cards>

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -104,6 +104,6 @@ All SDKs implement similar interfaces and are interoperable with one another.
     description="See the normative definition"
     icon="lucide:file-text"
     title="Protocol spec"
-    to="https://paymentauth.tempo.xyz"
+    to="/specs"
   />
 </Cards>

--- a/src/pages/payment-methods/tempo/charge.mdx
+++ b/src/pages/payment-methods/tempo/charge.mdx
@@ -121,5 +121,5 @@ See [`tempo.charge` client reference](/sdk/typescript/client/Method.tempo.charge
 ## Specification
 
 <Cards>
-  <SpecCard to="https://paymentauth.tempo.xyz/draft-tempo-charge-00" />
+  <SpecCard to="/specs/draft-tempo-charge-00" />
 </Cards>

--- a/src/pages/payment-methods/tempo/stream.mdx
+++ b/src/pages/payment-methods/tempo/stream.mdx
@@ -232,5 +232,5 @@ See [`tempo.stream` client reference](/sdk/typescript/client/Method.tempo.stream
 ## Specification
 
 <Cards>
-  <SpecCard to="https://paymentauth.tempo.xyz/draft-tempo-stream-00" />
+  <SpecCard to="/specs/draft-tempo-stream-00" />
 </Cards>

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -4,7 +4,7 @@ import { Badge } from 'vocs'
 
 The Machine Payments Protocol (MPP) is a machine-native protocol for machine-to-machine payments. It standardizes HTTP `402` "Payment Required" with an extensible framework that works with any payment network.
 
-These docs provide a developer-friendly overview. For the full specification, see [paymentauth.tempo.xyz](https://paymentauth.tempo.xyz).
+These docs provide a developer-friendly overview. For the full specification, see [the specifications](/specs).
 
 ## Flow
 
@@ -240,11 +240,11 @@ Implementations may define additional parameters in challenges:
 These docs provide a practical overview. For normative, IETF-style specifications:
 
 :::note[IETF-track specifications]
-- [Payment HTTP Authentication Scheme](https://paymentauth.tempo.xyz/draft-httpauth-payment-00)—Core protocol spec (draft-httpauth-payment-00)
-- [Payment Methods](https://paymentauth.tempo.xyz/methods)—Payment method definitions
-- [Payment Intents](https://paymentauth.tempo.xyz/intents)—Intent types (charge, authorize, subscription)
-- [MCP Transport](https://paymentauth.tempo.xyz/transports/mcp)—Model Context Protocol binding
-- [HTTP Transport](https://paymentauth.tempo.xyz/transports/http)—HTTP binding details
+- [Payment HTTP Authentication Scheme](/specs/draft-httpauth-payment-00)—Core protocol spec (draft-httpauth-payment-00)
+- [Payment Methods](/specs/methods)—Payment method definitions
+- [Payment Intents](/specs/intents)—Intent types (charge, authorize, subscription)
+- [MCP Transport](/specs/transports/mcp)—Model Context Protocol binding
+- [HTTP Transport](/specs/transports/http)—HTTP binding details
 :::
 
 The full specification includes detailed ABNF grammar, security analysis, IANA considerations, and complete examples for various payment scenarios.


### PR DESCRIPTION
Updates all references from `paymentauth.tempo.xyz` to `specs.tempo.xyz` across 7 files:

- `AGENTS.md`
- `scripts/gen-specs-page.ts`
- `src/pages/intents/charge.mdx`
- `src/pages/overview.mdx`
- `src/pages/payment-methods/tempo/charge.mdx`
- `src/pages/payment-methods/tempo/stream.mdx`
- `src/pages/protocol/index.mdx`