### PR TITLE
fix: make favicon gear icon bigger

### DIFF
--- a/public/favicon-gear.svg
+++ b/public/favicon-gear.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y="80" font-size="80" text-anchor="middle" x="50">⚙</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="10 10 80 80"><text y="75" font-size="90" text-anchor="middle" dominant-baseline="auto" x="50">⚙</text></svg>


### PR DESCRIPTION
Crop the SVG viewBox to zoom into the gear emoji so it renders larger in browser tabs.