### PR TITLE
refactor: switch payment token from AlphaUSD to PathUSD

### DIFF
--- a/src/components/CliPlayground.tsx
+++ b/src/components/CliPlayground.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { alphaUsd } from "../wagmi.config";
+import { pathUsd } from "../wagmi.config";
 import * as Cli from "./Cli";
 
 export function CliPlayground() {
@@ -128,7 +128,7 @@ export function CliPlayground() {
 
 			<Cli.Demo
 				title="Make a request with payment"
-				token={alphaUsd}
+				token={pathUsd}
 				restartStep={1}
 			>
 				<Cli.Startup />

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -4,7 +4,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { useConnectorClient } from "wagmi";
 import { fetch } from "../mpay.client";
-import { alphaUsd } from "../wagmi.config";
+import { pathUsd } from "../wagmi.config";
 import { AgentTabs } from "./AgentTabs";
 import { AsciiLogo } from "./AsciiLogo";
 import * as Cli from "./Cli";
@@ -102,7 +102,7 @@ export function LandingPage() {
 					<div className="flex-11 w-full min-w-0 flex flex-col order-last lg:order-first max-w-[574px] lg:max-w-none">
 						<Cli.Demo
 							title="agent-demo"
-							token={alphaUsd}
+							token={pathUsd}
 							height={337}
 							restartStep={1}
 						>

--- a/src/pages/_api/api/wallet.ts
+++ b/src/pages/_api/api/wallet.ts
@@ -1,7 +1,7 @@
 import { env } from "cloudflare:workers";
 
 const RPC_URL = "https://rpc.moderato.tempo.xyz";
-const DEFAULT_CURRENCY = "0x20c0000000000000000000000000000000000001";
+const DEFAULT_CURRENCY = "0x20c0000000000000000000000000000000000000";
 
 function getRpcHeaders(): Record<string, string> {
 	const headers: Record<string, string> = {

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -1,6 +1,6 @@
 import { Card, Cards } from 'vocs'
 import * as Cli from '../components/Cli'
-import { alphaUsd } from '../wagmi.config'
+import { pathUsd } from '../wagmi.config'
 
 # Machine Payments Protocol [The internet-native payments protocol]
 
@@ -28,7 +28,7 @@ The Machine Payment Protocol addresses this issue, providing an internet native 
 
 This documentation site is itself an MPP server. Create an account, fund it with testnet tokens, and make a paid request to see the full flow in action.
 
-<Cli.Demo title="Make a request with payment" token={alphaUsd} restartStep={1}>
+<Cli.Demo title="Make a request with payment" token={pathUsd} restartStep={1}>
   <Cli.Startup />
   <Cli.ConnectWallet />
   <Cli.Faucet />

--- a/src/pages/payment-methods/tempo/charge.mdx
+++ b/src/pages/payment-methods/tempo/charge.mdx
@@ -23,7 +23,7 @@ const mpay = Mpay.create({
 export async function handler(request: Request) {
   const result = await mpay.charge({
     amount: '0.1',
-    currency: '0x20c0000000000000000000000000000000000001',
+    currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
   })(request)
 
@@ -45,7 +45,7 @@ import { Expires } from 'mpay'
 export async function handler(request: Request) {
   const result = await mpay.charge({
     amount: '0.1',
-    currency: '0x20c0000000000000000000000000000000000001',
+    currency: '0x20c0000000000000000000000000000000000000',
     expires: Expires.minutes(10), // [!code hl]
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
   })(request)
@@ -66,7 +66,7 @@ declare const request: Request
 // ---cut---
 const result = await mpay.charge({
   amount: '0.1',
-  currency: '0x20c0000000000000000000000000000000000001',
+  currency: '0x20c0000000000000000000000000000000000000',
   feePayer: true, // [!code hl]
   recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
 })(request)

--- a/src/pages/payment-methods/tempo/index.mdx
+++ b/src/pages/payment-methods/tempo/index.mdx
@@ -59,7 +59,7 @@ declare const request: Request
 // ---cut---
 const response = await mpay.charge({
   amount: '0.1',
-  currency: '0x20c0000000000000000000000000000000000001',
+  currency: '0x20c0000000000000000000000000000000000000',
   feePayer: true, // [!code hl]
   recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
 })(request)

--- a/src/pages/payment-methods/tempo/stream.mdx
+++ b/src/pages/payment-methods/tempo/stream.mdx
@@ -107,7 +107,7 @@ declare const storage: import('mpay/server').ChannelStorage
 const mpay = Mpay.create({
   methods: [
     tempo.stream({
-      currency: '0x20c0000000000000000000000000000000000001',
+      currency: '0x20c0000000000000000000000000000000000000',
       recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
       rpcUrl: 'https://rpc.tempo.xyz',
       storage,
@@ -129,7 +129,7 @@ declare const storage: import('mpay/server').ChannelStorage
 const mpay = Mpay.create({
   methods: [
     tempo.stream({
-      currency: '0x20c0000000000000000000000000000000000001',
+      currency: '0x20c0000000000000000000000000000000000000',
       recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
       rpcUrl: 'https://rpc.tempo.xyz',
       storage,
@@ -140,7 +140,7 @@ const mpay = Mpay.create({
 export async function handler(request: Request) {
   const result = await mpay.stream({
     amount: '25',
-    currency: '0x20c0000000000000000000000000000000000001',
+    currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
     unitType: 'llm_token',
   })(request)

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -51,7 +51,7 @@ const mpay = Mpay.create({ methods: [tempo.charge()] })
 export async function handler(request: Request) { 
   const response = await mpay.charge({ 
     amount: '0.1', 
-    currency: '0x20c0000000000000000000000000000000000001', 
+    currency: '0x20c0000000000000000000000000000000000000', 
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8', 
   })(request) 
   // [!code focus:end]
@@ -87,7 +87,7 @@ type ServerResponse = import('node:http').ServerResponse
 export async function handler(req: IncomingMessage, res: ServerResponse) { 
   const response = await Mpay.toNodeListener(mpay.charge({ // [!code ++]
     amount: '0.1', 
-    currency: '0x20c0000000000000000000000000000000000001', 
+    currency: '0x20c0000000000000000000000000000000000000', 
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8', 
   }))(req, res) // [!code ++]
 
@@ -107,14 +107,14 @@ We can also hoist values that we use often up into the `Mpay` instance.
 ```ts
 const mpay = Mpay.create({ 
   methods: [tempo.charge({
-    currency: '0x20c0000000000000000000000000000000000001', // [!code ++]
+    currency: '0x20c0000000000000000000000000000000000000', // [!code ++]
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8', // [!code ++]
   })] 
 })
 
 const response = await mpay.charge({ 
   amount: '0.1', 
-  currency: '0x20c0000000000000000000000000000000000001',  // [!code --]
+  currency: '0x20c0000000000000000000000000000000000000',  // [!code --]
   recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',  // [!code --]
 })(request) 
 ```
@@ -135,7 +135,7 @@ const app = new Hono() // [!code focus]
 app.get('/resource', async (c) => { // [!code focus:99]
   const r = await mpay.charge({
     amount: '0.1',
-    currency: '0x20c0000000000000000000000000000000000001',
+    currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
   })(c.req.raw)
 

--- a/src/pages/sdk/python/client.mdx
+++ b/src/pages/sdk/python/client.mdx
@@ -50,7 +50,7 @@ account = TempoAccount.from_key("0x...")
 
 method = StreamMethod(
     account=account,
-    currency="0x20c0000000000000000000000000000000000001",
+    currency="0x20c0000000000000000000000000000000000000",
     deposit=10_000_000,
 )
 

--- a/src/pages/sdk/python/index.mdx
+++ b/src/pages/sdk/python/index.mdx
@@ -44,7 +44,7 @@ app = FastAPI()
 
 mpay = Mpay.create(
     method=tempo(
-        currency="0x20c0000000000000000000000000000000000001",
+        currency="0x20c0000000000000000000000000000000000000",
         recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
         intents={"charge": ChargeIntent()},
     ),

--- a/src/pages/sdk/python/server.mdx
+++ b/src/pages/sdk/python/server.mdx
@@ -17,7 +17,7 @@ app = FastAPI()
 
 mpay = Mpay.create(
     method=tempo(
-        currency="0x20c0000000000000000000000000000000000001",
+        currency="0x20c0000000000000000000000000000000000000",
         recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
         intents={"charge": ChargeIntent()},
     ),
@@ -46,7 +46,7 @@ async def get_resource(request: Request):
 ```python [server.py]
 mpay = Mpay.create(
     method=tempo(
-        currency="0x20c0000000000000000000000000000000000001",
+        currency="0x20c0000000000000000000000000000000000000",
         recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
         intents={"charge": ChargeIntent()},
     ),
@@ -63,7 +63,7 @@ mpay = Mpay.create(
 from mpay.methods.tempo import tempo, ChargeIntent
 
 method = tempo(
-    currency="0x20c0000000000000000000000000000000000001",
+    currency="0x20c0000000000000000000000000000000000000",
     recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
     intents={"charge": ChargeIntent()},
 )
@@ -79,7 +79,7 @@ from mpay.methods.tempo.stream.storage import MemoryStorage
 
 mpay = Mpay.create(
     method=tempo(
-        currency="0x20c0000000000000000000000000000000000001",
+        currency="0x20c0000000000000000000000000000000000000",
         recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
         intents={
             "charge": ChargeIntent(),
@@ -251,7 +251,7 @@ app = FastAPI()
 
 mpay = Mpay.create(
     method=tempo(
-        currency="0x20c0000000000000000000000000000000000001",
+        currency="0x20c0000000000000000000000000000000000000",
         recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
         intents={
             "stream": StreamIntent(

--- a/src/pages/sdk/rust/server.mdx
+++ b/src/pages/sdk/rust/server.mdx
@@ -27,7 +27,7 @@ let payment = Mpay::new(method, "mpp.dev", "my-secret");
 ```rust
 let challenge = payment.charge_challenge(
     "1000000",
-    "0x20c0000000000000000000000000000000000001",
+    "0x20c0000000000000000000000000000000000000",
     "0xa726a1CD723409074DF9108A2187cfA19899aCF8",
 )?;
 ```

--- a/src/pages/sdk/typescript/Challenge.fromIntent.mdx
+++ b/src/pages/sdk/typescript/Challenge.fromIntent.mdx
@@ -17,7 +17,7 @@ const challenge = Challenge.fromIntent(
     realm: 'mpp.dev',
     request: {
       amount: '0.1',
-      currency: '0x20c0000000000000000000000000000000000001',
+      currency: '0x20c0000000000000000000000000000000000000',
       decimals: 6,
       recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
     },

--- a/src/pages/sdk/typescript/PaymentRequest.fromIntent.mdx
+++ b/src/pages/sdk/typescript/PaymentRequest.fromIntent.mdx
@@ -10,7 +10,7 @@ import { MethodIntents } from 'mpay/tempo'
 
 const request = PaymentRequest.fromIntent(MethodIntents.charge, {
   amount: '0.1',
-  currency: '0x20c0000000000000000000000000000000000001',
+  currency: '0x20c0000000000000000000000000000000000000',
   decimals: 6,
   recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
 })

--- a/src/pages/sdk/typescript/core/PaymentRequest.from.mdx
+++ b/src/pages/sdk/typescript/core/PaymentRequest.from.mdx
@@ -9,7 +9,7 @@ import { PaymentRequest } from 'mpay'
 
 const request = PaymentRequest.from({
   amount: '1000000',
-  currency: '0x20c0000000000000000000000000000000000001',
+  currency: '0x20c0000000000000000000000000000000000000',
   recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
 })
 ```

--- a/src/pages/sdk/typescript/core/PaymentRequest.serialize.mdx
+++ b/src/pages/sdk/typescript/core/PaymentRequest.serialize.mdx
@@ -9,7 +9,7 @@ import { PaymentRequest } from 'mpay'
 
 const request = PaymentRequest.from({
   amount: '1000000',
-  currency: '0x20c0000000000000000000000000000000000001',
+  currency: '0x20c0000000000000000000000000000000000000',
   recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
 })
 

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -162,7 +162,7 @@ const mpay = Mpay.create({ methods: [tempo.charge()] })
 export async function handler(request: Request) { 
   const response = await mpay.charge({ 
     amount: '0.1', 
-    currency: '0x20c0000000000000000000000000000000000001', 
+    currency: '0x20c0000000000000000000000000000000000000', 
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8', 
   })(request) 
 
@@ -190,7 +190,7 @@ type ServerResponse = import('node:http').ServerResponse
 export async function handler(req: IncomingMessage, res: ServerResponse) { 
   const response = await Mpay.toNodeListener(mpay.charge({ // [!code ++]
     amount: '0.1', 
-    currency: '0x20c0000000000000000000000000000000000001', 
+    currency: '0x20c0000000000000000000000000000000000000', 
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8', 
   }))(req, res) // [!code ++]
 
@@ -219,7 +219,7 @@ const app = new Hono() // [!code focus]
 app.get('/resource', async (c) => { // [!code focus:99]
   const r = await mpay.charge({
     amount: '0.1',
-    currency: '0x20c0000000000000000000000000000000000001',
+    currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
   })(c.req.raw)
 

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -13,7 +13,7 @@ export async function handler(request: Request) {
   // [!code focus:start]
   const response = await mpay.charge({
     amount: '0.1',
-    currency: '0x20c0000000000000000000000000000000000001',
+    currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
   })(request)
   // [!code focus:end]
@@ -37,7 +37,7 @@ import { Expires } from 'mpay'
 export async function handler(request: Request) {
   const response = await mpay.charge({
     amount: '0.1',
-    currency: '0x20c0000000000000000000000000000000000001',
+    currency: '0x20c0000000000000000000000000000000000000',
     expires: Expires.minutes(10), // [!code focus]
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
   })(request)
@@ -59,7 +59,7 @@ const mpay = Mpay.create({ methods: [tempo.charge()] })
 export async function handler(request: Request) {
   const response = await mpay.charge({
     amount: '0.1',
-    currency: '0x20c0000000000000000000000000000000000001',
+    currency: '0x20c0000000000000000000000000000000000000',
     description: 'API access for /resource', // [!code focus]
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
   })(request)

--- a/src/pages/sdk/typescript/server/Method.tempo.stream.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.stream.mdx
@@ -14,7 +14,7 @@ const mpay = Mpay.create({
   // [!code focus:start]
   methods: [
     tempo.stream({
-      currency: '0x20c0000000000000000000000000000000000001',
+      currency: '0x20c0000000000000000000000000000000000000',
       recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
       storage,
     }),

--- a/src/snippets/server-setup.ts
+++ b/src/snippets/server-setup.ts
@@ -11,7 +11,7 @@ const mpay = Mpay.create({ methods: [tempo.charge()] });
 export async function handler(request: Request) {
 	const response = await mpay.charge({
 		amount: "0.1",
-		currency: "0x20c0000000000000000000000000000000000001",
+		currency: "0x20c0000000000000000000000000000000000000",
 		recipient: "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
 	})(request);
 

--- a/src/wagmi.config.ts
+++ b/src/wagmi.config.ts
@@ -3,12 +3,12 @@ import { tempoModerato } from "viem/chains";
 import { createConfig, webSocket } from "wagmi";
 import { KeyManager, webAuthn } from "wagmi/tempo";
 
-export const alphaUsd =
-	"0x20c0000000000000000000000000000000000001" as `0x${string}`;
+export const pathUsd =
+	"0x20c0000000000000000000000000000000000000" as `0x${string}`;
 
 export const queryClient = new QueryClient();
 
-const chain = tempoModerato.extend({ feeToken: alphaUsd });
+const chain = tempoModerato.extend({ feeToken: pathUsd });
 
 const rpId = (() => {
 	const hostname = globalThis.location?.hostname;


### PR DESCRIPTION
## Summary
Switch all payment defaults from AlphaUSD (`0x20c0...0001`) to PathUSD (`0x20c0...0000`). AlphaUSD was a testnet-only fake coin.

## Changes (21 files)
- `wagmi.config.ts` — renamed `alphaUsd` → `pathUsd` constant
- `LandingPage.tsx`, `CliPlayground.tsx`, `overview.mdx` — updated imports
- `server-setup.ts`, `wallet.ts` — updated default currency address
- 15 MDX docs — updated addresses in code examples

## Testing
TypeScript typecheck and Biome lint pass.

Thread: https://tempoxyz.slack.com/archives/C0A8YB63Q91/p1770606546055849