### PR TITLE
feat: add light/dark mode support

### DIFF
--- a/src/components/AgentTabs.tsx
+++ b/src/components/AgentTabs.tsx
@@ -125,8 +125,19 @@ export function AgentTabs() {
 	const cmd = AGENT_COMMANDS[active];
 
 	return (
-		<div className="max-w-xl border border-gray-200 rounded-md overflow-hidden">
-			<div className="flex bg-gray-50 border-b border-gray-200">
+		<div
+			className="max-w-xl rounded-md overflow-hidden"
+			style={{
+				border: `1px solid light-dark(#e5e7eb, #374151)`,
+			}}
+		>
+			<div
+				className="flex"
+				style={{
+					background: "light-dark(#f9fafb, #1f2937)",
+					borderBottom: `1px solid light-dark(#e5e7eb, #374151)`,
+				}}
+			>
 				{AGENT_COMMANDS.map((a, i) => {
 					const Icon = a.icon;
 					return (
@@ -134,11 +145,21 @@ export function AgentTabs() {
 							key={a.label}
 							type="button"
 							onClick={() => setActive(i)}
-							className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors ${
+							className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
+							style={
 								i === active
-									? "text-gray-900 bg-white border-b-2 border-gray-900 -mb-px"
-									: "text-gray-400 hover:text-gray-600"
-							}`}
+									? {
+											color: "light-dark(#111827, #f3f4f6)",
+											background: "light-dark(#ffffff, #111827)",
+											borderBottom: `2px solid light-dark(#111827, #f3f4f6)`,
+											marginBottom: "-1px",
+										}
+									: {
+											color: "#9ca3af",
+											background: "transparent",
+											border: "none",
+										}
+							}
 						>
 							<Icon className="w-3.5 h-3.5" />
 							{a.label}
@@ -146,13 +167,26 @@ export function AgentTabs() {
 					);
 				})}
 			</div>
-			<div className="flex items-center gap-3 bg-white px-4 py-3">
+			<div
+				className="flex items-center gap-3 px-4 py-3"
+				style={{ background: "light-dark(#ffffff, #111827)" }}
+			>
 				<pre className="text-sm select-none flex-1 truncate m-0 p-0 bg-transparent font-mono">
 					<code>
 						<span className="text-gray-400">$ </span>
-						<span className="text-gray-800">{cmd.bin}</span>
-						{cmd.args && <span className="text-gray-500"> {cmd.args}</span>}
-						<span className="text-green-700"> {cmd.str}</span>
+						<span style={{ color: "light-dark(#1f2937, #e5e7eb)" }}>
+							{cmd.bin}
+						</span>
+						{cmd.args && (
+							<span style={{ color: "light-dark(#6b7280, #9ca3af)" }}>
+								{" "}
+								{cmd.args}
+							</span>
+						)}
+						<span style={{ color: "light-dark(#15803d, #4ade80)" }}>
+							{" "}
+							{cmd.str}
+						</span>
 					</code>
 				</pre>
 				<CopyButton

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -14,7 +14,6 @@ export function LandingPage() {
 		<div
 			className="not-prose"
 			style={{
-				color: "#111",
 				fontFamily:
 					'"Berkeley Mono", "Commit Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
 			}}
@@ -28,13 +27,19 @@ export function LandingPage() {
 							<AsciiLogo morph={false} color="#9ca3af" />
 						</div>
 						{/* Title */}
-						<h1 className="text-2xl md:text-3xl lg:text-4xl font-bold text-black leading-[1.1] tracking-tight">
+						<h1
+							className="text-2xl md:text-3xl lg:text-4xl font-bold leading-[1.1] tracking-tight"
+							style={{ color: "light-dark(#000000, #ffffff)" }}
+						>
 							The Machine Payments Protocol
 						</h1>
 
 						{/* Description */}
 						<div className="space-y-1.5 max-w-xl">
-							<p className="text-sm md:text-base text-gray-600 leading-relaxed">
+							<p
+								className="text-sm md:text-base leading-relaxed"
+								style={{ color: "light-dark(#4b5563, #d1d5db)" }}
+							>
 								Accept payments from humans, software, or AI agents using
 								standard HTTP. No billing accounts or manual signup required.
 							</p>
@@ -91,7 +96,11 @@ export function LandingPage() {
 							</a>
 							<a
 								href="/specs"
-								className="inline-flex items-center gap-2 px-5 py-2.5 border border-gray-200 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-50 transition-colors no-underline"
+								className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium rounded-md transition-colors no-underline"
+								style={{
+									border: "1px solid light-dark(#e5e7eb, #4b5563)",
+									color: "light-dark(#374151, #e5e7eb)",
+								}}
 							>
 								Read the specs
 							</a>
@@ -116,7 +125,7 @@ export function LandingPage() {
 			</section>
 
 			{/* Footer */}
-			<div className="border-t border-gray-100" />
+			<div style={{ borderTop: "1px solid light-dark(#f3f4f6, #1f2937)" }} />
 			<footer className="px-6 py-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-gray-400">
 				<div className="flex items-center gap-4">
 					<a

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -153,49 +153,49 @@ pre[data-v] {
 	padding-block: calc(var(--vocs-spacing) * 3) !important;
 }
 
-/* Force mermaid diagrams to black and white */
+/* Mermaid diagram theme-aware colors */
 [data-v-mermaid] .note {
-	fill: #ffffff !important;
-	stroke: #000000 !important;
+	fill: light-dark(#ffffff, #1f2937) !important;
+	stroke: light-dark(#000000, #9ca3af) !important;
 }
 
 [data-v-mermaid] .noteText {
-	fill: #000000 !important;
+	fill: light-dark(#000000, #e5e7eb) !important;
 }
 
 [data-v-mermaid] .messageText {
-	fill: #000000 !important;
+	fill: light-dark(#000000, #e5e7eb) !important;
 }
 
 [data-v-mermaid] .messageLine0,
 [data-v-mermaid] .messageLine1 {
-	stroke: #000000 !important;
+	stroke: light-dark(#000000, #9ca3af) !important;
 }
 
 [data-v-mermaid] text.actor {
-	fill: #000000 !important;
+	fill: light-dark(#000000, #e5e7eb) !important;
 }
 
 [data-v-mermaid] rect.actor {
-	fill: #ffffff !important;
-	stroke: #000000 !important;
+	fill: light-dark(#ffffff, #1f2937) !important;
+	stroke: light-dark(#000000, #9ca3af) !important;
 }
 
 [data-v-mermaid] .actor-line {
-	stroke: #000000 !important;
+	stroke: light-dark(#000000, #4b5563) !important;
 }
 
 [data-v-mermaid] #arrowhead path {
-	fill: #000000 !important;
-	stroke: #000000 !important;
+	fill: light-dark(#000000, #9ca3af) !important;
+	stroke: light-dark(#000000, #9ca3af) !important;
 }
 
 [data-v-mermaid] .loopLine {
-	stroke: #000000 !important;
+	stroke: light-dark(#000000, #4b5563) !important;
 }
 
 [data-v-mermaid] .loopText {
-	fill: #000000 !important;
+	fill: light-dark(#000000, #e5e7eb) !important;
 }
 
 [data-v-footer] a,

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -11,7 +11,7 @@ const baseUrl = (() => {
 
 export default defineConfig({
 	accentColor: "#0166FF",
-	colorScheme: "light",
+	colorScheme: "light dark",
 	baseUrl,
 	redirects: [
 		{ source: "/docs", destination: "/overview" },


### PR DESCRIPTION
Enables Vocs theme toggle (light/dark) across the site.

### Changes
- **vocs.config.ts**: `colorScheme: 'light'` → `'light dark'` to enable the built-in theme toggle
- **AgentTabs.tsx**: Use CSS `light-dark()` for borders, backgrounds, and text colors
- **LandingPage.tsx**: Use CSS `light-dark()` for title, description, buttons, and footer
- **_root.css**: Mermaid diagram styles now use `light-dark()` for actor boxes, notes, lines, arrows, and text

### Approach
Tailwind `dark:` variant doesn't work with Vocs's `color-scheme` based dark mode, so all theme-aware colors use the CSS `light-dark()` function in inline styles — consistent with how the site already handles theme colors elsewhere.