### PR TITLE
perf: reduce Shiki bundle size by aliasing to minimal language set

### DIFF
--- a/src/shiki-langs.ts
+++ b/src/shiki-langs.ts
@@ -1,0 +1,23 @@
+// @ts-nocheck — Shiki lang subpath imports lack type declarations
+export const bundledLanguages = {
+	bash: () => import("@shikijs/langs/bash"),
+	html: () => import("@shikijs/langs/html"),
+	"html-derivative": () => import("@shikijs/langs/html-derivative"),
+	http: () => import("@shikijs/langs/http"),
+	javascript: () => import("@shikijs/langs/javascript"),
+	js: () => import("@shikijs/langs/js"),
+	json: () => import("@shikijs/langs/json"),
+	jsonc: () => import("@shikijs/langs/jsonc"),
+	jsx: () => import("@shikijs/langs/jsx"),
+	markdown: () => import("@shikijs/langs/markdown"),
+	md: () => import("@shikijs/langs/md"),
+	mdx: () => import("@shikijs/langs/mdx"),
+	python: () => import("@shikijs/langs/python"),
+	rust: () => import("@shikijs/langs/rust"),
+	shellscript: () => import("@shikijs/langs/shellscript"),
+	toml: () => import("@shikijs/langs/toml"),
+	ts: () => import("@shikijs/langs/ts"),
+	tsx: () => import("@shikijs/langs/tsx"),
+	typescript: () => import("@shikijs/langs/typescript"),
+	yaml: () => import("@shikijs/langs/yaml"),
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import nodeLoaderCloudflare from "@hiogawa/node-loader-cloudflare/vite";
 import react from "@vitejs/plugin-react";
 import Icons from "unplugin-icons/vite";
@@ -5,6 +6,13 @@ import { defineConfig } from "vite";
 import { vocs } from "vocs/vite";
 
 export default defineConfig({
+	resolve: {
+		alias: {
+			"shiki/bundle/web": fileURLToPath(
+				new URL("./src/shiki-langs.ts", import.meta.url),
+			),
+		},
+	},
 	optimizeDeps: {
 		include: ["@braintree/sanitize-url", "dayjs", "mermaid"],
 	},

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -386,6 +386,12 @@ export default defineConfig({
 		{ icon: "x", link: "https://x.com/mpp" },
 		{ icon: "github", link: "https://github.com/tempoxyz/payment-auth-spec" },
 	],
+	codeHighlight: {
+		themes: {
+			light: "github-light",
+			dark: "github-light",
+		},
+	},
 	title: "Machine Payments Protocol",
 	titleTemplate: "%s | MPP",
 	twoslash: {


### PR DESCRIPTION
Replace shiki/bundle/web (56 languages) with a minimal subset of 20
languages actually used in the docs. Set dark theme to github-light
since the site is light-only, avoiding loading github-dark-dimmed.

Amp-Thread-ID: https://ampcode.com/threads/T-019c4407-97a5-73ec-8368-3a8803fc70cb
Co-authored-by: Amp <amp@ampcode.com>
