### PR TITLE
docs: update tempoctl tagline to "wget for payments"

### DIFF
--- a/src/pages/quickstart/tempoctl.mdx
+++ b/src/pages/quickstart/tempoctl.mdx
@@ -1,6 +1,6 @@
 import { Card, Cards } from 'vocs'
 
-# tempoctl [wget for paid APIs]
+# tempoctl [wget for payments]
 
 `tempoctl` is a non-interactive commandline tool for making HTTP requests with automatic payment support. Handles `402 Payment Required` responses with built-in payment methods and permissions. Works from scripts, cron jobs, and AI agents.
 

--- a/src/pages/tools/tempoctl.mdx
+++ b/src/pages/tools/tempoctl.mdx
@@ -1,4 +1,4 @@
-# tempoctl [wget for paid APIs]
+# tempoctl [wget for payments]
 
 `tempoctl` is a non-interactive commandline tool for making HTTP requests with automatic payment support.
 


### PR DESCRIPTION
Update tagline from "wget for paid APIs" to "wget for payments" in tempoctl docs pages.

Thread: https://tempoxyz.slack.com/archives/C0A8YB63Q91/p1770660403448989

Co-Authored-By: georgios <georgios@tempo.xyz>