### PR TITLE
chore: update mpay to ^0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"class-variance-authority": "^0.7.1",
 		"dayjs": "^1.11.19",
 		"mermaid": "^11.12.2",
-		"mpay": "https://pkg.pr.new/wevm/mpay@2eae67a",
+		"mpay": "^0.2.4",
 		"react": "^19",
 		"react-dom": "^19",
 		"tailwindcss": "^4.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^11.12.2
         version: 11.12.2
       mpay:
-        specifier: https://pkg.pr.new/wevm/mpay@2eae67a
-        version: https://pkg.pr.new/wevm/mpay@2eae67a(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@4.3.6))(express@5.2.1)(hono@4.11.7)(typescript@5.9.3)(viem@2.45.0(typescript@5.9.3)(zod@4.3.6))
+        specifier: ^0.2.4
+        version: 0.2.4(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@4.3.6))(express@5.2.1)(hono@4.11.7)(typescript@5.9.3)(viem@2.45.0(typescript@5.9.3)(zod@4.3.6))
       react:
         specifier: ^19
         version: 19.2.4
@@ -3022,9 +3022,8 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
-  mpay@https://pkg.pr.new/wevm/mpay@2eae67a:
-    resolution: {integrity: sha512-xRhrmwZCgav1nTAbkj1StfXIvFwtu5tB/NJie647a4xnmMXu0+EXe7pvB8tZGArRanAlOn3J3z8T3vSrLtX1eQ==, tarball: https://pkg.pr.new/wevm/mpay@2eae67a}
-    version: 0.1.0
+  mpay@0.2.4:
+    resolution: {integrity: sha512-LTAa0qzPcSR6tnAWsPqfoqFHuKc8Ar3h3Gy6xW2h14IWdF+FZjAzHEm6MBP4t/1XYkfMZmEIgVUWYe+xrqDgxw==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
@@ -7191,7 +7190,7 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mpay@https://pkg.pr.new/wevm/mpay@2eae67a(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@4.3.6))(express@5.2.1)(hono@4.11.7)(typescript@5.9.3)(viem@2.45.0(typescript@5.9.3)(zod@4.3.6)):
+  mpay@0.2.4(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@4.3.6))(express@5.2.1)(hono@4.11.7)(typescript@5.9.3)(viem@2.45.0(typescript@5.9.3)(zod@4.3.6)):
     dependencies:
       '@remix-run/fetch-proxy': 0.7.1
       '@remix-run/node-fetch-server': 0.13.0


### PR DESCRIPTION
Updates mpay from a `pkg.pr.new` commit build (`@2eae67a`) to the latest npm release (`^0.2.4`).

- Types check and build pass
- The memo/transfer matching logic in 0.2.4 correctly handles both `Transfer` and `TransferWithMemo` when the challenge has no memo