### PR TITLE
docs: add push/pull charge mode guide and references

### DIFF
--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -203,6 +203,66 @@ export async function handler(req: IncomingMessage, res: ServerResponse) {
 ```
 
 
+## Push & pull modes
+
+Tempo charges support two transaction submission modes, determined by the client:
+
+- **`pull` mode (default)**: the client signs the transaction and sends the serialized transaction to the server. The server broadcasts it and verifies on-chain. This enables the server to sponsor gas fees via a `feePayer`.
+- **`push` mode**: the client builds, signs, and broadcasts the transaction itself (for example, via a browser wallet). It sends the transaction hash to the server, which verifies the payment by fetching the receipt.
+
+Your server handles both modes automatically – no configuration required. The server inspects the credential payload type (`transaction` for pull, `hash` for push) and verifies accordingly.
+
+If you would like to force a specific mode, you can set the `mode` parameter to `'pull'` or `'push'`.
+
+```ts
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    currency: '0x20c0000000000000000000000000000000000000',
+    mode: 'push', // [!code focus]
+    recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
+  })],
+})
+```
+
+### Fee sponsorship
+
+To sponsor gas fees for pull-mode clients, pass a `feePayer` account to `tempo()`:
+
+```ts
+import { Mppx, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    currency: '0x20c0000000000000000000000000000000000000',
+    feePayer: privateKeyToAccount('0x…'), // [!code focus]
+    recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
+  })],
+})
+```
+
+When a pull-mode client submits a signed transaction, the server co-signs with the fee payer account before broadcasting. Push-mode clients pay their own gas, so `feePayer` is ignored for those requests.
+
+### Optimistic verification
+
+By default, the server waits for onchain confirmation before returning a Receipt. For lower latency, set `waitForConfirmation: false` to return immediately after simulation:
+
+```ts
+const mppx = Mppx.create({
+  methods: [tempo({
+    currency: '0x20c0000000000000000000000000000000000000',
+    recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
+    waitForConfirmation: false, // [!code focus]
+  })],
+})
+```
+
+:::warning
+Optimistic verification simulates the transaction but does not wait for inclusion. If the transaction reverts onchain after broadcast, the Receipt does not reflect the failure. Only use this when latency matters more than guaranteed confirmation.
+:::
+
 ## Testing your server
 
 After your server is running, test it with the `mppx` CLI:

--- a/src/pages/sdk/typescript/client/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.charge.mdx
@@ -75,3 +75,23 @@ Client identifier used to derive the client fingerprint in attribution memos.
 - **Type:** `(parameters: { chainId: number }) => MaybePromise<Client>`
 
 Function that returns a viem client for the given chain ID.
+
+### mode (optional)
+
+- **Type:** `'push' | 'pull'`
+- **Default:** `'push'` for JSON-RPC accounts, `'pull'` for local accounts
+
+Controls how the charge transaction is submitted.
+
+- `'push'`: the client broadcasts the transaction and sends the transaction hash to the server for verification.
+- `'pull'`: the client signs the transaction and sends the serialized transaction to the server, which broadcasts it. This is required for server-side [fee sponsorship](/quickstart/server#fee-sponsorship).
+
+```ts
+import { tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const method = tempo.charge({
+  account: privateKeyToAccount('0xabc…123'),
+  mode: 'pull', // [!code focus]
+})
+```

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -121,6 +121,23 @@ On-chain memo for the transaction.
 
 Testnet mode. Defaults the chain ID to `42431` (Tempo testnet).
 
+### waitForConfirmation (optional)
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to wait for the charge transaction to confirm on-chain before responding. When `false`, the transaction is simulated via `eth_estimateGas` and broadcast without waiting for inclusion. The Receipt optimistically reports `status: 'success'` based on simulation alone.
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [tempo.charge({
+    waitForConfirmation: false, // [!code focus]
+  })],
+})
+```
+
 ## Request parameters
 
 ### amount


### PR DESCRIPTION
Documents push and pull transaction submission modes for Tempo charges.

### Changes

- **Server quickstart**: new "Push vs. pull mode" section explaining both modes, fee sponsorship with `feePayer`, and optimistic verification with `waitForConfirmation: false`
- **Client `tempo.charge` reference**: document `mode` parameter (`'push' | 'pull'`)
- **Server `tempo.charge` reference**: document `waitForConfirmation` parameter