### PR TITLE
fix: remove stale node shim from Vercel build cache

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "rm -rf node_modules/.bin/node && pnpm install",
   "redirects": [
     {
       "source": "/:path(.*)",


### PR DESCRIPTION
Vercel's build cache retains a broken `node_modules/.bin/node` shim from a previous deployment. When esbuild's postinstall tries to run, it uses this stale shim instead of the system node, causing `/vercel/path0/node_modules/.bin/../node/bin/node: No such file or directory`.

Fix: remove the stale shim before `pnpm install` via a custom install command. This can be removed once Vercel's cache is clean.