### PR TITLE
docs: update client examples to use composed tempo() method

### DIFF
--- a/src/pages/quickstart/client.mdx
+++ b/src/pages/quickstart/client.mdx
@@ -45,7 +45,7 @@ import { Mpay, tempo } from 'mpay/client' // [!code hl]
 const account = privateKeyToAccount('0xabc…123')
 
 Mpay.create({ // [!code hl]
-  methods: [tempo.charge({ account })], // [!code hl] 
+  methods: [tempo({ account })], // [!code hl] 
 }) // [!code hl]
 ```
 
@@ -55,7 +55,7 @@ If you want to avoid polyfilling, use the returned `fetch` instead.
 ```ts
 const mpay = Mpay.create({
   polyfill: false, // [!code hl]
-  methods: [tempo.charge({ account })]
+  methods: [tempo({ account })]
 })
 
 const response = await mpay.fetch('https://mpp.dev/api/ping/paid') // [!code hl]
@@ -87,7 +87,7 @@ import { Mpay, tempo } from 'mpay/client'
 
 const mpay = Mpay.create({
   polyfill: false,
-  methods: [tempo.charge()]
+  methods: [tempo()]
 })
 
 const response = await mpay.fetch('https://mpp.dev/api/ping/paid', {
@@ -115,7 +115,7 @@ const mpay = Mpay.create({
   // [!code hl:start]
   polyfill: false,
   // [!code hl:end]
-  methods: [tempo.charge()],
+  methods: [tempo()],
 })
 
 // [!code hl:start]

--- a/src/pages/sdk/typescript/client/Mpay.create.mdx
+++ b/src/pages/sdk/typescript/client/Mpay.create.mdx
@@ -11,7 +11,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 const account = privateKeyToAccount('0x...')
 
 Mpay.create({
-  methods: [tempo.charge({ account })],
+  methods: [tempo({ account })],
 })
 
 // Global fetch now handles 402 automatically
@@ -30,7 +30,7 @@ const account = privateKeyToAccount('0x...')
 
 const mpay = Mpay.create({
   polyfill: false, // [!code hl]
-  methods: [tempo.charge({ account })],
+  methods: [tempo({ account })],
 })
 
 // Use the returned fetch // [!code hl]
@@ -47,7 +47,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 
 const mpay = Mpay.create({
   polyfill: false, // [!code hl]
-  methods: [tempo.charge()],
+  methods: [tempo()],
 })
 
 // [!code hl:start]
@@ -99,7 +99,7 @@ const account = privateKeyToAccount('0x...')
 
 const mpay = Mpay.create({
   // [!code focus:start]
-  methods: [tempo.charge({ account })],
+  methods: [tempo({ account })],
   // [!code focus:end]
 })
 ```
@@ -119,7 +119,7 @@ const account = privateKeyToAccount('0x...')
 
 const mpay = Mpay.create({
   polyfill: false, // [!code focus]
-  methods: [tempo.charge({ account })],
+  methods: [tempo({ account })],
 })
 ```
 
@@ -140,7 +140,7 @@ const account = privateKeyToAccount('0x...')
 
 const mpay = Mpay.create({
   fetch: customFetch, // [!code focus]
-  methods: [tempo.charge({ account })],
+  methods: [tempo({ account })],
 })
 ```
 
@@ -158,7 +158,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 const account = privateKeyToAccount('0x...')
 
 const mpay = Mpay.create({
-  methods: [tempo.charge({ account })],
+  methods: [tempo({ account })],
   transport: Transport.mcp(), // [!code focus]
 })
 ```

--- a/src/pages/sdk/typescript/client/Mpay.restore.mdx
+++ b/src/pages/sdk/typescript/client/Mpay.restore.mdx
@@ -11,7 +11,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 const account = privateKeyToAccount('0x...')
 
 Mpay.create({
-  methods: [tempo.charge({ account })],
+  methods: [tempo({ account })],
 })
 
 // ... use payment-aware fetch ...

--- a/src/pages/sdk/typescript/client/Transport.http.mdx
+++ b/src/pages/sdk/typescript/client/Transport.http.mdx
@@ -11,7 +11,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 const account = privateKeyToAccount('0x...')
 
 const mpay = Mpay.create({
-  methods: [tempo.charge({ account })],
+  methods: [tempo({ account })],
   transport: Transport.http(), // [!code focus]
 })
 ```

--- a/src/pages/sdk/typescript/client/Transport.mcp.mdx
+++ b/src/pages/sdk/typescript/client/Transport.mcp.mdx
@@ -11,7 +11,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 const account = privateKeyToAccount('0x...')
 
 const mpay = Mpay.create({
-  methods: [tempo.charge({ account })],
+  methods: [tempo({ account })],
   transport: Transport.mcp(), // [!code focus]
 })
 ```

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -83,7 +83,7 @@ import { Mpay, tempo } from 'mpay/client' // [!code hl]
 const account = privateKeyToAccount('0xabc…123')
 
 Mpay.create({ // [!code hl]
-  methods: [tempo.charge({ account })], // [!code hl]
+  methods: [tempo({ account })], // [!code hl]
 }) // [!code hl]
 ```
 
@@ -93,7 +93,7 @@ If you want to avoid polyfilling, use the returned `fetch` instead.
 ```ts 
 const mpay = Mpay.create({
   polyfill: false, // [!code hl]
-  methods: [tempo.charge({ account })]
+  methods: [tempo({ account })]
 })
 
 const response = await mpay.fetch('https://mpp.dev/api/ping/paid') // [!code hl]


### PR DESCRIPTION
Updates all client-side documentation to use the composed `tempo()` function instead of individual `tempo.charge()`/`tempo.stream()` calls.

The composed form returns both charge and stream intents as a tuple, so `methods: [tempo({ account })]` replaces `methods: [tempo.charge({ account })]` or `methods: [tempo.charge({ account }), tempo.stream({ account })]`.

Individual method reference pages (`Method.tempo.charge`, `Method.tempo.stream`) retain their specific usage examples. Server-side examples are unchanged.