### PR TITLE
fix: detect untracked generated icons in CI freshness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
             echo "::error::Generated files are out of date. Run 'node scripts/generate-discovery.ts && node scripts/gen-icons.cjs' and commit the result."
             exit 1
           fi
+          UNTRACKED=$(git ls-files --others --exclude-standard schemas/ public/icons/)
+          if [ -n "$UNTRACKED" ]; then
+            echo "::error::Untracked generated files found. Commit these files:${UNTRACKED}"
+            exit 1
+          fi
 
   lint:
     name: Lint


### PR DESCRIPTION
The generated-files check only used `git diff --exit-code`, which doesn't catch new untracked files. CI could pass even when `gen-icons.cjs` creates a new SVG that was never committed, resulting in missing icons at runtime.

Adds a `git ls-files --others --exclude-standard` check for `schemas/` and `public/icons/` after the existing diff check.