### PR TITLE
chore: bump mppx to 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "class-variance-authority": "^0.7.1",
     "dayjs": "^1.11.19",
     "mermaid": "^11.12.2",
-    "mppx": "~0.2.2",
+    "mppx": "~0.2.4",
     "react": "^19",
     "react-dom": "^19",
     "tailwindcss": "^4.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^11.12.2
         version: 11.12.2
       mppx:
-        specifier: ~0.2.2
-        version: 0.2.2(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(express@5.2.1)(hono@4.11.9)(typescript@5.9.3)(viem@2.46.2(typescript@5.9.3)(zod@4.3.6))
+        specifier: ~0.2.4
+        version: 0.2.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(express@5.2.1)(hono@4.11.9)(typescript@5.9.3)(viem@2.46.2(typescript@5.9.3)(zod@4.3.6))
       react:
         specifier: ^19
         version: 19.2.4
@@ -2589,15 +2589,15 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
-  mppx@0.2.2:
-    resolution: {integrity: sha512-wGdRhnrnRbl7Oyd2jYbqaVEtg7M23MZSO4/w4GhvMr3N+TFImE5gBpYZzy2VAbYugYCenjjetK5HR4bMjadsig==}
+  mppx@0.2.4:
+    resolution: {integrity: sha512-dz8N1qqFJpwEKkB+/RsWalNl+pVQzJ1RyI4gMZuQhBui1wqvk5FBJcuhI9EC6K00CLarq453gYM8nDIJZ80EzQ==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
       hono: '>=4'
-      viem: '>=2.44.4'
+      viem: '>=2.46.2'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -2775,14 +2775,6 @@ packages:
 
   ox@0.11.3:
     resolution: {integrity: sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  ox@0.12.2:
-    resolution: {integrity: sha512-v67fcvGLx4iYYT08fzEpZcHrcC6/6pUPQpVNLGvzDOhaUUOyGJcU08Oq+84pZ6IdGwoy8TU9LRRknZuF61FXwg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -6514,12 +6506,12 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.2.2(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(express@5.2.1)(hono@4.11.9)(typescript@5.9.3)(viem@2.46.2(typescript@5.9.3)(zod@4.3.6)):
+  mppx@0.2.4(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(express@5.2.1)(hono@4.11.9)(typescript@5.9.3)(viem@2.46.2(typescript@5.9.3)(zod@4.3.6)):
     dependencies:
       '@remix-run/fetch-proxy': 0.7.1
       '@remix-run/node-fetch-server': 0.13.0
       cac: 6.7.14
-      ox: 0.12.2(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.12.4(typescript@5.9.3)(zod@4.3.6)
       viem: 2.46.2(typescript@5.9.3)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -6584,21 +6576,6 @@ snapshots:
   outvariant@1.4.0: {}
 
   ox@0.11.3(typescript@5.9.3)(zod@4.3.6):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.12.2(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0


### PR DESCRIPTION
## Summary
- bump mppx dependency to 0.2.4
- refresh lockfile and generated snippets/css

## Testing
- pnpm check:types
- pnpm build