### PR TITLE
refactor: extract all cards into shared components

### DIFF
--- a/src/components/cards.tsx
+++ b/src/components/cards.tsx
@@ -1,0 +1,314 @@
+import { Badge, Card } from "vocs";
+
+export function QuickstartCard() {
+  return (
+    <Card
+      description="Build a payment-enabled API"
+      icon="lucide:rocket"
+      title="Quickstart"
+      to="/quickstart"
+    />
+  );
+}
+
+export function ClientQuickstartCard() {
+  return (
+    <Card
+      description="Learn how to pay for resources"
+      icon="lucide:user"
+      title="Client quickstart"
+      to="/quickstart/client"
+    />
+  );
+}
+
+export function ServerQuickstartCard() {
+  return (
+    <Card
+      description="Learn how to charge for resources"
+      icon="lucide:server"
+      title="Server quickstart"
+      to="/quickstart/server"
+    />
+  );
+}
+
+export function PrestoCliCard() {
+  return (
+    <Card
+      description="Command-line tool for making paid HTTP requests"
+      icon="lucide:terminal"
+      title="presto CLI"
+      to="/tools/presto"
+    />
+  );
+}
+
+export function TempoMethodCard() {
+  return (
+    <Card
+      description="Web scale payments with TIP-20 stablecoins on Tempo with sub second settlement"
+      icon='<svg viewBox="0 0 24 24"><path fill="currentColor" d="M10.55 17h-2.73l2.53-7.73h-3.24l.71-2.27h9.03l-.71 2.27h-3.07L10.55 17Z"/></svg>'
+      title="Tempo"
+      to="/payment-methods/tempo"
+    />
+  );
+}
+
+export function OneTimePaymentsCard() {
+  return (
+    <Card
+      description="Charge per request with a payment-gated API"
+      icon="lucide:zap"
+      title="Accept one-time payments"
+      to="/guides/one-time-payments"
+    />
+  );
+}
+
+export function PayAsYouGoCard() {
+  return (
+    <Card
+      description="Session-based billing with payment channels"
+      icon="lucide:repeat"
+      title="Accept pay-as-you-go payments"
+      to="/guides/pay-as-you-go"
+    />
+  );
+}
+
+export function ProtocolConceptsCard() {
+  return (
+    <Card
+      description="Learn about MPP's core control flow"
+      icon="lucide:book-open"
+      title="Protocol concepts"
+      to="/protocol"
+    />
+  );
+}
+
+export function TypeScriptSdkCard() {
+  return (
+    <Card
+      description="Get started with `mppx`, the reference implementation of the MPP SDKs"
+      icon="simple-icons:typescript"
+      title="TypeScript"
+      to="/sdk/typescript"
+    />
+  );
+}
+
+export function PythonSdkCard() {
+  return (
+    <Card
+      description="Get started with `pympp`, the official MPP SDK for Python"
+      icon="simple-icons:python"
+      title="Python"
+      to="/sdk/python"
+    />
+  );
+}
+
+export function RustSdkCard() {
+  return (
+    <Card
+      description="Get started with `mpp-rs`, the official MPP SDK for Rust"
+      icon="simple-icons:rust"
+      title="Rust"
+      to="/sdk/rust"
+    />
+  );
+}
+
+export function MppxCreateReferenceCard({
+  to,
+}: {
+  to: string;
+}) {
+  return (
+    <Card
+      description="Full API documentation"
+      icon="lucide:book-open"
+      title="Mppx.create reference"
+      to={to}
+    />
+  );
+}
+
+export function PaymentMethodsCard() {
+  return (
+    <Card
+      description="Method-specific request schemas"
+      icon="lucide:credit-card"
+      title="Payment Methods"
+      to="/payment-methods"
+    />
+  );
+}
+
+export function PrestoExamplesCard() {
+  return (
+    <Card
+      description="Usage patterns, examples, and full reference"
+      icon="lucide:code"
+      title="Examples"
+      to="/tools/presto/examples"
+    />
+  );
+}
+
+export function PrestoDownloadCard() {
+  return (
+    <Card
+      description="Download presto for your platform"
+      icon="lucide:download"
+      title="Download presto"
+      to="https://github.com/tempoxyz/presto"
+    />
+  );
+}
+
+export function Http402Card() {
+  return (
+    <Card
+      description="The 402 status code that signals payment is required"
+      icon="lucide:alert-circle"
+      title="HTTP 402"
+      to="/protocol/http-402"
+    />
+  );
+}
+
+export function ChallengesCard() {
+  return (
+    <Card
+      description="Server-issued payment requirements in WWW-Authenticate"
+      icon="lucide:file-question"
+      title="Challenges"
+      to="/protocol/challenges"
+    />
+  );
+}
+
+export function CredentialsCard() {
+  return (
+    <Card
+      description="Client-submitted payment proofs in Authorization"
+      icon="lucide:key"
+      title="Credentials"
+      to="/protocol/credentials"
+    />
+  );
+}
+
+export function ReceiptsCard() {
+  return (
+    <Card
+      description="Server acknowledgment of successful payment"
+      icon="lucide:receipt"
+      title="Receipts"
+      to="/protocol/receipts"
+    />
+  );
+}
+
+export function TransportsCard() {
+  return (
+    <Card
+      description="HTTP and MCP transport bindings"
+      icon="lucide:network"
+      title="Transports"
+      to="/protocol/transports"
+    />
+  );
+}
+
+export function StripeMethodCard() {
+  return (
+    <Card
+      description="Traditional payment methods through Stripe"
+      icon="simple-icons:stripe"
+      title="Stripe"
+      to="/payment-methods/stripe"
+    />
+  );
+}
+
+export function CustomMethodCard() {
+  return (
+    <Card
+      description="Build your own method or extend existing methods with the SDK."
+      icon="lucide:anvil"
+      title="Custom"
+      to="/payment-methods/custom"
+    />
+  );
+}
+
+export function TempoChargeCard() {
+  return (
+    <Card
+      description="Immediate one-time payments settled on-chain"
+      icon='<svg viewBox="0 0 24 24"><path fill="currentColor" d="M10.55 17h-2.73l2.53-7.73h-3.24l.71-2.27h9.03l-.71 2.27h-3.07L10.55 17Z"/></svg>'
+      title="Tempo charge"
+      to="/payment-methods/tempo/charge"
+    />
+  );
+}
+
+export function TempoSessionCard() {
+  return (
+    <Card
+      description="Pay-as-you-go payment sessions over payment channels"
+      icon="lucide:waves"
+      title="Session"
+      to="/payment-methods/tempo/session"
+      topRight={<Badge variant="info">Recommended</Badge>}
+    />
+  );
+}
+
+export function StripeChargeCard() {
+  return (
+    <Card
+      description="One-time payment using Shared Payment Tokens (SPTs)"
+      icon="lucide:credit-card"
+      title="Charge"
+      to="/payment-methods/stripe/charge"
+    />
+  );
+}
+
+export function PythonCoreTypesCard() {
+  return (
+    <Card
+      description="Challenge, Credential, Receipt types"
+      icon="lucide:box"
+      title="Core types"
+      to="/sdk/python/core"
+    />
+  );
+}
+
+export function PythonClientCard() {
+  return (
+    <Card
+      description="Handle 402 responses automatically"
+      icon="lucide:send"
+      title="Client"
+      to="/sdk/python/client"
+    />
+  );
+}
+
+export function PythonServerCard() {
+  return (
+    <Card
+      description="Protect endpoints with payments"
+      icon="lucide:server"
+      title="Server"
+      to="/sdk/python/server"
+    />
+  );
+}

--- a/src/pages/guides/one-time-payments.mdx
+++ b/src/pages/guides/one-time-payments.mdx
@@ -1,4 +1,5 @@
-import { Card, Cards, Tabs, Tab } from 'vocs'
+import { Cards, Tabs, Tab } from 'vocs'
+import { PayAsYouGoCard, ServerQuickstartCard, PrestoCliCard } from '../../components/cards'
 import * as Cli from '../../components/Cli'
 import { pathUsd } from '../../wagmi.config'
 
@@ -555,22 +556,7 @@ $ npx mppx http://localhost:3000
 ## Next steps
 
 <Cards>
-  <Card
-    icon="lucide:repeat"
-    title="Accept pay-as-you-go payments"
-    description="Session-based billing with payment channels"
-    to="/guides/pay-as-you-go"
-  />
-  <Card
-    icon="lucide:code"
-    title="Server quickstart"
-    description="Framework middleware reference"
-    to="/quickstart/server"
-  />
-  <Card
-    icon="lucide:terminal"
-    title="mppx CLI reference"
-    description="Full command reference and options"
-    to="/tools/presto"
-  />
+  <PayAsYouGoCard />
+  <ServerQuickstartCard />
+  <PrestoCliCard />
 </Cards>

--- a/src/pages/guides/pay-as-you-go.mdx
+++ b/src/pages/guides/pay-as-you-go.mdx
@@ -1,4 +1,5 @@
-import { Card, Cards, Tabs, Tab } from 'vocs'
+import { Cards, Tabs, Tab } from 'vocs'
+import { OneTimePaymentsCard, ServerQuickstartCard, PrestoCliCard } from '../../components/cards'
 import * as Cli from '../../components/Cli'
 import { pathUsd } from '../../wagmi.config'
 
@@ -585,22 +586,7 @@ const res = await fetch('http://localhost:3000/api/sessions/photo')
 ## Next steps
 
 <Cards>
-  <Card
-    icon="lucide:zap"
-    title="Accept one-time payments"
-    description="Charge per request with a payment-gated API"
-    to="/guides/one-time-payments"
-  />
-  <Card
-    icon="lucide:code"
-    title="Server quickstart"
-    description="Framework middleware reference"
-    to="/quickstart/server"
-  />
-  <Card
-    icon="lucide:terminal"
-    title="mppx CLI reference"
-    description="Full command reference and options"
-    to="/tools/presto"
-  />
+  <OneTimePaymentsCard />
+  <ServerQuickstartCard />
+  <PrestoCliCard />
 </Cards>

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -1,4 +1,5 @@
-import { Card, Cards, Tabs, Tab } from 'vocs'
+import { Cards, Tabs, Tab } from 'vocs'
+import { OneTimePaymentsCard, PayAsYouGoCard, PrestoCliCard } from '../../components/cards'
 import * as Cli from '../../components/Cli'
 import { pathUsd } from '../../wagmi.config'
 
@@ -543,22 +544,7 @@ for await (const word of stream) {
 ## Next steps
 
 <Cards>
-  <Card
-    icon="lucide:zap"
-    title="Accept one-time payments"
-    description="Charge per request with a payment-gated API"
-    to="/guides/one-time-payments"
-  />
-  <Card
-    icon="lucide:repeat"
-    title="Accept pay-as-you-go payments"
-    description="Session-based billing with payment channels"
-    to="/guides/pay-as-you-go"
-  />
-  <Card
-    icon="lucide:terminal"
-    title="mppx CLI reference"
-    description="Full command reference and options"
-    to="/tools/presto"
-  />
+  <OneTimePaymentsCard />
+  <PayAsYouGoCard />
+  <PrestoCliCard />
 </Cards>

--- a/src/pages/intents/charge.mdx
+++ b/src/pages/intents/charge.mdx
@@ -1,5 +1,6 @@
-import { Badge, Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
 import { MermaidDiagram } from '../../components/MermaidDiagram'
+import { TempoChargeCard, StripeMethodCard } from '../../components/cards'
 import { SpecCard } from '../../components/SpecCard'
 
 # Charge [Immediate one-time payments]
@@ -60,18 +61,8 @@ Payment methods extend this schema with method-specific fields through `methodDe
 Each payment method defines how charge is fulfilled, verified, and settled on its underlying network.
 
 <Cards>
-  <Card
-    icon='<svg viewBox="0 0 24 24"><path fill="currentColor" d="M10.55 17h-2.73l2.53-7.73h-3.24l.71-2.27h9.03l-.71 2.27h-3.07L10.55 17Z"/></svg>'
-    title="Tempo"
-    description="One-time TIP-20 token transfers with sub second settlement and optional fee sponsorship"
-    to="/payment-methods/tempo/charge"
-  />
-  <Card
-    icon="simple-icons:stripe"
-    title="Stripe"
-    description="One-time card or bank payment"
-    to="/payment-methods/stripe"
-  />
+  <TempoChargeCard />
+  <StripeMethodCard />
 </Cards>
 
 ## Specification

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -1,6 +1,7 @@
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
 import * as Cli from '../components/Cli'
 import { SpecCard } from '../components/SpecCard'
+import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, QuickstartCard, ProtocolConceptsCard } from '../components/cards'
 import { PaymentFlowDiagram } from '../components/PaymentFlowDiagram'
 import { pathUsd } from '../wagmi.config'
 
@@ -54,40 +55,15 @@ When a client requests a paid resource, the server returns a `402` response with
 MPP comes with a suite of official SDKs maintained by [Tempo Labs](https://tempo.xyz) and [Wevm](https://wevm.dev). The SDKs offer high-level abstractions and low-level primitives to implement and extend the Machine Payments Protocol.
 
 <Cards>
-  <Card
-    description="Get started with `mppx`, the reference implementation of the MPP SDKs"
-    icon="simple-icons:typescript"
-    title="TypeScript"
-    to="/sdk/typescript"
-  />
-  <Card
-    description="Get started with `pympp`, the official MPP SDK for Python"
-    icon="simple-icons:python"
-    title="Python"
-    to="/sdk/python"
-  />
-  <Card
-    description="Get started with `mpp-rs`, the official MPP SDK for Rust"
-    icon="simple-icons:rust"
-    title="Rust"
-    to="/sdk/rust"
-  />
+  <TypeScriptSdkCard />
+  <PythonSdkCard />
+  <RustSdkCard />
 </Cards>
 
 ## Next steps
 
 <Cards>
-  <Card
-    description="Build a payment-enabled API"
-    icon="lucide:rocket"
-    title="Quickstart"
-    to="/quickstart"
-  />
-  <Card
-    description="Learn about challenges, credentials, and receipts"
-    icon="lucide:book-open"
-    title="Protocol concepts"
-    to="/protocol"
-  />
+  <QuickstartCard />
+  <ProtocolConceptsCard />
   <SpecCard to="https://tempoxyz.github.io/mpp-specs/" />
 </Cards>

--- a/src/pages/payment-methods/index.mdx
+++ b/src/pages/payment-methods/index.mdx
@@ -1,4 +1,5 @@
-import { Card, Cards, Tab, Tabs } from 'vocs'
+import { Cards, Tab, Tabs } from 'vocs'
+import { TempoMethodCard, StripeMethodCard, CustomMethodCard } from '../../components/cards'
 
 # Payment methods [Available methods and how to choose one]
 
@@ -26,22 +27,7 @@ WWW-Authenticate: Payment method="stripe", intent="charge", ...
 ## Available methods
 
 <Cards>
-  <Card
-    icon='<svg viewBox="0 0 24 24"><path fill="currentColor" d="M10.55 17h-2.73l2.53-7.73h-3.24l.71-2.27h9.03l-.71 2.27h-3.07L10.55 17Z"/></svg>'
-    title="Tempo"
-    description="Web scale payments with TIP-20 stablecoins on Tempo with sub second settlement."
-    to="/payment-methods/tempo"
-  />
-  <Card
-    icon="simple-icons:stripe"
-    title="Stripe"
-    description="Traditional card payment methods through Stripe."
-    to="/payment-methods/stripe"
-  />
-  <Card
-    icon="lucide:anvil"
-    title="Custom"
-    description="Build your own method or extend existing methods with the SDK."
-    to="/payment-methods/custom"
-  />
+  <TempoMethodCard />
+  <StripeMethodCard />
+  <CustomMethodCard />
 </Cards>

--- a/src/pages/payment-methods/stripe/index.mdx
+++ b/src/pages/payment-methods/stripe/index.mdx
@@ -1,4 +1,5 @@
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
+import { StripeChargeCard } from '../../../components/cards'
 
 # Stripe [Cards, wallets, and other Stripe supported payment methods]
 
@@ -16,10 +17,5 @@ Both the client and server need a Stripe account. The client creates an SPT usin
 ## Intents
 
 <Cards>
-  <Card
-    icon="lucide:credit-card"
-    title="Charge"
-    description="One-time payment using Shared Payment Tokens (SPTs)"
-    to="/payment-methods/stripe/charge"
-  />
+  <StripeChargeCard />
 </Cards>

--- a/src/pages/payment-methods/tempo/index.mdx
+++ b/src/pages/payment-methods/tempo/index.mdx
@@ -1,4 +1,5 @@
-import { Badge, Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
+import { TempoChargeCard, TempoSessionCard } from '../../../components/cards'
 
 # Tempo [Stablecoin payments on the Tempo blockchain]
 
@@ -29,19 +30,8 @@ Tempo is purpose-built for the payment patterns MPP enables:
 ## Intents
 
 <Cards>
-  <Card
-    icon="lucide:credit-card"
-    title="Charge"
-    description="Immediate one-time payments settled on-chain"
-    to="/payment-methods/tempo/charge"
-  />
-  <Card
-    topRight={<Badge variant="info">Recommended</Badge>}
-    icon="lucide:waves"
-    title="Session"
-    description="Pay-as-you-go payment sessions over payment channels"
-    to="/payment-methods/tempo/session"
-  />
+  <TempoChargeCard />
+  <TempoSessionCard />
 </Cards>
 
 ## Fee sponsorship

--- a/src/pages/protocol/challenges.mdx
+++ b/src/pages/protocol/challenges.mdx
@@ -78,15 +78,11 @@ Use an [HMAC-bound](https://en.wikipedia.org/wiki/HMAC) challenge ID to prevent 
 
 ## Learn more
 
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
 import { SpecCard } from '../../components/SpecCard'
+import { PaymentMethodsCard } from '../../components/cards'
 
 <Cards>
   <SpecCard to="https://tempoxyz.github.io/mpp-specs/" />
-  <Card
-    description="Method-specific request schemas"
-    icon="lucide:credit-card"
-    title="Payment Methods"
-    to="/payment-methods"
-  />
+  <PaymentMethodsCard />
 </Cards>

--- a/src/pages/protocol/credentials.mdx
+++ b/src/pages/protocol/credentials.mdx
@@ -68,15 +68,11 @@ The server verifies the signature authorizes a transfer matching the challenge p
 
 ## Learn more
 
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
 import { SpecCard } from '../../components/SpecCard'
+import { PaymentMethodsCard } from '../../components/cards'
 
 <Cards>
   <SpecCard to="https://tempoxyz.github.io/mpp-specs/" />
-  <Card
-    description="Method-specific payload schemas"
-    icon="lucide:credit-card"
-    title="Payment Methods"
-    to="https://tempoxyz.github.io/mpp-specs/"
-  />
+  <PaymentMethodsCard />
 </Cards>

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -13,39 +13,15 @@ These docs provide a developer-friendly overview. For the full specification, se
 
 ## Core concepts
 
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
+import { Http402Card, ChallengesCard, CredentialsCard, ReceiptsCard, TransportsCard } from '../../components/cards'
 
 <Cards>
-  <Card
-    description="The 402 status code that signals payment is required"
-    icon="lucide:alert-circle"
-    title="HTTP 402"
-    to="/protocol/http-402"
-  />
-  <Card
-    description="Server-issued payment requirements in WWW-Authenticate"
-    icon="lucide:file-question"
-    title="Challenges"
-    to="/protocol/challenges"
-  />
-  <Card
-    description="Client-submitted payment proofs in Authorization"
-    icon="lucide:key"
-    title="Credentials"
-    to="/protocol/credentials"
-  />
-  <Card
-    description="Server acknowledgment of successful payment"
-    icon="lucide:receipt"
-    title="Receipts"
-    to="/protocol/receipts"
-  />
-  <Card
-    description="HTTP and MCP transport bindings"
-    icon="lucide:network"
-    title="Transports"
-    to="/protocol/transports"
-  />
+  <Http402Card />
+  <ChallengesCard />
+  <CredentialsCard />
+  <ReceiptsCard />
+  <TransportsCard />
 </Cards>
 
 ## Status codes

--- a/src/pages/quickstart/client.mdx
+++ b/src/pages/quickstart/client.mdx
@@ -1,5 +1,6 @@
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
 import { ClientPrompt } from '../../components/QuickstartPrompt'
+import { ServerQuickstartCard, TempoMethodCard, MppxCreateReferenceCard } from '../../components/cards'
 
 # Client quickstart [Handle payment-gated resources automatically]
 
@@ -202,22 +203,7 @@ console.log(receipt.timestamp)
 ## Next steps
 
 <Cards>
-  <Card
-    icon="lucide:server"
-    title="Server quickstart"
-    description="Learn how to charge for resources"
-    to="/quickstart/server"
-  />
-  <Card
-    icon="lucide:credit-card"
-    title="Tempo payment method"
-    description="Configure Tempo blockchain payments"
-    to="/payment-methods/tempo"
-  />
-  <Card
-    icon="lucide:book-open"
-    title="Mppx.create reference"
-    description="Full API documentation"
-    to="/sdk/typescript/client/Mppx.create"
-  />
+  <ServerQuickstartCard />
+  <TempoMethodCard />
+  <MppxCreateReferenceCard to="/sdk/typescript/client/Mppx.create" />
 </Cards>

--- a/src/pages/quickstart/index.mdx
+++ b/src/pages/quickstart/index.mdx
@@ -1,5 +1,6 @@
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
 import { QuickstartPrompts } from '../../components/QuickstartPrompt'
+import { ClientQuickstartCard, ServerQuickstartCard, PrestoCliCard } from '../../components/cards'
 
 # Quickstart [Get started with MPP in minutes]
 
@@ -16,22 +17,7 @@ Paste one of these into your AI coding agent to build your first MPP app or serv
 Pick a starting point based on your role:
 
 <Cards>
-  <Card
-    icon="lucide:user"
-    title="Client"
-    description="Handle payment-gated resources automatically"
-    to="/quickstart/client"
-  />
-  <Card
-    icon="lucide:server"
-    title="Server"
-    description="Charge for resource access"
-    to="/quickstart/server"
-  />
-  <Card
-    icon="lucide:terminal"
-    title="presto CLI"
-    description="Command-line interface for mpp"
-    to="/quickstart/presto"
-  />
+  <ClientQuickstartCard />
+  <ServerQuickstartCard />
+  <PrestoCliCard />
 </Cards>

--- a/src/pages/quickstart/presto.mdx
+++ b/src/pages/quickstart/presto.mdx
@@ -1,4 +1,5 @@
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
+import { PrestoExamplesCard } from '../../components/cards'
 
 # presto [Make paid HTTP requests from the command line]
 
@@ -163,16 +164,5 @@ $ presto https://api.dev-tools.com/analyze?repo=myorg/myrepo
 ## Next steps
 
 <Cards>
-  <Card
-    icon="lucide:code"
-    title="Examples"
-    description="More usage patterns and real endpoints"
-    to="/tools/presto/examples"
-  />
-  <Card
-    icon="lucide:book-open"
-    title="Reference"
-    description="Full command reference and configuration"
-    to="/tools/presto"
-  />
+  <PrestoExamplesCard />
 </Cards>

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -1,5 +1,6 @@
-import { Badge, Card, Cards } from 'vocs'
+import { Badge, Cards } from 'vocs'
 import { ServerPrompt } from '../../components/QuickstartPrompt'
+import { ClientQuickstartCard, TempoMethodCard, MppxCreateReferenceCard } from '../../components/cards'
 
 # Server quickstart [Charge for resources and verify payment credentials]
 
@@ -239,22 +240,7 @@ Use `presto inspect` or `npx mppx --inspect` to debug your server's Challenge re
 ## Next steps
 
 <Cards>
-  <Card
-    icon="lucide:user"
-    title="Client quickstart"
-    description="Learn how to pay for resources"
-    to="/quickstart/client"
-  />
-  <Card
-    icon="lucide:credit-card"
-    title="Tempo payment method"
-    description="Configure Tempo blockchain payments"
-    to="/payment-methods/tempo"
-  />
-  <Card
-    icon="lucide:book-open"
-    title="Mppx.create reference"
-    description="Full API documentation"
-    to="/sdk/typescript/server/Mppx.create"
-  />
+  <ClientQuickstartCard />
+  <TempoMethodCard />
+  <MppxCreateReferenceCard to="/sdk/typescript/server/Mppx.create" />
 </Cards>

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -1,30 +1,11 @@
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
+import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, PrestoCliCard } from '../../components/cards'
 
 # SDKs & Tools [Official implementations in multiple languages]
 
 <Cards>
-  <Card
-    description="Get started with `mppx`, the reference implementation of the MPP SDKs"
-    icon="simple-icons:typescript"
-    title="TypeScript"
-    to="/sdk/typescript"
-  />
-  <Card
-    description="Get started with `pympp`, the official MPP SDK for Python"
-    icon="simple-icons:python"
-    title="Python"
-    to="/sdk/python"
-  />
-  <Card
-    description="Get started with `mpp-rs`, the official MPP SDK for Rust"
-    icon="simple-icons:rust"
-    title="Rust"
-    to="/sdk/rust"
-  />
-  <Card
-    description="A command-line tool for making paid HTTP requests"
-    icon="lucide:terminal"
-    title="presto CLI"
-    to="/tools/presto"
-  />
+  <TypeScriptSdkCard />
+  <PythonSdkCard />
+  <RustSdkCard />
+  <PrestoCliCard />
 </Cards>

--- a/src/pages/sdk/python/index.mdx
+++ b/src/pages/sdk/python/index.mdx
@@ -87,25 +87,11 @@ asyncio.run(main())
 
 ## Next steps
 
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
+import { PythonCoreTypesCard, PythonClientCard, PythonServerCard } from '../../../components/cards'
 
 <Cards>
-  <Card
-    description="Challenge, Credential, Receipt types"
-    icon="lucide:box"
-    title="Core types"
-    to="/sdk/python/core"
-  />
-  <Card
-    description="Handle 402 responses automatically"
-    icon="lucide:send"
-    title="Client"
-    to="/sdk/python/client"
-  />
-  <Card
-    description="Protect endpoints with payments"
-    icon="lucide:server"
-    title="Server"
-    to="/sdk/python/server"
-  />
+  <PythonCoreTypesCard />
+  <PythonClientCard />
+  <PythonServerCard />
 </Cards>

--- a/src/pages/tools/presto.mdx
+++ b/src/pages/tools/presto.mdx
@@ -99,19 +99,10 @@ moderato_rpc = "https://my-custom-moderato-rpc.com"
 
 ## Learn more
 
-import { Card, Cards } from 'vocs'
+import { Cards } from 'vocs'
+import { PrestoExamplesCard, PrestoDownloadCard } from '../../components/cards'
 
 <Cards>
-  <Card
-    description="Complete command reference and options"
-    icon="lucide:book-open"
-    title="Full Reference"
-    to="/tools/presto/examples"
-  />
-  <Card
-    description="Download presto for your platform"
-    icon="lucide:download"
-    title="Download presto"
-    to="https://github.com/tempoxyz/presto"
-  />
+  <PrestoExamplesCard />
+  <PrestoDownloadCard />
 </Cards>


### PR DESCRIPTION
Extracts all inline `<Card>` definitions across 18 MDX files into a single shared `src/components/cards.tsx` module (following the existing `SpecCard` pattern).

## Changes

- **New file:** `src/components/cards.tsx` — 27 shared card components
- **Updated:** 18 MDX files to import shared components instead of inline `<Card>` definitions
- **Consolidated duplicates:** Merged 4 pairs of cards that linked to the same destination (`TempoMethodCard`, `TempoChargeCard`, `StripeMethodCard`, `PrestoExamplesCard`)
- **Standardized descriptions:** Removed per-page overrides so every card has exactly one canonical description
- **Updated copy:** Protocol concepts card → "Learn about MPP's core control flow"; StripeMethodCard → "Traditional payment methods through Stripe"

Types and build pass.