### PR TITLE
fix: resolve dead links on protocol overview page

### DIFF
--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -240,11 +240,11 @@ Implementations may define additional parameters in challenges:
 These docs provide a practical overview. For normative, IETF-style specifications:
 
 :::note[IETF-track specifications]
-- [Payment HTTP Authentication Scheme](/specs/draft-httpauth-payment-00)—Core protocol spec (draft-httpauth-payment-00)
-- [Payment Methods](/specs/methods)—Payment method definitions
-- [Payment Intents](/specs/intents)—Intent types (charge, authorize, subscription)
-- [MCP Transport](/specs/transports/mcp)—Model Context Protocol binding
-- [HTTP Transport](/specs/transports/http)—HTTP binding details
+- <a href="/specs/draft-httpauth-payment-00.html" data-v="true">Payment HTTP Authentication Scheme</a>—Core protocol spec (draft-httpauth-payment-00)
+- [Payment Methods](/specs#payment-methods)—Payment method definitions
+- [Payment Intents](/specs#intents)—Intent types (charge, authorize, subscription)
+- <a href="/specs/draft-payment-transport-mcp-00.html" data-v="true">MCP Transport</a>—Model Context Protocol binding
+- [HTTP Transport](/specs#transports)—HTTP binding details
 :::
 
 The full specification includes detailed ABNF grammar, security analysis, IANA considerations, and complete examples for various payment scenarios.


### PR DESCRIPTION
Fixes 5 dead links detected by vocs on the protocol overview page (`/protocol/index.mdx`):

| Dead link | Fix |
|---|---|
| `/specs/draft-httpauth-payment-00` | `/specs/draft-httpauth-payment-00.html` |
| `/specs/methods` | `/specs#payment-methods` |
| `/specs/intents` | `/specs#intents` |
| `/specs/transports/mcp` | `/specs/draft-payment-transport-mcp-00.html` |
| `/specs/transports/http` | `/specs#transports` |