### PR TITLE
fix: categorize core specs under Core instead of Other

### DIFF
--- a/scripts/gen-specs-page.ts
+++ b/scripts/gen-specs-page.ts
@@ -63,7 +63,7 @@ function parseXml(file: string): Spec {
 const specs = xmlFiles.map(parseXml);
 
 const categories: [string, (b: string) => boolean, string | null][] = [
-	["Core", (b) => b.startsWith("draft-httpauth-"), null],
+	["Core", (b) => b.startsWith("draft-httpauth-") || b.startsWith("draft-ryan-httpauth-"), null],
 	["Intents", (b) => b.startsWith("draft-payment-intent"), null],
 	["Tempo", (b) => b.startsWith("draft-tempo-"), "Payment Methods"],
 	["Stripe", (b) => b.startsWith("draft-stripe-"), "Payment Methods"],


### PR DESCRIPTION
The core spec (`draft-ryan-httpauth-payment`) was falling into the **Other** section on the /specs page because the category matcher only checked for the `draft-httpauth-` prefix. The actual filename uses `draft-ryan-httpauth-`, so it was uncategorized.

Adds the `draft-ryan-httpauth-` prefix to the Core category matcher.