### PR TITLE
fix: use pinned service ordering on discovery homepage

### DIFF
--- a/src/components/ServiceDiscovery.tsx
+++ b/src/components/ServiceDiscovery.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { Category, Endpoint, Service } from "../data/registry";
 import { fetchServices } from "../data/registry";
+import { PINNED_IDS } from "./ServicesPage";
 
 const CATEGORY_LABELS: Record<Category, string> = {
   ai: "AI",
@@ -193,7 +194,14 @@ export function ServiceDiscovery() {
 
   useEffect(() => {
     fetchServices()
-      .then((s) => setServices(shuffle(s)))
+      .then((data) => {
+        const pinnedSet = new Set(PINNED_IDS);
+        const pinned = PINNED_IDS.flatMap((id) =>
+          data.filter((s) => s.id === id),
+        );
+        const rest = shuffle(data.filter((s) => !pinnedSet.has(s.id)));
+        setServices([...pinned, ...rest]);
+      })
       .catch(() => {});
   }, []);
 

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -22,7 +22,7 @@ const URL_COLOR = "light-dark(rgba(0,0,0,0.7), rgba(255,255,255,0.7))";
 const CMD_PURPLE = "light-dark(#7c3aed, #c084fc)";
 const CMD_GREEN = "light-dark(#15803d, #4ade80)";
 
-const PINNED_IDS: string[] = [
+export const PINNED_IDS: string[] = [
   "openai",
   "anthropic",
   "google-gemini",


### PR DESCRIPTION
Pins the same services (OpenAI, Anthropic, Gemini, Parallel, OpenRouter, StableTravel, Code Storage, Browserbase) to the top of the homepage card grid, matching the /services page ordering. Remaining services are still shuffled.

- Exports `PINNED_IDS` from `ServicesPage.tsx` and reuses it in `ServiceDiscovery.tsx`
- Replaces pure `shuffle()` with pinned-first + shuffled-rest ordering