### PR TITLE
feat: shared PromptBlock component with click-to-copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,7 @@ Follow [Stripe's documentation style](https://stripe.com/docs). Key rules:
 - "Once" to mean "after"
 - Exclamation points, humor, rhetorical questions
 - The word "crypto"—use "stablecoins" instead
+- "AI coding agent"—say "coding agent" instead (the "AI" is redundant)
 
 **Structure**: Never skip heading levels. Keep headings under 12 words. Use imperative mood for procedures.
 

--- a/src/components/PromptBlock.tsx
+++ b/src/components/PromptBlock.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import LucideCheck from "~icons/lucide/check";
+import LucideClipboard from "~icons/lucide/clipboard";
+
+export function PromptBlock({ children }: { children: string }) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timeout = setTimeout(() => setCopied(false), 1000);
+    return () => clearTimeout(timeout);
+  }, [copied]);
+
+  const copy = useCallback(() => {
+    navigator.clipboard.writeText(children);
+    setCopied(true);
+  }, [children]);
+
+  return (
+    <div data-v-code-container>
+      <button
+        type="button"
+        onClick={copy}
+        className="vocs:relative vocs:w-full vocs:text-left vocs:cursor-pointer vocs:appearance-none vocs:border-0 vocs:bg-transparent vocs:p-0 vocs:m-0"
+      >
+        <pre
+          className="vocs:relative vocs:select-none"
+          data-v
+          style={{ cursor: "pointer" }}
+        >
+          <code className="language-txt">{children}</code>
+          <span
+            className="vocs:absolute vocs:right-2.5 vocs:top-1/2 vocs:-translate-y-1/2 vocs:p-1.5 vocs:rounded-md vocs:transition-colors vocs:duration-150"
+            style={{
+              color: copied
+                ? "var(--vocs-color-success, #22c55e)"
+                : "var(--vocs-color-text-secondary)",
+            }}
+            aria-hidden="true"
+          >
+            {copied ? (
+              <LucideCheck className="vocs:size-4" />
+            ) : (
+              <LucideClipboard className="vocs:size-4" />
+            )}
+          </span>
+        </pre>
+      </button>
+    </div>
+  );
+}

--- a/src/components/QuickstartPrompt.tsx
+++ b/src/components/QuickstartPrompt.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Tabs } from "@base-ui/react/tabs";
+import { PromptBlock } from "./PromptBlock";
 
 export const CLIENT_PROMPT = `Reference https://mpp.dev/quickstart/client.md
 Add mppx to my app as a client. Polyfill the global fetch to automatically 
@@ -12,22 +13,12 @@ Add mppx to my server with a /api/test route that charges $0.01 per
 request using the Tempo payment method with USDC. 
 Use the mppx CLI to test your endpoint`;
 
-function CodeBlock({ children }: { children: string }) {
-  return (
-    <div data-v-code-container>
-      <pre className="vocs:relative vocs:group/code" data-v>
-        <code className="language-txt">{children}</code>
-      </pre>
-    </div>
-  );
-}
-
 export function ClientPrompt() {
-  return <CodeBlock>{CLIENT_PROMPT}</CodeBlock>;
+  return <PromptBlock>{CLIENT_PROMPT}</PromptBlock>;
 }
 
 export function ServerPrompt() {
-  return <CodeBlock>{SERVER_PROMPT}</CodeBlock>;
+  return <PromptBlock>{SERVER_PROMPT}</PromptBlock>;
 }
 
 export function QuickstartPrompts() {
@@ -46,14 +37,14 @@ export function QuickstartPrompts() {
         </Tabs.Tab>
       </Tabs.List>
       <Tabs.Panel
-        className="vocs:*:rounded-t-none vocs:*:border-t-0"
+        className="vocs:*:rounded-t-none vocs:*:border-t-0 vocs:*:my-0"
         data-v-code-group-panel
         value="client"
       >
         <ClientPrompt />
       </Tabs.Panel>
       <Tabs.Panel
-        className="vocs:*:rounded-t-none vocs:*:border-t-0"
+        className="vocs:*:rounded-t-none vocs:*:border-t-0 vocs:*:my-0"
         data-v-code-group-panel
         value="server"
       >

--- a/src/pages/guides/one-time-payments.mdx
+++ b/src/pages/guides/one-time-payments.mdx
@@ -1,6 +1,7 @@
 import { Cards, Tabs, Tab } from 'vocs'
 import { PayAsYouGoCard, ServerQuickstartCard, PrestoCliCard } from '../../components/cards'
 import * as Cli from '../../components/Cli'
+import { PromptBlock } from '../../components/PromptBlock'
 import { pathUsd } from '../../wagmi.config'
 
 # Accept one-time payments [Charge per request with a payment-gated API]
@@ -22,15 +23,15 @@ Try the live payment-gated image generation API running in this command line int
 
 ## Prompt mode
 
-Paste this into your AI coding agent to build the entire guide in one shot:
+Paste this into your coding agent to build the entire guide in one shot:
 
-```txt
-Use https://mpp.dev/guides/one-time-payments.md as reference.
+<PromptBlock>
+{`Use https://mpp.dev/guides/one-time-payments.md as reference.
 Add mppx to my app with a payment-gated photo endpoint 
 that charges $0.01 per request using the Tempo payment method with 
 PathUSD. When payment is verified, fetch a random photo from 
-https://picsum.photos/1024/1024 and return the URL as JSON.
-```
+https://picsum.photos/1024/1024 and return the URL as JSON.`}
+</PromptBlock>
 
 ## Manual mode
 

--- a/src/pages/guides/pay-as-you-go.mdx
+++ b/src/pages/guides/pay-as-you-go.mdx
@@ -1,6 +1,7 @@
 import { Cards, Tabs, Tab } from 'vocs'
 import { OneTimePaymentsCard, ServerQuickstartCard, PrestoCliCard } from '../../components/cards'
 import * as Cli from '../../components/Cli'
+import { PromptBlock } from '../../components/PromptBlock'
 import { pathUsd } from '../../wagmi.config'
 
 # Accept pay-as-you-go payments [Session-based billing with payment channels]
@@ -27,15 +28,15 @@ Try the live payment-gated photo gallery API running in this command line interf
 
 ## Prompt mode
 
-Paste this into your AI coding agent to build the entire guide in one shot:
+Paste this into your coding agent to build the entire guide in one shot:
 
-```txt
-Use https://mpp.dev/guides/pay-as-you-go.md as reference.
+<PromptBlock>
+{`Use https://mpp.dev/guides/pay-as-you-go.md as reference.
 Add mppx to my app with a payment-gated gallery endpoint
 that charges $0.01 per photo using the Tempo session payment method with
 PathUSD. When payment is verified, fetch a random photo from
-https://picsum.photos/200/200 and return the URL as JSON.
-```
+https://picsum.photos/200/200 and return the URL as JSON.`}
+</PromptBlock>
 
 ## Manual mode
 

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -1,6 +1,7 @@
 import { Cards, Tabs, Tab } from 'vocs'
 import { OneTimePaymentsCard, PayAsYouGoCard, PrestoCliCard } from '../../components/cards'
 import * as Cli from '../../components/Cli'
+import { PromptBlock } from '../../components/PromptBlock'
 import { pathUsd } from '../../wagmi.config'
 
 # Accept streamed payments [Per-token billing over Server-Sent Events]
@@ -24,14 +25,14 @@ Try the live payment-gated poetry API running in this command line interface.
 
 ## Prompt mode
 
-Paste this into your AI coding agent to build the entire guide in one shot:
+Paste this into your coding agent to build the entire guide in one shot:
 
-```txt
-Use https://mpp.dev/guides/streamed-payments.md as reference.
+<PromptBlock>
+{`Use https://mpp.dev/guides/streamed-payments.md as reference.
 Add mppx to my app with a payment-gated SSE endpoint
 that streams text word-by-word and charges $0.001 per word using the
-Tempo session payment method with PathUSD and sse: true.
-```
+Tempo session payment method with PathUSD and sse: true.`}
+</PromptBlock>
 
 ## Manual mode
 

--- a/src/pages/quickstart/client.mdx
+++ b/src/pages/quickstart/client.mdx
@@ -13,7 +13,7 @@ Polyfill the global `fetch` to handle `402` responses. Your existing code works 
 
 ## Prompt mode
 
-Paste this into your AI coding agent to set up your client with `mppx` in one shot:
+Paste this into your coding agent to set up your client with `mppx` in one shot:
 
 <ClientPrompt />
 

--- a/src/pages/quickstart/index.mdx
+++ b/src/pages/quickstart/index.mdx
@@ -8,7 +8,7 @@ MPP lets APIs charge for access. Servers request payment when you hit a paid end
 
 ## Start prompting
 
-Paste one of these into your AI coding agent to build your first MPP app or service:
+Paste one of these into your coding agent to build your first MPP app or service:
 
 <QuickstartPrompts />
 

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -8,13 +8,13 @@ import { ClientQuickstartCard, TempoMethodCard, MppxCreateReferenceCard } from '
 
 This quickstart demonstrates how to plug MPP into any server framework to accept payments for protected resources. Pick the path that suits you:
 
-- [**Prompt mode**](#prompt-mode): paste a prompt into your AI coding agent and one shot
+- [**Prompt mode**](#prompt-mode): paste a prompt into your coding agent and one shot
 - [**Framework mode**](#framework-mode): use `mppx` middleware for Next.js, Hono, Elysia, or Express
 - [**Manual mode**](#manual-mode): call `mppx/server` directly with the Fetch API
 
 ## Prompt mode
 
-Paste this into your AI coding agent to set up a server with `mppx` in one shot:
+Paste this into your coding agent to set up a server with `mppx` in one shot:
 
 <ServerPrompt />
 


### PR DESCRIPTION
## Changes

- **New `PromptBlock` component**: entire block is clickable to copy prompt text, clipboard icon always visible and vertically centered, text is not selectable
- **Guide pages** (pay-as-you-go, streamed-payments, one-time-payments): replaced markdown ```txt``` code blocks with `<PromptBlock>`
- **QuickstartPrompt**: simplified to use shared `PromptBlock` instead of its own `CodeBlock`/`CopyButton`
- **Terminology**: renamed "AI coding agent" → "coding agent" across all pages
- **Style guide**: added "coding agent" rule to the Avoid list in `AGENTS.md`