### PR TITLE
feat: add [use link] button to stripe card form

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1010,7 +1010,15 @@ function CardForm({
               className="cursor-pointer hover:underline"
               style={{ color: "#635BFF" }}
             >
-              Use test card (4242)
+              [use test card]
+            </button>{" "}
+            <button
+              type="button"
+              onClick={useTestCard}
+              className="cursor-pointer hover:underline"
+              style={{ color: "#00D66F" }}
+            >
+              [use link]
             </button>
           </>
         ) : (


### PR DESCRIPTION
Adds a Link-branded `[use link]` button next to the existing `[use test card]` button in the terminal Stripe card form. Both auto-fill the 4242 test card details.

- `[use test card]` in Stripe purple (#635BFF)
- `[use link]` in Link green (#00D66F)