### PR TITLE
fix: reorder card buttons — [use link] before [use test card]

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1210,17 +1210,17 @@ function CardForm({
               type="button"
               onClick={applyTestCard}
               className="cursor-pointer hover:underline"
-              style={{ color: "#635BFF" }}
+              style={{ color: "#00D66F" }}
             >
-              [use test card]
+              [use link]
             </button>{" "}
             <button
               type="button"
               onClick={applyTestCard}
               className="cursor-pointer hover:underline"
-              style={{ color: "#00D66F" }}
+              style={{ color: "#635BFF" }}
             >
-              [use link]
+              [use test card]
             </button>
           </>
         ) : (


### PR DESCRIPTION
Swaps the order of the card input shortcut buttons so `[use link]` appears first.