### PR TITLE
fix: remove SDKs tab from top nav

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -476,7 +476,6 @@ export default defineConfig({
   topNav: [
     { text: "Docs", link: "/overview", match: (path) => path !== "/" },
     { text: "Services", link: "/services" },
-    { text: "SDKs", link: "/sdk" },
     { text: "IETF Specs", link: "https://tempoxyz.github.io/mpp-specs/" },
     {
       text: "GitHub",


### PR DESCRIPTION
Removes the SDKs link from the top navigation bar. SDK pages and sidebar remain accessible via the docs sidebar.