### PR TITLE
docs: rename stream to sse

### DIFF
--- a/src/mppx.server.ts
+++ b/src/mppx.server.ts
@@ -11,7 +11,7 @@ export const mppx = Mppx.create({
     tempo({
       currency: import.meta.env.VITE_DEFAULT_CURRENCY!,
       recipient: import.meta.env.VITE_DEFAULT_RECIPIENT!,
-      stream: true,
+      sse: true,
       ...(import.meta.env.VITE_FEE_PAYER_PRIVATE_KEY
         ? {
             feePayer: privateKeyToAccount(

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -29,7 +29,7 @@ Paste this into your AI coding agent to build the entire guide in one shot:
 Use https://mpp.sh/guides/streamed-payments.md as reference.
 Add mppx to my app with a payment-gated SSE endpoint
 that streams text word-by-word and charges $0.001 per word using the
-Tempo session payment method with PathUSD and stream: true.
+Tempo session payment method with PathUSD and sse: true.
 ```
 
 ## Manual mode
@@ -56,7 +56,7 @@ bun add mppx viem
 
 #### Set up `Mppx` instance with streaming
 
-Set up an `Mppx` instance with `stream: true` to enable SSE support on the session method.
+Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
 ```ts [app/api/sessions/poem/route.ts]
 import { Mppx, tempo } from 'mppx/nextjs'
@@ -65,7 +65,7 @@ export const mppx = Mppx.create({
   methods: [tempo({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
-    stream: true,
+    sse: true,
   })],
 })
 ```
@@ -81,7 +81,7 @@ export const mppx = Mppx.create({
   methods: [tempo({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
-    stream: true,
+    sse: true,
   })],
 })
 
@@ -144,7 +144,7 @@ bun add mppx hono viem
 
 #### Set up `Mppx` instance with streaming
 
-Set up an `Mppx` instance with `stream: true` to enable SSE support on the session method.
+Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
 ```ts [server.ts]
 import { Hono } from 'hono'
@@ -156,7 +156,7 @@ const mppx = Mppx.create({
   methods: [tempo({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
-    stream: true,
+    sse: true,
   })],
 })
 ```
@@ -175,7 +175,7 @@ const mppx = Mppx.create({
   methods: [tempo({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
-    stream: true,
+    sse: true,
   })],
 })
 
@@ -240,7 +240,7 @@ bun add mppx viem
 
 #### Set up `Mppx` instance with streaming
 
-Set up an `Mppx` instance with `stream: true` to enable SSE support on the session method.
+Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
 ```ts [src/index.ts]
 import { Mppx, tempo } from 'mppx/server'
@@ -249,7 +249,7 @@ const mppx = Mppx.create({
   methods: [tempo({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
-    stream: true,
+    sse: true,
   })],
 })
 ```
@@ -265,7 +265,7 @@ const mppx = Mppx.create({
   methods: [tempo({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
-    stream: true,
+    sse: true,
   })],
 })
 
@@ -335,7 +335,7 @@ bun add mppx express viem
 
 #### Set up `Mppx` instance with streaming
 
-Set up an `Mppx` instance with `stream: true` to enable SSE support on the session method.
+Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
 ```ts [server.ts]
 import express from 'express'
@@ -347,7 +347,7 @@ const mppx = Mppx.create({
   methods: [tempo({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
-    stream: true,
+    sse: true,
   })],
 })
 ```
@@ -366,7 +366,7 @@ const mppx = Mppx.create({
   methods: [tempo({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
-    stream: true,
+    sse: true,
   })],
 })
 
@@ -436,7 +436,7 @@ bun add mppx viem
 
 #### Set up `Mppx` instance with streaming
 
-Set up an `Mppx` instance with `stream: true` to enable SSE support on the session method.
+Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
 ```ts [server.ts]
 import { Mppx, tempo } from 'mppx/server'
@@ -445,7 +445,7 @@ const mppx = Mppx.create({
   methods: [tempo({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
-    stream: true,
+    sse: true,
   })],
 })
 ```
@@ -461,7 +461,7 @@ const mppx = Mppx.create({
   methods: [tempo({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
-    stream: true,
+    sse: true,
   })],
 })
 


### PR DESCRIPTION
Renames `stream: true` to `sse: true` across streamed payments guide and server config.