### PR TITLE
chore: rename Specifications to IETF Specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,7 +247,7 @@ Use `<Badge variant="...">` in tables to indicate status or maturity. Import fro
 8. **Bash terminal blocks** - Use ` ```bash [test.sh] ` with `$` prefixes for shell commands
 9. **TypeScript twoslash** - Always use ` ```ts twoslash ` for TypeScript code blocks, never bare ` ```ts `
 10. **Spec link Cards** - When linking to specs, use title `"Protocol spec"` and description `"See the normative definition"`
-11. **Plural "specifications"** - Use "specifications" (plural) when referring to multiple specs collectively
+11. **"IETF Specs"** - Use "IETF Specs" when referring to the specifications collectively, not "Specifications"
 
 ## Vocs Framework Reference
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -79,7 +79,7 @@ export default defineConfig({
         items: [
           { text: "Overview", link: "/overview" },
           {
-            text: "Specifications",
+            text: "IETF Specs",
             link: "https://tempoxyz.github.io/mpp-specs/",
           },
           { text: "FAQ", link: "/faq" },
@@ -455,7 +455,7 @@ export default defineConfig({
         { text: "mpay-rs [Rust]", link: "https://github.com/tempoxyz/mpay-rs" },
         { text: "pympay [Python]", link: "https://github.com/tempoxyz/pympay" },
         {
-          text: "Specifications",
+          text: "IETF Specs",
           link: "https://github.com/tempoxyz/payment-auth-spec",
         },
       ],


### PR DESCRIPTION
Renames all mentions of "Specifications" to "IETF Specs" in the sidebar and top nav, and updates AGENTS.md terminology accordingly.