### PR TITLE
fix: update SDK references from mpay-rs/pympay to mpp-rs/pympp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,8 @@ When editing Python or Rust pages, keep the structure aligned with the existing 
 ## SDK References
 
 - Typescript: <https://github.com/wevm/mppx>
-- Python: <https://github.com/tempoxyz/pympay>
-- Rust: <<https://github.com/tempoxyz/mpay-rs>
+- Python: <https://github.com/tempoxyz/pympp>
+- Rust: <https://github.com/tempoxyz/mpp-rs>
 
 ## Be Opinionated
 

--- a/src/pages/_vocs.generated.css
+++ b/src/pages/_vocs.generated.css
@@ -2,6 +2,7 @@
 /* Source: node_modules/vocs/src/styles/theme.css */
 
 @theme {
+
   /* #region Primitive Colors */
 
   --color-white: white;
@@ -75,80 +76,43 @@
   --color-accenta8: oklch(from var(--vocs-color-accent) 0.44 c h / 84%);
   --color-accenta9: oklch(from var(--vocs-color-accent) 0.4 c h / 94%);
 
-  --color-accentInvert: oklch(
-    from var(--vocs-color-accent) clamp(0, (0.5 - l) * 100, 1) 0 0
-  );
+  --color-accentInvert: oklch(from var(--vocs-color-accent) clamp(0, (0.5 - l) * 100, 1) 0 0);
 
   /* #endregion */
 
   /* #region Standard Colors */
 
-  --background-color-primary: light-dark(
-    var(--vocs-color-gray14),
-    var(--vocs-color-gray2)
-  );
+  --background-color-primary: light-dark(var(--vocs-color-gray14), var(--vocs-color-gray2));
   --background-color-surface: light-dark(white, var(--vocs-color-gray4));
-  --background-color-surfaceMuted: light-dark(
-    var(--vocs-color-gray13),
-    var(--vocs-color-gray2)
-  );
-  --background-color-surfaceTint: light-dark(
-    var(--vocs-color-gray14),
-    var(--vocs-color-gray5)
-  );
+  --background-color-surfaceMuted: light-dark(var(--vocs-color-gray13), var(--vocs-color-gray2));
+  --background-color-surfaceTint: light-dark(var(--vocs-color-gray14), var(--vocs-color-gray5));
 
-  --text-color-primary: light-dark(
-    var(--vocs-color-gray6),
-    var(--vocs-color-gray12)
-  );
-  --text-color-secondary: light-dark(
-    var(--vocs-color-gray8),
-    var(--vocs-color-gray10)
-  );
-  --text-color-muted: light-dark(
-    var(--vocs-color-gray9),
-    var(--vocs-color-gray8)
-  );
+  --text-color-primary: light-dark(var(--vocs-color-gray6), var(--vocs-color-gray12));
+  --text-color-secondary: light-dark(var(--vocs-color-gray8), var(--vocs-color-gray10));
+  --text-color-muted: light-dark(var(--vocs-color-gray9), var(--vocs-color-gray8));
 
   /* #endregion */
 
   /* #region Contextual Colors */
 
   --color-destructive: var(--vocs-color-red);
-  --color-destructive-hover: oklch(
-    from var(--vocs-color-red) calc(l - 0.1) c h
-  );
+  --color-destructive-hover: oklch(from var(--vocs-color-red) calc(l - 0.1) c h);
   --color-destructive-tint: oklch(from var(--vocs-color-red) l c h / 8%);
-  --border-color-destructive-tint: oklch(
-    from var(--vocs-color-red) l c h /
-    16%
-  );
+  --border-color-destructive-tint: oklch(from var(--vocs-color-red) l c h / 16%);
 
   --color-info: var(--vocs-color-blue);
   --color-info-hover: oklch(from var(--vocs-color-blue) calc(l - 0.1) c h);
-  --background-color-info-tint: color-mix(
-    in srgb,
-    var(--vocs-color-blue) 8%,
-    var(--vocs-background-color-surface)
-  );
+  --background-color-info-tint: color-mix(in srgb, var(--vocs-color-blue) 8%, var(--vocs-background-color-surface));
   --border-color-info-tint: oklch(from var(--vocs-color-blue) l c h / 16%);
 
   --color-note: light-dark(var(--vocs-color-gray7), var(--vocs-color-gray10));
   --color-note-hover: oklch(from var(--vocs-color-gray8) calc(l - 0.1) c h);
-  --background-color-note-tint: color-mix(
-    in srgb,
-    var(--vocs-color-gray10) 8%,
-    var(--vocs-background-color-surface)
-  );
+  --background-color-note-tint: color-mix(in srgb, var(--vocs-color-gray10) 8%, var(--vocs-background-color-surface));
   --border-color-note-tint: oklch(from var(--vocs-color-gray10) l c h / 16%);
 
   --color-success: oklch(from var(--vocs-color-green) l c h);
   --color-success-hover: oklch(from var(--vocs-color-green) calc(l - 0.1) c h);
-  --background-color-success-tint: color-mix(
-    in srgb,
-    var(--vocs-color-green) 8%,
-    var(--vocs-background-color-surface)
-  );
+  --background-color-success-tint: color-mix(in srgb, var(--vocs-color-green) 8%, var(--vocs-background-color-surface));
   --border-color-success-tint: oklch(from var(--vocs-color-green) l c h / 16%);
 
   --color-tip: var(--vocs-color-iris);
@@ -169,47 +133,23 @@
   );
   --border-color-warning-tint: oklch(from var(--vocs-color-yellow) l c h / 16%);
 
-  --border-color-primary: light-dark(
-    var(--vocs-color-gray12),
-    var(--vocs-color-gray6)
-  );
-  --border-color-secondary: light-dark(
-    var(--vocs-color-gray12),
-    var(--vocs-color-gray5)
-  );
+  --border-color-primary: light-dark(var(--vocs-color-gray12), var(--vocs-color-gray6));
+  --border-color-secondary: light-dark(var(--vocs-color-gray12), var(--vocs-color-gray5));
 
   /* #endregion */
 
   /* #region Semantic Colors */
 
   --background-color-blockquote: var(--vocs-color-background2);
-  --background-color-code-block: light-dark(
-    var(--vocs-color-gray14),
-    var(--vocs-color-gray2)
-  );
-  --background-color-code-highlighted: light-dark(
-    var(--vocs-color-gray12),
-    var(--vocs-color-gray4)
-  );
-  --background-color-inline-code: light-dark(
-    var(--vocs-color-gray14),
-    var(--vocs-color-gray2)
-  );
-  --border-color-code-highlighted: light-dark(
-    var(--vocs-color-gray11),
-    var(--vocs-color-gray6)
-  );
+  --background-color-code-block: light-dark(var(--vocs-color-gray14), var(--vocs-color-gray2));
+  --background-color-code-highlighted: light-dark(var(--vocs-color-gray12), var(--vocs-color-gray4));
+  --background-color-inline-code: light-dark(var(--vocs-color-gray14), var(--vocs-color-gray2));
+  --border-color-code-highlighted: light-dark(var(--vocs-color-gray11), var(--vocs-color-gray6));
   --border-color-tab-active: var(--vocs-color-accent);
   --text-color-heading: light-dark(black, white);
   --text-color-link: light-dark(black, white);
-  --text-color-link-hover: light-dark(
-    var(--vocs-color-gray7),
-    var(--vocs-color-gray11)
-  );
-  --text-color-quote: light-dark(
-    var(--vocs-color-gray7),
-    var(--vocs-color-gray11)
-  );
+  --text-color-link-hover: light-dark(var(--vocs-color-gray7), var(--vocs-color-gray11));
+  --text-color-quote: light-dark(var(--vocs-color-gray7), var(--vocs-color-gray11));
 
   /* #endregion */
 
@@ -252,14 +192,8 @@
   --spacing-content-py: 2.5rem;
   --spacing-content: calc(70ch + (var(--vocs-spacing-content-px) * 2));
   --spacing-outline: 280px;
-  --spacing-logo: max(
-    calc((100vw - var(--vocs-spacing-content)) / 2),
-    var(--vocs-spacing-sidebar)
-  );
-  --spacing-gutter: max(
-    calc((100vw - var(--vocs-spacing-content)) / 2),
-    var(--vocs-spacing-sidebar)
-  );
+  --spacing-logo: max(calc((100vw - var(--vocs-spacing-content)) / 2), var(--vocs-spacing-sidebar));
+  --spacing-gutter: max(calc((100vw - var(--vocs-spacing-content)) / 2), var(--vocs-spacing-sidebar));
   --spacing-sidebar-px: 1.5rem;
   --spacing-sidebar-py: 0rem;
   --spacing-sidebar: 300px;

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -77,13 +77,13 @@ All SDKs implement similar interfaces and are interoperable with one another.
     to="/sdk/typescript"
   />
   <Card
-    description="Get started with `pympay`, the official MPP SDK for Python"
+    description="Get started with `pympp`, the official MPP SDK for Python"
     icon="simple-icons:python"
     title="Python"
     to="/sdk/python"
   />
   <Card
-    description="Get started with `mpay-rs`, the official MPP SDK for Rust"
+    description="Get started with `mpp-rs`, the official MPP SDK for Rust"
     icon="simple-icons:rust"
     title="Rust"
     to="/sdk/rust"

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -10,13 +10,13 @@ import { Card, Cards } from 'vocs'
     to="/sdk/typescript"
   />
   <Card
-    description="Get started with `pympay`, the official MPP SDK for Python"
+    description="Get started with `pympp`, the official MPP SDK for Python"
     icon="simple-icons:python"
     title="Python"
     to="/sdk/python"
   />
   <Card
-    description="Get started with `mpay-rs`, the official MPP SDK for Rust"
+    description="Get started with `mpp-rs`, the official MPP SDK for Rust"
     icon="simple-icons:rust"
     title="Rust"
     to="/sdk/rust"

--- a/src/pages/sdk/python/client.mdx
+++ b/src/pages/sdk/python/client.mdx
@@ -5,8 +5,8 @@ Handle `402` Payment Required responses automatically.
 ## Quick start
 
 ```python [client.py]
-from mpay.client import Client
-from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
+from mpp.client import Client
+from mpp.methods.tempo import tempo, TempoAccount, ChargeIntent
 
 account = TempoAccount.from_key("0x...")
 
@@ -28,8 +28,8 @@ async with Client(methods=[tempo(account=account, intents={"charge": ChargeInten
 ## One-off requests
 
 ```python [client.py]
-from mpay.client import get
-from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
+from mpp.client import get
+from mpp.methods.tempo import tempo, TempoAccount, ChargeIntent
 
 response = await get(
     "https://api.example.com/resource",
@@ -43,8 +43,8 @@ For payment session channels, use `StreamMethod` instead of `tempo()`. The clien
 
 ```python [stream.py]
 import httpx
-from mpay.client import PaymentTransport
-from mpay.methods.tempo import StreamMethod, TempoAccount
+from mpp.client import PaymentTransport
+from mpp.methods.tempo import StreamMethod, TempoAccount
 
 account = TempoAccount.from_key("0x...")
 
@@ -72,8 +72,8 @@ async with httpx.AsyncClient(transport=transport, timeout=60.0) as client:
 
 ```python [transport.py]
 import httpx
-from mpay.client import PaymentTransport
-from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
+from mpp.client import PaymentTransport
+from mpp.methods.tempo import tempo, TempoAccount, ChargeIntent
 
 account = TempoAccount.from_key("0x...")
 transport = PaymentTransport(

--- a/src/pages/sdk/python/core.mdx
+++ b/src/pages/sdk/python/core.mdx
@@ -3,7 +3,7 @@
 The SDK provides three core types that map directly to HTTP headers: `Challenge`, `Credential`, and `Receipt`.
 
 ```python
-from mpay import Challenge, Credential, Receipt
+from mpp import Challenge, Credential, Receipt
 ```
 
 ## Parse a Challenge

--- a/src/pages/sdk/python/index.mdx
+++ b/src/pages/sdk/python/index.mdx
@@ -1,26 +1,26 @@
 import * as SdkBadge from '../../../components/SdkBadge'
 
-# Python SDK [The pympay Python library]
+# Python SDK [The pympp Python library]
 
 ## Overview
 
-The `mpay` Python library provides a typed interface over the Machine Payments Protocol, from high-level abstractions to low-level primitives and building blocks.
+The `mpp` Python library provides a typed interface over the Machine Payments Protocol, from high-level abstractions to low-level primitives and building blocks.
 
 <div className="flex gap-2">
-  <SdkBadge.GitHub repo="tempoxyz/pympay" />
+  <SdkBadge.GitHub repo="tempoxyz/pympp" />
   <SdkBadge.Maintainer name="Tempo" href="https://github.com/tempoxyz" />
 </div>
 
 ## Install
 
 ```bash [install.sh]
-$ pip install pympay
+$ pip install pympp
 ```
 
 With Tempo blockchain support:
 
 ```bash [install-with-tempo.sh]
-$ pip install "pympay[tempo]"
+$ pip install "pympp[tempo]"
 ```
 
 ## Requirements
@@ -36,13 +36,13 @@ $ pip install "pympay[tempo]"
 ```python [server.py]
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from mpay import Challenge
-from mpay.server import Mpay
-from mpay.methods.tempo import tempo, ChargeIntent
+from mpp import Challenge
+from mpp.server import Mpp
+from mpp.methods.tempo import tempo, ChargeIntent
 
 app = FastAPI()
 
-mpay = Mpay.create(
+mpp = Mpp.create(
     method=tempo(
         currency="0x20c0000000000000000000000000000000000000",
         recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
@@ -52,7 +52,7 @@ mpay = Mpay.create(
 
 @app.get("/resource")
 async def get_resource(request: Request):
-    result = await mpay.charge(
+    result = await mpp.charge(
         authorization=request.headers.get("Authorization"),
         amount="0.50",
     )
@@ -61,7 +61,7 @@ async def get_resource(request: Request):
         return JSONResponse(
             status_code=402,
             content={"error": "Payment required"},
-            headers={"WWW-Authenticate": result.to_www_authenticate(mpay.realm)},
+            headers={"WWW-Authenticate": result.to_www_authenticate(mpp.realm)},
         )
 
     credential, receipt = result
@@ -72,8 +72,8 @@ async def get_resource(request: Request):
 
 ```python [client.py]
 import asyncio
-from mpay.client import Client
-from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
+from mpp.client import Client
+from mpp.methods.tempo import tempo, TempoAccount, ChargeIntent
 
 async def main():
     account = TempoAccount.from_env()

--- a/src/pages/sdk/python/server.mdx
+++ b/src/pages/sdk/python/server.mdx
@@ -4,18 +4,18 @@ Protect endpoints with payment requirements.
 
 ## Quick start
 
-Create an `Mpay` instance with `Mpay.create()` and call `charge()` with a human-readable amount. The `tempo()` factory creates a Tempo payment method—configure `currency` and `recipient` once, then every `charge()` call uses those defaults.
+Create an `Mpp` instance with `Mpp.create()` and call `charge()` with a human-readable amount. The `tempo()` factory creates a Tempo payment method—configure `currency` and `recipient` once, then every `charge()` call uses those defaults.
 
 ```python [server.py]
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from mpay import Challenge
-from mpay.server import Mpay
-from mpay.methods.tempo import tempo, ChargeIntent
+from mpp import Challenge
+from mpp.server import Mpp
+from mpp.methods.tempo import tempo, ChargeIntent
 
 app = FastAPI()
 
-mpay = Mpay.create(
+mpp = Mpp.create(
     method=tempo(
         currency="0x20c0000000000000000000000000000000000000",
         recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
@@ -25,7 +25,7 @@ mpay = Mpay.create(
 
 @app.get("/resource")
 async def get_resource(request: Request):
-    result = await mpay.charge(
+    result = await mpp.charge(
         authorization=request.headers.get("Authorization"),
         amount="0.50",
     )
@@ -34,17 +34,17 @@ async def get_resource(request: Request):
         return JSONResponse(
             status_code=402,
             content={"error": "Payment required"},
-            headers={"WWW-Authenticate": result.to_www_authenticate(mpay.realm)},
+            headers={"WWW-Authenticate": result.to_www_authenticate(mpp.realm)},
         )
 
     credential, receipt = result
     return {"data": "paid content", "payer": credential.source}
 ```
 
-`Mpay.create()` auto-detects `realm` from environment variables (`VERCEL_URL`, `FLY_APP_NAME`, `HOSTNAME`, and others) and auto-generates a `secret_key` persisted to `.env`. Pass explicit values to override:
+`Mpp.create()` auto-detects `realm` from environment variables (`VERCEL_URL`, `FLY_APP_NAME`, `HOSTNAME`, and others) and auto-generates a `secret_key` persisted to `.env`. Pass explicit values to override:
 
 ```python [server.py]
-mpay = Mpay.create(
+mpp = Mpp.create(
     method=tempo(
         currency="0x20c0000000000000000000000000000000000000",
         recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
@@ -60,7 +60,7 @@ mpay = Mpay.create(
 `tempo()` creates a `TempoMethod` that bundles a payment network, its intents, and default parameters together. Each intent must be explicitly registered via the `intents` parameter.
 
 ```python [server.py]
-from mpay.methods.tempo import tempo, ChargeIntent
+from mpp.methods.tempo import tempo, ChargeIntent
 
 method = tempo(
     currency="0x20c0000000000000000000000000000000000000",
@@ -74,10 +74,10 @@ method = tempo(
 Register both intents on a single method:
 
 ```python [server.py]
-from mpay.methods.tempo import tempo, ChargeIntent, StreamIntent
-from mpay.methods.tempo.stream.storage import MemoryStorage
+from mpp.methods.tempo import tempo, ChargeIntent, StreamIntent
+from mpp.methods.tempo.stream.storage import MemoryStorage
 
-mpay = Mpay.create(
+mpp = Mpp.create(
     method=tempo(
         currency="0x20c0000000000000000000000000000000000000",
         recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
@@ -126,7 +126,7 @@ Default recipient address for charges.
 
 Tempo RPC endpoint URL.
 
-## `Mpay.create()` parameters
+## `Mpp.create()` parameters
 
 ### method
 
@@ -242,14 +242,14 @@ import json
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from mpay import Challenge
-from mpay.methods.tempo import StreamIntent, tempo
-from mpay.methods.tempo.stream.storage import MemoryStorage
-from mpay.server import Mpay
+from mpp import Challenge
+from mpp.methods.tempo import StreamIntent, tempo
+from mpp.methods.tempo.stream.storage import MemoryStorage
+from mpp.server import Mpp
 
 app = FastAPI()
 
-mpay = Mpay.create(
+mpp = Mpp.create(
     method=tempo(
         currency="0x20c0000000000000000000000000000000000000",
         recipient="0xa726a1CD723409074DF9108A2187cfA19899aCF8",
@@ -264,7 +264,7 @@ mpay = Mpay.create(
 
 @app.get("/api/chat")
 async def chat(request: Request, prompt: str = "Hello!"):
-    result = await mpay.stream(
+    result = await mpp.stream(
         authorization=request.headers.get("Authorization"),
         amount="0.000075",
         unit_type="token",
@@ -274,7 +274,7 @@ async def chat(request: Request, prompt: str = "Hello!"):
         return JSONResponse(
             status_code=402,
             content={"error": "Payment required"},
-            headers={"WWW-Authenticate": result.to_www_authenticate(mpay.realm)},
+            headers={"WWW-Authenticate": result.to_www_authenticate(mpp.realm)},
         )
 
     credential, receipt = result
@@ -298,9 +298,9 @@ For the lower-level decorator API, use `@requires_payment` with an explicit inte
 
 ```python [server.py]
 from fastapi import FastAPI, Request
-from mpay import Credential, Receipt
-from mpay.server import requires_payment
-from mpay.methods.tempo import ChargeIntent
+from mpp import Credential, Receipt
+from mpp.server import requires_payment
+from mpp.methods.tempo import ChargeIntent
 
 app = FastAPI()
 intent = ChargeIntent(rpc_url="https://rpc.tempo.xyz")

--- a/src/pages/sdk/rust/client.mdx
+++ b/src/pages/sdk/rust/client.mdx
@@ -7,7 +7,7 @@ Handle `402` Payment Required responses automatically.
 Add `.send_with_payment()` to any `reqwest::RequestBuilder`.
 
 ```rust
-use mpay::client::{PaymentExt, TempoProvider};
+use mpp::client::{PaymentExt, TempoProvider};
 use alloy::signers::local::PrivateKeySigner;
 
 let signer = PrivateKeySigner::random();
@@ -32,7 +32,7 @@ let response = reqwest::Client::new()
 All requests automatically handle 402. Requires the `middleware` feature.
 
 ```rust
-use mpay::client::{PaymentMiddleware, TempoProvider};
+use mpp::client::{PaymentMiddleware, TempoProvider};
 use reqwest_middleware::ClientBuilder;
 
 let provider = TempoProvider::new(signer, "https://rpc.tempo.xyz")?;

--- a/src/pages/sdk/rust/index.mdx
+++ b/src/pages/sdk/rust/index.mdx
@@ -1,26 +1,26 @@
 import * as SdkBadge from '../../../components/SdkBadge'
 
-# Rust SDK [The mpay Rust library]
+# Rust SDK [The mpp Rust library]
 
 ## Overview
 
-The `mpay` Rust library provides a typed interface over the Machine Payments Protocol, from high-level abstractions to low-level primitives and building blocks.
+The `mpp` Rust library provides a typed interface over the Machine Payments Protocol, from high-level abstractions to low-level primitives and building blocks.
 
 <div className="flex gap-2">
-  <SdkBadge.GitHub repo="tempoxyz/mpay-rs" />
+  <SdkBadge.GitHub repo="tempoxyz/mpp-rs" />
   <SdkBadge.Maintainer name="Tempo" href="https://github.com/tempoxyz" />
 </div>
 
 ## Install
 
 ```bash [install.sh]
-$ cargo add mpay
+$ cargo add mpp
 ```
 
 With Tempo blockchain support:
 
 ```bash [install-with-tempo.sh]
-$ cargo add mpay --features tempo,client,server
+$ cargo add mpp --features tempo,client,server
 ```
 
 ## Quick start
@@ -28,7 +28,7 @@ $ cargo add mpay --features tempo,client,server
 ### Parse a Challenge
 
 ```rust
-use mpay::parse_www_authenticate;
+use mpp::parse_www_authenticate;
 
 let header = r#"Payment id="abc", realm="mpp.dev", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwIn0""#;
 let challenge = parse_www_authenticate(header)?;
@@ -40,7 +40,7 @@ println!("Intent: {}", challenge.intent);
 ### Create a Credential
 
 ```rust
-use mpay::{PaymentCredential, PaymentPayload, ChallengeEcho};
+use mpp::{PaymentCredential, PaymentPayload, ChallengeEcho};
 
 let credential = PaymentCredential::with_source(
     ChallengeEcho::new("challenge-id", "tempo", "charge"),
@@ -48,13 +48,13 @@ let credential = PaymentCredential::with_source(
     PaymentPayload::transaction("0xf86c..."),
 );
 
-let header = mpay::format_authorization(&credential)?;
+let header = mpp::format_authorization(&credential)?;
 ```
 
 ### Parse a Receipt
 
 ```rust
-use mpay::parse_receipt;
+use mpp::parse_receipt;
 
 let receipt = parse_receipt(receipt_header)?;
 println!("Status: {:?}", receipt.status);
@@ -74,16 +74,16 @@ println!("Reference: {}", receipt.reference);
 
 ```toml
 # Client only
-mpay = { version = "0.1", features = ["tempo", "client"] }
+mpp = { version = "0.1", features = ["tempo", "client"] }
 
 # Server only
-mpay = { version = "0.1", features = ["tempo", "server"] }
+mpp = { version = "0.1", features = ["tempo", "server"] }
 
 # Both
-mpay = { version = "0.1", features = ["tempo", "client", "server"] }
+mpp = { version = "0.1", features = ["tempo", "client", "server"] }
 
 # With middleware
-mpay = { version = "0.1", features = ["tempo", "client", "middleware"] }
+mpp = { version = "0.1", features = ["tempo", "client", "middleware"] }
 ```
 
 ## Next steps

--- a/src/pages/sdk/rust/server.mdx
+++ b/src/pages/sdk/rust/server.mdx
@@ -7,18 +7,18 @@ Protect endpoints with payment requirements.
 Bind method, realm, and secret_key for stateless verification.
 
 ```rust
-use mpay::server::{Mpay, tempo_provider, TempoChargeMethod};
+use mpp::server::{Mpp, tempo_provider, TempoChargeMethod};
 
 let provider = tempo_provider("https://rpc.tempo.xyz")?;
 let method = TempoChargeMethod::new(provider);
-let payment = Mpay::new(method, "mpp.dev", "my-secret");
+let payment = Mpp::new(method, "mpp.dev", "my-secret");
 ```
 
 ## Key types
 
 | Type | Description |
 |------|-------------|
-| `Mpay` | Server helper for challenges and verification |
+| `Mpp` | Server helper for challenges and verification |
 | `TempoChargeMethod` | Built-in Tempo verification logic |
 | `ChargeMethod` | Trait for custom verification |
 
@@ -39,4 +39,4 @@ let receipt = payment.verify(&credential, &request).await?;
 println!("Payment verified: {}", receipt.reference);
 ```
 
-For custom verification, implement `ChargeMethod` and pass it to `Mpay::new`.
+For custom verification, implement `ChargeMethod` and pass it to `Mpp::new`.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -58,9 +58,9 @@ export default defineConfig({
     enabled: true,
     sources: [
       McpSource.github({ name: "mppx", repo: "wevm/mppx" }),
-      McpSource.github({ name: "mpay-rs", repo: "tempoxyz/mpay-rs" }),
-      McpSource.github({ name: "mpay-sdks", repo: "tempoxyz/mpay-sdks" }),
-      McpSource.github({ name: "pympay", repo: "tempoxyz/pympay" }),
+      McpSource.github({ name: "mpp-rs", repo: "tempoxyz/mpp-rs" }),
+      McpSource.github({ name: "mpp-tools", repo: "tempoxyz/mpp-tools" }),
+      McpSource.github({ name: "pympp", repo: "tempoxyz/pympp" }),
       McpSource.github({
         name: "payment-auth-spec",
         repo: "tempoxyz/payment-auth-spec",
@@ -471,8 +471,8 @@ export default defineConfig({
       text: "GitHub",
       items: [
         { text: "mppx [TypeScript]", link: "https://github.com/wevm/mppx" },
-        { text: "mpay-rs [Rust]", link: "https://github.com/tempoxyz/mpay-rs" },
-        { text: "pympay [Python]", link: "https://github.com/tempoxyz/pympay" },
+        { text: "mpp-rs [Rust]", link: "https://github.com/tempoxyz/mpp-rs" },
+        { text: "pympp [Python]", link: "https://github.com/tempoxyz/pympp" },
         {
           text: "IETF Specs",
           link: "https://github.com/tempoxyz/payment-auth-spec",


### PR DESCRIPTION
## Summary
Updates all references to the renamed SDK repos and packages.

## Changes
- `mpay-rs` → `mpp-rs` (Rust crate: `mpay` → `mpp`)
- `pympay` → `pympp` (pip package: `pympay` → `pympp`, import: `mpay` → `mpp`)
- `mpay-sdks` → `mpp-tools` (MCP source)
- `Mpay` class → `Mpp` in all Python/Rust code examples
- Updated AGENTS.md SDK references
- Updated vocs.config.ts nav links and MCP sources

## Testing
- `pnpm check:types` — passes
- `pnpm build` — passes

Prompted by: brendan