### PR TITLE
fix: guard privateKeyToAccount against missing env var during SSG

### DIFF
--- a/src/mppx.server.ts
+++ b/src/mppx.server.ts
@@ -4,15 +4,15 @@ import { privateKeyToAccount } from "viem/accounts";
 import { tempoModerato } from "viem/chains";
 
 const realm = process.env.REALM ?? "mpp.tempo.xyz";
-const account = privateKeyToAccount(
-  process.env.FEE_PAYER_PRIVATE_KEY as `0x${string}`,
-);
+const account = process.env.FEE_PAYER_PRIVATE_KEY
+  ? privateKeyToAccount(process.env.FEE_PAYER_PRIVATE_KEY as `0x${string}`)
+  : undefined;
 
 export const mppx = Mppx.create({
   realm,
   methods: [
     tempo({
-      account,
+      account: account!,
       feePayer: true,
       currency: import.meta.env.VITE_DEFAULT_CURRENCY!,
       sse: true,


### PR DESCRIPTION
## Problem

`privateKeyToAccount(process.env.FEE_PAYER_PRIVATE_KEY)` runs at the top level of `src/mppx.server.ts`. During SSG/build, the env var is missing, causing viem to crash with:

```
TypeError: Cannot read properties of undefined (reading 'slice')
```

This breaks the build and causes 500 errors on pages whose API routes import this module (e.g. `/payment-methods/tempo`, `/api/demo/poem`).

## Fix

Guard the `privateKeyToAccount` call so it returns `undefined` when the env var is missing. The module can now be safely imported during build — the account is only needed at request time.