### PR TITLE
fix: terminal renders light in dark mode

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -777,8 +777,6 @@ a[href*="/payment-methods/tempo"][class*="vocs:rounded-md"]
 
   /* Pink */
   --term-pink9: light-dark(hsl(336 65% 45%), hsl(341 90% 67%));
-
-  color-scheme: light dark;
 }
 
 /* Terminal-scoped utility overrides — map tailwind-like classes to --term- vars */


### PR DESCRIPTION
Remove `color-scheme: light dark` from `.terminal-theme` which overrode the inherited `color-scheme` from Vocs's root element, causing `light-dark()` CSS functions to always resolve to the light value.

The terminal now correctly inherits dark/light from Vocs's theme toggle.