### PR TITLE
fix: remove scroll snap and scroll takeovers on landing page

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -38,20 +38,6 @@ const AgentContext = createContext<{
 export function LandingPage() {
   const [activeAgent, setActiveAgent] = useState(0);
   useEffect(() => {
-    const handleVisibility = () => {
-      if (document.visibilityState === "visible") {
-        const el = document.querySelector(".landing-page") as HTMLElement;
-        if (el) {
-          el.scrollTo({ top: 0 });
-        }
-      }
-    };
-    document.addEventListener("visibilitychange", handleVisibility);
-    return () =>
-      document.removeEventListener("visibilitychange", handleVisibility);
-  }, []);
-
-  useEffect(() => {
     const logoLink = document.querySelector(
       "[data-v-logo] a",
     ) as HTMLAnchorElement;
@@ -387,9 +373,8 @@ function LandingStyles() {
         .landing-terminal { padding-left: 1.5rem; padding-right: 1.5rem; }
       }
 
-      /* ---- Mobile: three snap sections ---- */
+      /* ---- Mobile: three sections ---- */
       @media (max-width: 767px) {
-        .landing-page { scroll-snap-type: y mandatory !important; }
 
         /* Force gradient nav background — must beat the global background-color rule */
         :has(.landing-page) [data-v-gutter-top] {

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -26,11 +26,7 @@ function MobileNav() {
     const el = document.querySelector(".landing-page") as HTMLElement;
     if (el) {
       window.dispatchEvent(new CustomEvent("mpp:reset-discovery"));
-      el.style.scrollSnapType = "none";
       el.scrollTo({ top: 0, behavior: "smooth" });
-      setTimeout(() => {
-        el.style.scrollSnapType = "";
-      }, 600);
     } else {
       window.location.href = "/";
       return;


### PR DESCRIPTION
Fixes the issue where loading mpp.dev sometimes snaps to the bottom of the page.

### Changes

- **Remove `scroll-snap-type: y mandatory`** on mobile — no `scroll-snap-align` was set on children, so the browser snapped to arbitrary elements (often the bottom)
- **Remove `visibilitychange` handler** that forced `scrollTo({ top: 0 })` every time you tabbed back
- **Clean up `scrollSnapType` JS manipulation** in mobile nav logo click (no longer needed)

### Testing

- `pnpm check:types` ✅
- `pnpm build` ✅