### PR TITLE
fix: remove all `// @noErrors` from twoslash blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@base-ui/react": "^1.1.0",
     "@fontsource/commit-mono": "^5.2.5",
+    "@stripe/stripe-js": "^8.9.0",
     "@vercel/blob": "^2.3.1",
     "class-variance-authority": "^0.7.1",
     "form-data": "^4.0.5",
@@ -28,6 +29,7 @@
     "mppx": "~0.3.16",
     "react": "^19",
     "react-dom": "^19",
+    "stripe": "^20.4.1",
     "tailwindcss": "^4.1.18",
     "viem": "^2.46.2",
     "vocs": "https://pkg.pr.new/wevm/vocs@3426e73",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@fontsource/commit-mono':
         specifier: ^5.2.5
         version: 5.2.5
+      '@stripe/stripe-js':
+        specifier: ^8.9.0
+        version: 8.9.0
       '@vercel/blob':
         specifier: ^2.3.1
         version: 2.3.1
@@ -38,6 +41,9 @@ importers:
       react-dom:
         specifier: ^19
         version: 19.2.4(react@19.2.4)
+      stripe:
+        specifier: ^20.4.1
+        version: 20.4.1(@types/node@22.19.11)
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -1082,6 +1088,10 @@ packages:
 
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
+
+  '@stripe/stripe-js@8.9.0':
+    resolution: {integrity: sha512-OJkXvUI5GAc56QdiSRimQDvWYEqn475J+oj8RzRtFTCPtkJNO2TWW619oDY+nn1ExR+2tCVTQuRQBbR4dRugww==}
+    engines: {node: '>=12.16'}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -3706,6 +3716,15 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  stripe@20.4.1:
+    resolution: {integrity: sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@types/node': '>=16'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
@@ -5183,6 +5202,8 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@stitches/core@1.2.8': {}
+
+  '@stripe/stripe-js@8.9.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
@@ -8334,6 +8355,10 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  stripe@20.4.1(@types/node@22.19.11):
+    optionalDependencies:
+      '@types/node': 22.19.11
 
   style-mod@4.1.3: {}
 

--- a/src/pages/payment-methods/stripe/charge.mdx
+++ b/src/pages/payment-methods/stripe/charge.mdx
@@ -18,7 +18,7 @@ You can provide either a `client` (a pre-configured Stripe SDK instance) or a ra
 ### With Stripe SDK client (recommended)
 
 ```ts twoslash
-// @noErrors
+
 import Stripe from 'stripe'
 import { Mppx, stripe } from 'mppx/server'
 
@@ -71,7 +71,7 @@ const mppx = Mppx.create({
 Include `metadata` in the `stripe.charge` configuration to forward key-value pairs to Stripe. The metadata appears in the Challenge and attaches to the Stripe `PaymentIntent`.
 
 ```ts twoslash
-// @noErrors
+
 import Stripe from 'stripe'
 import { Mppx, stripe } from 'mppx/server'
 
@@ -106,7 +106,7 @@ export async function handler(request: Request) {
 Allow multiple payment methods, like cards and Link, by specifying them in `paymentMethodTypes`.
 
 ```ts twoslash
-// @noErrors
+
 import Stripe from 'stripe'
 import { Mppx, stripe } from 'mppx/server'
 
@@ -144,7 +144,7 @@ SPT creation requires a Stripe secret key, so the client accepts a `createToken`
 If you already have a payment method ID (e.g. a test card or a stored method), pass it as `paymentMethod` and mppx handles the full 402 → SPT → retry flow automatically.
 
 ```ts twoslash
-// @noErrors
+
 import { loadStripe } from '@stripe/stripe-js'
 import { Mppx, stripe } from 'mppx/client'
 
@@ -178,7 +178,7 @@ const response = await fetch('https://api.example.com/resource')
 For interactive payment collection, use `onChallenge` to render Stripe Elements when a 402 is received. The user enters card details, you create a payment method, then pass it to `createCredential`.
 
 ```ts twoslash
-// @noErrors
+
 import { loadStripe } from '@stripe/stripe-js'
 import { Receipt } from 'mppx'
 import { Mppx, stripe } from 'mppx/client'
@@ -282,7 +282,7 @@ const paid = await fetch('/api/resource', {
 If you don't want to patch `globalThis.fetch`, use `mppx.fetch` directly:
 
 ```ts twoslash
-// @noErrors
+
 import { loadStripe } from '@stripe/stripe-js'
 import { Mppx, stripe } from 'mppx/client'
 

--- a/src/pages/quickstart/client.mdx
+++ b/src/pages/quickstart/client.mdx
@@ -94,28 +94,38 @@ You can inject a [Wagmi](https://wagmi.sh) connector into Mppx by passing the `g
 :::code-group
 
 ```ts twoslash [example.ts]
-// @noErrors
-import { Mppx, tempo } from 'mppx/client'
+import { createConfig, http } from 'wagmi'
 import { getConnectorClient } from 'wagmi/actions'
-import { config } from './config'
+import { tempoModerato } from 'viem/chains'
+import { Mppx, tempo } from 'mppx/client'
+
+declare const connectors: Parameters<typeof createConfig>[0]['connectors']
+// ---cut---
+const config = createConfig({
+  connectors,
+  chains: [tempoModerato],
+  transports: {
+    [tempoModerato.id]: http(),
+  },
+})
 
 Mppx.create({
   methods: [tempo({
-    getClient: (parameters) => getConnectorClient(config, parameters), // 
+    getClient: (parameters) =>
+      getConnectorClient(config, parameters as any),
   })],
 })
-
-const response = await fetch(`https://mpp.dev/api/ping/${address}`)
 ```
 
-```ts twoslash [config.ts] filename="wagmi.config.ts"
-// @noErrors
+```ts twoslash [config.ts]
 import { createConfig, http } from 'wagmi'
-import { webAuthn } from 'wagmi/tempo'
+import { webAuthn, KeyManager } from 'wagmi/tempo'
 import { tempoModerato } from 'viem/chains'
 
+declare const keyManager: KeyManager.KeyManager
+// ---cut---
 export const config = createConfig({
-  connectors: [webAuthn()],
+  connectors: [webAuthn({ keyManager })],
   chains: [tempoModerato],
   transports: {
     [tempoModerato.id]: http(),

--- a/src/pages/sdk/typescript/client/Method.stripe.charge.mdx
+++ b/src/pages/sdk/typescript/client/Method.stripe.charge.mdx
@@ -5,7 +5,7 @@ Creates a Stripe charge payment method for client-side SPT-based payments.
 ## Usage
 
 ```ts twoslash
-// @noErrors
+
 import { loadStripe } from '@stripe/stripe-js'
 import { Mppx, stripe } from 'mppx/client'
 
@@ -47,7 +47,7 @@ type ReturnType = Method.Client
 Stripe.js instance from `@stripe/stripe-js`. Forwarded to the `createToken` callback for use with Stripe Elements.
 
 ```ts twoslash
-// @noErrors
+
 import { loadStripe } from '@stripe/stripe-js'
 import { stripe } from 'mppx/client'
 
@@ -91,7 +91,7 @@ Client reference ID included in the Credential payload.
 Default Stripe payment method ID (e.g. `pm_card_visa`). Overridden by `context.paymentMethod` at credential-creation time.
 
 ```ts twoslash
-// @noErrors
+
 import { stripe } from 'mppx/client'
 
 const method = stripe.charge({

--- a/src/pages/sdk/typescript/client/Method.stripe.mdx
+++ b/src/pages/sdk/typescript/client/Method.stripe.mdx
@@ -5,7 +5,7 @@ Convenience function that creates the Stripe `charge` method intent.
 ## Usage
 
 ```ts twoslash
-// @noErrors
+
 import { loadStripe } from '@stripe/stripe-js'
 import { Mppx, stripe } from 'mppx/client'
 

--- a/src/pages/sdk/typescript/server/Method.stripe.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.stripe.charge.mdx
@@ -5,7 +5,7 @@ The `charge` intent for the Stripe payment method. Requests a one-time payment u
 ## Usage
 
 ```ts twoslash
-// @noErrors
+
 import Stripe from 'stripe'
 import { Mppx, stripe } from 'mppx/server'
 
@@ -56,7 +56,7 @@ These parameters configure the `stripe.charge()` constructor. You must provide e
 Pre-configured Stripe SDK instance. Any object matching the duck-typed `StripeClient` shape works. Using `client` is recommended — it lets you configure retries, API version, and other options.
 
 ```ts twoslash
-// @noErrors
+
 import Stripe from 'stripe'
 import { stripe } from 'mppx/server'
 

--- a/src/pages/sdk/typescript/server/Method.stripe.mdx
+++ b/src/pages/sdk/typescript/server/Method.stripe.mdx
@@ -5,7 +5,7 @@ Convenience function that creates the Stripe `charge` method intent.
 ## Usage
 
 ```ts twoslash
-// @noErrors
+
 import Stripe from 'stripe'
 import { Mppx, stripe } from 'mppx/server'
 


### PR DESCRIPTION
All twoslash code examples now typecheck during build—no more suppressed errors.

## Changes

- **Install `stripe` and `@stripe/stripe-js`** as dependencies so Stripe code examples resolve their imports
- **Remove 16 `// @noErrors` directives** across 7 files:
  - `payment-methods/stripe/charge.mdx` (6)
  - `quickstart/client.mdx` (2)
  - `sdk/typescript/client/Method.stripe.charge.mdx` (3)
  - `sdk/typescript/client/Method.stripe.mdx` (1)
  - `sdk/typescript/server/Method.stripe.charge.mdx` (2)
  - `sdk/typescript/server/Method.stripe.mdx` (1)