### PR TITLE
style: scale site to 90% via root font-size

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -68,6 +68,7 @@
 
 /* Prevent layout shift when scrollbar appears/disappears between routes */
 html {
+  font-size: 90%;
   scrollbar-gutter: stable;
   overflow-y: scroll;
 }


### PR DESCRIPTION
Sets `font-size: 90%` on the `html` element, which scales everything down since Vocs uses `rem`-based sizing throughout.