### PR TITLE
fix(docs): remove invalid `prompt` subcommand from claude example

### DIFF
--- a/src/pages/quickstart/agent.mdx
+++ b/src/pages/quickstart/agent.mdx
@@ -26,7 +26,7 @@ You can discover what services are available by prompting your agent.
 ::::code-group
 
 ```bash [Claude]
-claude prompt "What image generation services can I use with Tempo Wallet?"
+claude "What image generation services can I use with Tempo Wallet?"
 ```
 
 ```bash [Amp]


### PR DESCRIPTION
\`claude prompt\` is not a valid subcommand. The correct usage is \`claude "query"\` which starts an interactive session with an initial prompt, consistent with the other claude example on the same page.