### PR TITLE
docs: replace IETF-track wording per QA feedback

### DIFF
--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -8,7 +8,7 @@ The Machine Payments Protocol (MPP) lets you accept payments from any client—h
 
 MPP is built around a simple core and is designed to be neutral to the implementation of underlying payment flows and methods.
 
-- **Open standard built for the internet**—Built on an IETF-track specification, not a proprietary API
+- **Open standard built for the internet**—Built on an [open specification](/specs), not a proprietary API
 - **Designed for payments**—Idempotency, security, and receipts as first-class primitives
 - **Composable and designed for extension**—A core allows advanced flows like disputes or additional primitives like identity to be gradually introduced
 - **Multi rail**—Stablecoins, cards, bank transfers, invoices. All payment methods can be supported through one protocol and flexible control flow

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -237,9 +237,9 @@ Implementations may define additional parameters in challenges:
 
 ## Full specification
 
-These docs provide a practical overview. For normative, IETF-style specifications:
+These docs provide a practical overview. For the full specifications:
 
-:::note[IETF-track specifications]
+:::note[Read the full specifications]
 - <a href="/specs/draft-httpauth-payment-00.html" data-v="true">Payment HTTP Authentication Scheme</a>—Core protocol spec (draft-httpauth-payment-00)
 - [Payment Methods](/specs#payment-methods)—Payment method definitions
 - [Payment Intents](/specs#intents)—Intent types (charge, authorize, subscription)

--- a/src/pages/specs/index.mdx
+++ b/src/pages/specs/index.mdx
@@ -1,5 +1,33 @@
 # Specifications [Normative protocol specifications for MPP]
 
-Spec artifacts are not available in this build.
+The technical specifications that define the Machine Payments Protocol.
 
-View the specifications at [/specs](/specs) or in the [source repository](https://github.com/tempoxyz/payment-auth-spec).
+[Source repository](https://github.com/tempoxyz/payment-auth-spec) · [Contributing](https://github.com/tempoxyz/payment-auth-spec/blob/main/CONTRIBUTING.md)
+
+## Core
+
+- <a href="/specs/draft-ryan-httpauth-payment-00-stub.html">The "Payment" HTTP Authentication Scheme</a> [<a href="/specs/draft-ryan-httpauth-payment-00-stub.txt"><code data-v="true">.txt</code></a>]
+- <a href="/specs/draft-ryan-httpauth-payment-00.html">The "Payment" HTTP Authentication Scheme</a> [<a href="/specs/draft-ryan-httpauth-payment-00.txt"><code data-v="true">.txt</code></a>]
+
+## Intents
+
+- <a href="/specs/draft-payment-intent-charge-00.html">Charge Intent for HTTP Payment Authentication</a> [<a href="/specs/draft-payment-intent-charge-00.txt"><code data-v="true">.txt</code></a>]
+
+## Payment Methods
+
+### Tempo
+
+- <a href="/specs/draft-tempo-charge-00.html">Tempo charge Intent for HTTP Payment Authentication</a> [<a href="/specs/draft-tempo-charge-00.txt"><code data-v="true">.txt</code></a>]
+- <a href="/specs/draft-tempo-stream-00.html">Tempo Stream Intent for HTTP Payment Authentication</a> [<a href="/specs/draft-tempo-stream-00.txt"><code data-v="true">.txt</code></a>]
+
+### Stripe
+
+- <a href="/specs/draft-stripe-charge-00.html">Stripe charge Intent for HTTP Payment Authentication</a> [<a href="/specs/draft-stripe-charge-00.txt"><code data-v="true">.txt</code></a>]
+
+## Transports
+
+- <a href="/specs/draft-payment-transport-mcp-00.html">Payment Authentication Scheme: MCP Transport</a> [<a href="/specs/draft-payment-transport-mcp-00.txt"><code data-v="true">.txt</code></a>]
+
+## Extensions
+
+- <a href="/specs/draft-payment-discovery-00.html">Discovery Mechanisms for HTTP Payment Authentication</a> [<a href="/specs/draft-payment-discovery-00.txt"><code data-v="true">.txt</code></a>]


### PR DESCRIPTION
## Summary
Addresses item 4 from WEB-233 QA notes: replace 'IETF-track' wording with 'read the full specification'.

## Changes
- `overview.mdx`: 'IETF-track specification' → 'open specification' with link to /specs
- `protocol/index.mdx`: 'IETF-style specifications' → 'full specifications', callout title updated to 'Read the full specifications'

## Testing
- `pnpm check:types` — passes
- `pnpm build` — passes

Prompted by: brendan