### PR TITLE
Make AgentMail a first-party integration

### DIFF
--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -11,7 +11,7 @@
         "ai",
         "social"
       ],
-      "integration": "third-party",
+      "integration": "first-party",
       "tags": [
         "email",
         "inbox",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -118,10 +118,10 @@ export const services: ServiceDef[] = [
     description:
       "Email inboxes for AI agents — create, send, receive, and manage email programmatically.",
     categories: ["ai", "social"],
-    integration: "third-party",
+    integration: "first-party",
     tags: ["email", "inbox", "agents", "messaging"],
     docs: {
-      homepage: "https://docs.agentmail.to",
+    	homepage: "https://docs.agentmail.to",
       llmsTxt: "https://docs.agentmail.to/llms.txt",
     },
     provider: { name: "AgentMail", url: "https://agentmail.to" },


### PR DESCRIPTION
Changes AgentMail from `third-party` to `first-party` in the service registry and regenerates discovery.json.