### PR TITLE
fix: update hero quickstart link to /quickstart/server

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -177,7 +177,7 @@ function Hero() {
             Use with your agent
           </Link>
           <Link
-            to="/quickstart"
+            to="/quickstart/server"
             className="no-underline! px-6 py-3 rounded-lg transition-opacity hover:opacity-80"
             style={{
               fontSize: "1rem",


### PR DESCRIPTION
Updates the hero "Get started" link from `/quickstart` to `/quickstart/server`.