### PR TITLE
Fix landing page scroll, spacing, alignment, and responsive layout

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -163,18 +163,18 @@ function LandingStyles() {
 			}
 
 			@media (max-width: 1023px) {
+				.hero-right .lockup-wide { display: none !important; }
+				.hero-right .lockup-stacked { display: block !important; }
+				.co-designed-by { padding-top: 64px; }
+			}
+
+			@media (max-width: 767px) {
 				.lockup-stacked { max-width: 320px; margin: 0 auto; }
 				.hero-right {
 					align-items: center !important;
 					text-align: center !important;
 				}
-				.hero-right .lockup-wide { display: none !important; }
-				.hero-right .lockup-stacked { display: block !important; }
-				.co-designed-by { padding-top: 64px; }
 				.cli-demo-pane { margin: 0 auto; }
-			}
-
-			@media (max-width: 767px) {
 				[data-v-gutter-top] {
 					background: var(--vocs-background-color-primary) !important;
 					background-color: var(--vocs-background-color-primary) !important;
@@ -300,7 +300,7 @@ function Hero({ shouldAnimate }: { shouldAnimate: boolean }) {
           </div>
 
           {/* Right pane — hero content (staggers in after CLI) */}
-          <div className="hero-right flex-[9] min-w-0 order-first lg:order-last text-center lg:text-left flex flex-col items-center lg:items-start justify-center gap-6">
+          <div className="hero-right flex-[9] min-w-0 order-first lg:order-last text-center md:text-left flex flex-col items-center md:items-start justify-center gap-6">
             {/* Co-designed by */}
             <div style={anim(shouldAnimate, 800, 800)}>
               <CoDesignedBy shouldAnimate={false} />
@@ -322,7 +322,7 @@ function Hero({ shouldAnimate }: { shouldAnimate: boolean }) {
 
             {/* Agent prompt tabs */}
             <div
-              className="w-full max-w-xl mx-auto lg:mx-0"
+              className="w-full max-w-xl mx-auto md:mx-0"
               style={anim(shouldAnimate, 1800, 700)}
             >
               <AgentTabs />
@@ -330,7 +330,7 @@ function Hero({ shouldAnimate }: { shouldAnimate: boolean }) {
 
             {/* CTA buttons */}
             <div
-              className="flex flex-col items-center lg:items-start gap-4"
+              className="flex flex-col items-center md:items-start gap-4"
               style={anim(shouldAnimate, 2100, 700)}
             >
               <CTAButtons />


### PR DESCRIPTION
## Summary
- **Fix scroll behavior**: Hero section uses `min-height` by default (scrollable on smaller viewports) and locks to viewport height with `overflow: hidden` at `>=1280px`
- **Add nav-to-content spacing**: Add `paddingTop: 24px` to the hero content wrapper for breathing room between nav and content
- **Fix tagline text indent**: Extract `Tagline` into its own component using block `<div>` elements to prevent JSX whitespace from rendering as a first-line indent
- **Responsive alignment**: Three clean viewport states:
  - **Mobile (<768px)**: Single column, centered text/buttons/lockup
  - **Tablet (768px–1023px)**: Single column, left-aligned, stacked lockup
  - **Desktop (>=1024px)**: Two-column layout (CLI left, hero right), left-aligned
- **Reduce spacing**: Tighten `marginTop` and `paddingBottom` on the service logos section so "Works instantly with powerful APIs" stays in viewport

## Test plan
- [ ] Desktop (>=1280px): Page fills exactly one viewport height with no scroll
- [ ] Tablet (768px–1023px): Content is scrollable, single column, left-aligned
- [ ] Mobile (<768px): Content is scrollable, single column, centered
- [ ] Two-column layout kicks in at the same viewport width as the current production site (~1024px)
- [ ] "Supercharge your agent..." tagline has no first-line indent at any viewport
- [ ] "Works instantly with powerful APIs" section is visible without scrolling on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)