### PR TITLE
fix: allow esbuild postinstall script in pnpm strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
   "engines": {
     "node": ">=24"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  },
   "simple-git-hooks": {
     "pre-commit": "pnpm check"
   }


### PR DESCRIPTION
Fixes Vercel production deployment failure. pnpm 10 blocks postinstall scripts by default — esbuild needs its postinstall to download the platform-specific binary. Adding `pnpm.onlyBuiltDependencies` allowlist.