### PR TITLE
style: use Geist Mono for hero heading

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -215,7 +215,7 @@ function Tagline() {
       style={{ color: "var(--vocs-text-color-secondary)" }}
     >
       <div>
-        The open protocol for Internet-native payments. Charge for API requests,
+        The open protocol for internet-native payments. Charge for API requests,
         tool calls, or content. Agents, apps, and humans securely pay per
         request.
       </div>


### PR DESCRIPTION
Changes the "Machine Payments Protocol" hero heading font from Geist (sans-serif) to Geist Mono (monospace).