### PR TITLE
docs: update landing page tagline copy

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -216,7 +216,7 @@ function Tagline() {
     >
       <div>
         The open protocol for internet-native payments. Charge for API requests,
-        tool calls, or content. Agents, apps, and humans securely pay per
+        tool calls, or access to content. Agents, apps, and humans securely pay per
         request.
       </div>
     </div>


### PR DESCRIPTION
Changed "or content" to "or access to content" in the homepage tagline.

Prompted by: brendan