### PR TITLE
docs: update specs page description

### DIFF
--- a/scripts/gen-specs-page.ts
+++ b/scripts/gen-specs-page.ts
@@ -74,7 +74,7 @@ const categories: [string, (b: string) => boolean, string | null][] = [
 const lines: string[] = [
 	"# Specifications [Normative protocol specifications for MPP]",
 	"",
-	"The IETF-track Internet-Drafts that define the Machine Payments Protocol.",
+	"The technical specifications that define the Machine Payments Protocol.",
 	"",
 	"[Source repository](https://github.com/tempoxyz/payment-auth-spec) · [Contributing](https://github.com/tempoxyz/payment-auth-spec/blob/main/CONTRIBUTING.md)",
 	"",


### PR DESCRIPTION
Changes 'IETF-track Internet-Drafts' to 'technical specifications' in the specs page generator.