### PR TITLE
fix: externalize typescript from server bundle to fix SSR __filename error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -82,6 +82,20 @@ export default defineConfig({
     react(),
     vocs(),
   ],
+  // Prevent the TypeScript compiler (used by twoslash) from being bundled into
+  // the server output. TypeScript uses `__filename` which doesn't exist in ESM.
+  environments: {
+    rsc: {
+      build: {
+        rollupOptions: {
+          external: ["typescript"],
+        },
+      },
+    },
+  },
+  ssr: {
+    external: ["typescript"],
+  },
   test: {
     exclude: [...configDefaults.exclude, "e2e/**"],
   },


### PR DESCRIPTION
## Problem

All pages return 500 in `vocs preview` (and on Vercel production for some routes like `/payment-methods/tempo`) with:

```
ReferenceError: __filename is not defined in ES module scope
```

The error occurs because Vocs v2 bundles the TypeScript compiler (used by twoslash for ```ts twoslash``` code blocks) into the server output. TypeScript internally uses `__filename`, which doesn't exist in ESM (`"type": "module"`).

## Fix

Externalize `typescript` from both:
- The **RSC environment** (Waku server build → `dist/server/assets/`)
- The **SSR build** (`dist/server/ssr/`)

This keeps `typescript` as a runtime `require()` from `node_modules` instead of inlining it into the bundle.

## Verification

- `pnpm build` succeeds
- `pnpm check:types` passes
- `vocs preview` → all pages return 200 (previously all returned 500)