### PR TITLE
fix: use 'client' consistently for protocol-level actor

### DIFF
--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -54,7 +54,7 @@ The protocol itself is free and open. There are no licensing fees for implementi
 
 ## Is it safe?
 
-MPP requires TLS 1.2+ for all connections. Challenge IDs are cryptographically bound to prevent replay attacks. The protocol never performs side effects on unpaid requests—your agent only pays after verifying what it is paying for.
+MPP requires TLS 1.2+ for all connections. Challenge IDs are cryptographically bound to prevent replay attacks. The protocol never performs side effects on unpaid requests—your client only pays after verifying what it is paying for.
 
 Payments use the same security model as the underlying payment method. For Tempo, that means cryptographic signatures over every transaction. For Stripe, it means Stripe's existing fraud and dispute infrastructure.
 

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -41,7 +41,7 @@ This documentation site is itself an MPP server. Create an account, fund it with
 ## Use cases
 
 * **Paid APIs**—Accept payments inline without requiring API keys, billing accounts, or manual signup. Clients pay per request.
-* **MCP servers**—Monetize tool calls served through the Model Context Protocol (MCP). Agents pay autonomously without complicated OAuth or account setup.
+* **MCP servers**—Monetize tool calls served through the Model Context Protocol (MCP). Clients pay autonomously without complicated OAuth or account setup.
 * **Digital content**—Monetize articles, data, or media without subscription paywalls. Charge per access or per query.
 
 ## Payment flow

--- a/src/pages/services.mdx
+++ b/src/pages/services.mdx
@@ -12,9 +12,9 @@ import { Cards, Card } from "vocs";
   [data-v-content] table td:nth-child(2) { width: 44%; }
 `}</style>
 
-# Services [Use MPP-enabled APIs your agent or application can pay for]
+# Services [Use MPP-enabled APIs your client or application can pay for]
 
-Discover MPP services that are live, and how to use them via the examples below. After you fund a supported payment method, you can start using MPP services from your agent or application for real-time, programmable payments.
+Discover MPP services that are live, and how to use them via the examples below. After you fund a supported payment method, you can start using MPP services from your client or application for real-time, programmable payments.
 
 :::tip
 Examples use [Tempo](/payment-methods/tempo) for payments, where [stablecoins](/payment-methods/tempo#stablecoins) enable low-cost, instant, and secure payments. Services also offer [Stripe](/payment-methods/stripe), with more payment methods on the way.


### PR DESCRIPTION
The overview page establishes **client** as the umbrella term for the protocol-level actor (agents, apps, humans). Several other pages incorrectly used "agent" when referring to this same concept, creating confusion with the separate "AI coding agent" meaning (the dev tool you paste prompts into).

### Changes
- **services.mdx**: agent → client in title and intro paragraph
- **faq.mdx**: "your agent only pays" → "your client only pays"
- **overview.mdx**: "Agents pay autonomously" → "Clients pay autonomously"