### PR TITLE
fix: site bugs — sidebar, tempo RSC, 404 logo, mobile overflow

### DIFF
--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -273,7 +273,8 @@ function NotFoundHeaderLogo() {
   if (!target) return null;
 
   return createPortal(
-    <div
+    <a
+      href="/"
       style={{
         position: "absolute",
         top: 0,
@@ -281,8 +282,9 @@ function NotFoundHeaderLogo() {
         height: "100%",
         display: "flex",
         alignItems: "center",
-        pointerEvents: "none",
+        pointerEvents: "auto",
         zIndex: 1,
+        textDecoration: "none",
       }}
     >
       <picture>
@@ -293,7 +295,7 @@ function NotFoundHeaderLogo() {
           style={{ height: 20, width: "auto" }}
         />
       </picture>
-    </div>,
+    </a>,
     target,
   );
 }

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -1999,7 +1999,7 @@ function PageStyles() {
         .search-mobile input { padding-top: 0.6rem !important; padding-bottom: 0.6rem !important; font-size: 15px !important; }
         .search-mobile select { font-size: 15px !important; padding-top: 0.55rem !important; padding-bottom: 0.55rem !important; }
         .filter-tags { justify-content: center !important; margin-bottom: 3.75rem !important; margin-left: 0 !important; margin-right: 0 !important; padding: 0 1.25rem !important; }
-        .filter-tags button { font-size: 14px !important; padding: 0.4rem 0.85rem !important; flex: 1 1 18% !important; justify-content: center !important; }
+        .filter-tags button { font-size: 14px !important; padding: 0.4rem 0.85rem !important; flex: 1 1 auto !important; justify-content: center !important; }
         .page-header { text-align: center !important; margin-bottom: 1.25rem !important; padding: 0 1.25rem !important; }
         .page-header p { max-width: 80% !important; margin-left: auto !important; margin-right: auto !important; }
         .pagination { padding: 0 1.25rem !important; }
@@ -2014,7 +2014,7 @@ function PageStyles() {
         .expanded-links { padding-left: 4rem !important; }
         .header-cards-grid > * > div > div:first-child { font-size: 17px !important; }
         .header-cards-grid > * > div > div:last-child { font-size: 15px !important; }
-        .filter-tags button { min-width: 0 !important; }
+        .filter-tags button { min-width: auto !important; }
       }
     `}</style>
   );

--- a/src/pages/payment-methods/tempo/index.mdx
+++ b/src/pages/payment-methods/tempo/index.mdx
@@ -1,5 +1,4 @@
-import { Cards } from 'vocs'
-import { TempoChargeCard, TempoSessionCard } from '../../../components/cards'
+import { Badge } from 'vocs'
 
 # Tempo [Stablecoin payments on the Tempo blockchain]
 
@@ -29,10 +28,23 @@ Tempo is purpose-built for the payment patterns MPP enables:
 
 ## Intents
 
-<Cards>
-  <TempoChargeCard />
-  <TempoSessionCard />
-</Cards>
+<div className="vocs:grid vocs:grid-cols-1 vocs:md:grid-cols-2 vocs:gap-4">
+  <a href="/payment-methods/tempo/charge" className="vocs:relative vocs:flex vocs:flex-col vocs:space-y-2 vocs:rounded-md vocs:bg-surfaceTint/70 vocs:border vocs:border-primary vocs:p-4 vocs:no-underline vocs:transition-colors vocs:hover:bg-surfaceTint">
+    <div className="vocs:size-8 vocs:flex vocs:items-center vocs:justify-center vocs:rounded-lg vocs:border vocs:border-primary vocs:bg-surface vocs:text-accent">
+      <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M10.55 17h-2.73l2.53-7.73h-3.24l.71-2.27h9.03l-.71 2.27h-3.07L10.55 17Z"/></svg>
+    </div>
+    <div className="vocs:text-[15px] vocs:font-medium vocs:text-heading">Tempo charge</div>
+    <div className="vocs:text-sm vocs:leading-relaxed vocs:text-secondary">Immediate one-time payments settled on-chain</div>
+  </a>
+  <a href="/payment-methods/tempo/session" className="vocs:relative vocs:flex vocs:flex-col vocs:space-y-2 vocs:rounded-md vocs:bg-surfaceTint/70 vocs:border vocs:border-primary vocs:p-4 vocs:no-underline vocs:transition-colors vocs:hover:bg-surfaceTint">
+    <div className="vocs:absolute vocs:top-4 vocs:right-4"><Badge variant="info">Recommended</Badge></div>
+    <div className="vocs:size-8 vocs:flex vocs:items-center vocs:justify-center vocs:rounded-lg vocs:border vocs:border-primary vocs:bg-surface vocs:text-accent">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M2 6c.6.5 1.2 1 2.5 1C7 7 7 5 9.5 5c2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"/><path d="M2 12c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"/><path d="M2 18c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 2.6 0 2.4 2 5 2 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1"/></svg>
+    </div>
+    <div className="vocs:text-[15px] vocs:font-medium vocs:text-heading">Session</div>
+    <div className="vocs:text-sm vocs:leading-relaxed vocs:text-secondary">Pay-as-you-go payment sessions over payment channels</div>
+  </a>
+</div>
 
 ## Fee sponsorship
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -77,7 +77,6 @@ export default defineConfig({
         text: "Introduction",
         items: [
           { text: "Overview", link: "/overview" },
-          { text: "Services", link: "/services" },
           {
             text: "IETF Specs",
             link: "https://tempoxyz.github.io/mpp-specs/",


### PR DESCRIPTION
Fixes several reported site bugs:

- **Remove Services from sidebar** — removes the Services link from the sidebar navigation
- **Fix `/payment-methods/tempo` server component render error** — replaces async `Card` components (from vocs) with inlined card markup to avoid RSC rendering failures in production
- **Make 404 page logo clickable** — wraps the logo in an `<a href="/">` and enables pointer events so users can navigate home
- **Fix Services page mobile text overflow** — changes `flex: 1 1 18%` to `flex: 1 1 auto` so category labels like "Blockchain" and "Compute" don't bleed into each other on small screens