### PR TITLE
docs: add Stripe method reference pages to SDK sidebar

### DIFF
--- a/src/pages/sdk/typescript/client/Method.stripe.charge.mdx
+++ b/src/pages/sdk/typescript/client/Method.stripe.charge.mdx
@@ -1,0 +1,101 @@
+# `Method.stripe.charge` [One-time payments via Shared Payment Tokens]
+
+Creates a Stripe charge payment method for client-side SPT-based payments.
+
+## Usage
+
+```ts twoslash
+// @noErrors
+import { loadStripe } from '@stripe/stripe-js'
+import { Mppx, stripe } from 'mppx/client'
+
+const stripeJs = (await loadStripe('pk_test_...'))!
+
+Mppx.create({
+  methods: [
+    // [!code focus:start]
+    stripe.charge({
+      client: stripeJs,
+      createToken: async ({ amount, currency, expiresAt, metadata, networkId, paymentMethod }) => {
+        const res = await fetch('/api/create-spt', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ paymentMethod, amount, currency, networkId, expiresAt, metadata }),
+        })
+        return (await res.json()).spt
+      },
+    }),
+    // [!code focus:end]
+  ],
+})
+```
+
+## Return type
+
+```ts
+import type { Method } from 'mppx'
+
+type ReturnType = Method.Client
+```
+
+## Parameters
+
+### client (optional)
+
+- **Type:** `StripeJs`
+
+Stripe.js instance from `@stripe/stripe-js`. Forwarded to the `createToken` callback for use with Stripe Elements.
+
+```ts twoslash
+// @noErrors
+import { loadStripe } from '@stripe/stripe-js'
+import { stripe } from 'mppx/client'
+
+const stripeJs = (await loadStripe('pk_test_...'))!
+
+const method = stripe.charge({
+  client: stripeJs, // [!code focus]
+  createToken: async (params) => '...',
+})
+```
+
+### createToken
+
+- **Type:** `(params: OnChallengeParameters) => Promise<string>`
+
+Callback invoked when a Stripe challenge is received. Must return an SPT token string (`spt_...`). Typically proxied through a server endpoint since SPT creation requires a Stripe secret key.
+
+The callback receives:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `amount` | `string` | Payment amount in smallest currency unit |
+| `challenge` | `Challenge` | The parsed Challenge from the server |
+| `client` | `StripeJs \| undefined` | Stripe.js instance, if provided |
+| `currency` | `string` | Three-letter ISO currency code |
+| `expiresAt` | `number` | SPT expiration as a Unix timestamp (seconds) |
+| `metadata` | `Record<string, string>` | Optional metadata from the Challenge |
+| `networkId` | `string \| undefined` | Stripe Business Network profile ID |
+| `paymentMethod` | `string \| undefined` | Stripe payment method ID |
+
+### externalId (optional)
+
+- **Type:** `string`
+
+Client reference ID included in the Credential payload.
+
+### paymentMethod (optional)
+
+- **Type:** `string`
+
+Default Stripe payment method ID (e.g. `pm_card_visa`). Overridden by `context.paymentMethod` at credential-creation time.
+
+```ts twoslash
+// @noErrors
+import { stripe } from 'mppx/client'
+
+const method = stripe.charge({
+  createToken: async (params) => '...',
+  paymentMethod: 'pm_card_visa', // [!code focus]
+})
+```

--- a/src/pages/sdk/typescript/client/Method.stripe.mdx
+++ b/src/pages/sdk/typescript/client/Method.stripe.mdx
@@ -1,0 +1,44 @@
+# `stripe` [Register all Stripe intents]
+
+Convenience function that creates the Stripe `charge` method intent.
+
+## Usage
+
+```ts twoslash
+// @noErrors
+import { loadStripe } from '@stripe/stripe-js'
+import { Mppx, stripe } from 'mppx/client'
+
+const stripeJs = (await loadStripe('pk_test_...'))!
+
+Mppx.create({
+  methods: [
+    // [!code focus:start]
+    stripe({
+      client: stripeJs,
+      createToken: async (params) => {
+        const res = await fetch('/api/create-spt', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(params),
+        })
+        return (await res.json()).spt
+      },
+      paymentMethod: 'pm_card_visa',
+    }),
+    // [!code focus:end]
+  ],
+})
+```
+
+## Return type
+
+```ts
+import type { Method } from 'mppx'
+
+type ReturnType = Method.Client
+```
+
+## Parameters
+
+See [`stripe.charge`](/sdk/typescript/client/Method.stripe.charge) for the full parameter list.

--- a/src/pages/sdk/typescript/server/Method.stripe.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.stripe.charge.mdx
@@ -1,0 +1,130 @@
+# `Method.stripe.charge` [One-time payments via Shared Payment Tokens]
+
+The `charge` intent for the Stripe payment method. Requests a one-time payment using [Shared Payment Tokens (SPTs)](https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens).
+
+## Usage
+
+```ts twoslash
+// @noErrors
+import Stripe from 'stripe'
+import { Mppx, stripe } from 'mppx/server'
+
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
+
+const mppx = Mppx.create({
+  methods: [stripe.charge({
+    client: stripeClient,
+    networkId: 'internal',
+    paymentMethodTypes: ['card'],
+  })],
+})
+
+export async function handler(request: Request) {
+  // [!code focus:start]
+  const response = await mppx.charge({
+    amount: '1',
+    currency: 'usd',
+    decimals: 2,
+    description: 'Premium API access',
+  })(request)
+  // [!code focus:end]
+
+  if (response.status === 402) return response.challenge
+  return response.withReceipt(Response.json({ data: '...' }))
+}
+```
+
+## Return type
+
+Returns a function that accepts a `Request` and returns a response object with payment status.
+
+```ts
+type ReturnType = (request: Request) => Promise<
+  | { status: 402; challenge: Response }
+  | { status: 200; withReceipt: <T>(response: T) => T }
+>
+```
+
+## Configuration
+
+These parameters configure the `stripe.charge()` constructor. You must provide either `client` or `secretKey`.
+
+### client
+
+- **Type:** `StripeClient`
+
+Pre-configured Stripe SDK instance. Any object matching the duck-typed `StripeClient` shape works. Using `client` is recommended — it lets you configure retries, API version, and other options.
+
+```ts twoslash
+// @noErrors
+import Stripe from 'stripe'
+import { stripe } from 'mppx/server'
+
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
+
+const method = stripe.charge({
+  client: stripeClient, // [!code focus]
+  networkId: 'internal',
+  paymentMethodTypes: ['card'],
+})
+```
+
+### secretKey
+
+- **Type:** `string`
+
+Stripe secret API key. When provided instead of `client`, mppx makes raw API calls to Stripe.
+
+```ts twoslash
+import { stripe } from 'mppx/server'
+
+const method = stripe.charge({
+  secretKey: process.env.STRIPE_SECRET_KEY!, // [!code focus]
+  networkId: 'internal',
+  paymentMethodTypes: ['card'],
+})
+```
+
+### networkId
+
+- **Type:** `string`
+
+Stripe [Business Network](https://docs.stripe.com/get-started/account/profile) profile ID.
+
+### paymentMethodTypes
+
+- **Type:** `string[]`
+
+Allowed Stripe payment method types (e.g. `['card']`, `['card', 'link']`).
+
+### metadata (optional)
+
+- **Type:** `Record<string, string>`
+
+Key-value pairs forwarded to Stripe. Appears in the Challenge and attaches to the Stripe `PaymentIntent`.
+
+## Request parameters
+
+### amount
+
+- **Type:** `string`
+
+Payment amount in human-readable units.
+
+### currency
+
+- **Type:** `string`
+
+ISO currency code (e.g. `'usd'`).
+
+### decimals
+
+- **Type:** `number`
+
+Number of decimal places in the amount (e.g. `2` for cents).
+
+### description (optional)
+
+- **Type:** `string`
+
+Human-readable description of the payment request.

--- a/src/pages/sdk/typescript/server/Method.stripe.mdx
+++ b/src/pages/sdk/typescript/server/Method.stripe.mdx
@@ -1,0 +1,37 @@
+# `stripe` [Register all Stripe intents]
+
+Convenience function that creates the Stripe `charge` method intent.
+
+## Usage
+
+```ts twoslash
+// @noErrors
+import Stripe from 'stripe'
+import { Mppx, stripe } from 'mppx/server'
+
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
+
+Mppx.create({
+  methods: [
+    // [!code focus:start]
+    stripe({
+      client: stripeClient,
+      networkId: 'internal',
+      paymentMethodTypes: ['card'],
+    }),
+    // [!code focus:end]
+  ],
+})
+```
+
+## Return type
+
+```ts
+import type { Method } from 'mppx'
+
+type ReturnType = Method.Server
+```
+
+## Parameters
+
+See [`stripe.charge`](/sdk/typescript/server/Method.stripe.charge) for the full parameter list.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -188,6 +188,14 @@ export default defineConfig({
                         text: "tempo.session",
                         link: "/sdk/typescript/client/Method.tempo.session",
                       },
+                      {
+                        text: "stripe",
+                        link: "/sdk/typescript/client/Method.stripe",
+                      },
+                      {
+                        text: "stripe.charge",
+                        link: "/sdk/typescript/client/Method.stripe.charge",
+                      },
                     ],
                   },
                   {
@@ -242,6 +250,14 @@ export default defineConfig({
                       {
                         text: "tempo.session",
                         link: "/sdk/typescript/server/Method.tempo.session",
+                      },
+                      {
+                        text: "stripe",
+                        link: "/sdk/typescript/server/Method.stripe",
+                      },
+                      {
+                        text: "stripe.charge",
+                        link: "/sdk/typescript/server/Method.stripe.charge",
                       },
                     ],
                   },


### PR DESCRIPTION
Adds Stripe method reference pages to the SDK sidebar, matching the existing tempo method pattern:

- **Client**: `stripe`, `stripe.charge` — SPT-based payment with `createToken` callback and Stripe.js support
- **Server**: `stripe`, `stripe.charge` — PaymentIntent creation via `client` (Stripe SDK) or `secretKey`

Follow-up to #275.