### PR TITLE
fix: update smoke test to use /quickstart/presto

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,7 @@ jobs:
             rm -f "$BODY"
           }
 
-          check_route 'http://localhost:8788/quickstart/tempoctl' '/quickstart/tempoctl (html)' 'text/html'
+          check_route 'http://localhost:8788/quickstart/presto' '/quickstart/presto (html)' 'text/html'
           check_route 'http://localhost:8788/'                     '/ (html)'                    'text/html'
           check_route 'http://localhost:8788/'                     '/ (markdown/llms.txt)'        'text/markdown'
 


### PR DESCRIPTION
The smoke test was hitting `/quickstart/tempoctl` which redirects (307) to `/quickstart/presto`. Updated to hit the canonical URL directly.