### PR TITLE
Remove seller_details param in test helper

### DIFF
--- a/src/pages/payment-methods/stripe/charge.mdx
+++ b/src/pages/payment-methods/stripe/charge.mdx
@@ -323,7 +323,6 @@ export async function POST(request: Request) {
     'usage_limits[max_amount]': amount,
     'usage_limits[expires_at]': expiresAt.toString(),
   })
-  if (networkId) body.set('seller_details[network_id]', networkId)
   if (metadata) {
     for (const [key, value] of Object.entries(metadata)) {
       body.set(`metadata[${key}]`, value)


### PR DESCRIPTION
Stripe's removed the `seller_details` param in the SPT test helper; we avoid devs running into an "unrecognized param `seller_details`" here.