### PR TITLE
fix: update CTA copy to 'Monetize your service'

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -188,12 +188,12 @@ function Hero() {
             }}
             onClick={() =>
               captureEvent(AnalyticsEvents.LANDING_CTA_CLICKED, {
-                cta_label: "Install on your server",
+                cta_label: "Monetize your service",
                 href: "/quickstart/server",
               })
             }
           >
-            Install on your server
+            Monetize your service
           </Link>
         </div>
 


### PR DESCRIPTION
Changes landing page CTA from "Install on your server" to "Monetize your service" — better communicates the value prop.

Prompted by: Brendan