### PR TITLE
chore: center landing page; tweak cli accent

### DIFF
--- a/src/components/Cli.tsx
+++ b/src/components/Cli.tsx
@@ -718,10 +718,10 @@ export namespace Toggle {
         className={cx(
           "flex items-center px-4 py-2 rounded-md cursor-pointer transition-colors text-sm font-medium",
           "text-secondary border border-transparent",
-          "has-[[data-checked]]:bg-neutral-100 has-[[data-checked]]:text-neutral-800",
-          "has-[[data-checked]]:border-neutral-300",
-          "has-[:focus-visible]:bg-neutral-100 has-[:focus-visible]:text-neutral-800",
-          "has-[:focus-visible]:border-neutral-300",
+          "has-[[data-checked]]:bg-accenta3 has-[[data-checked]]:text-accent",
+          "has-[[data-checked]]:border-accenta3",
+          "has-[:focus-visible]:bg-accenta3 has-[:focus-visible]:text-accent",
+          "has-[:focus-visible]:border-accenta3",
           className,
         )}
         onPointerUp={() => onSubmit?.(value)}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -66,6 +66,8 @@ export function LandingPage() {
         style={{
           color: ACCENT,
           fontFamily: "var(--font-copy)",
+          marginTop: "calc(var(--vocs-spacing-topNav) / 2 * -1) !important",
+          minHeight: "100vh",
           userSelect: "none",
           WebkitUserSelect: "none",
         }}
@@ -180,7 +182,6 @@ function Hero({ shouldAnimate }: { shouldAnimate: boolean }) {
           maxWidth: 1200,
           marginTop: "auto",
           marginBottom: "auto",
-          paddingTop: 24,
         }}
       >
         {/* Two-column layout: CLI left, hero right */}


### PR DESCRIPTION
- Landing page not vertically centered.
- Softened accent color on CLI buttons to not confuse with landing "Get started" CTA.