### PR TITLE
fix: 404 page logo swap and mobile viewport overflow

### DIFF
--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -158,7 +158,7 @@ export function NotFoundPage() {
       <div
         onMouseEnter={() => startMorph(1)}
         onMouseLeave={() => startMorph(0)}
-        className="overflow-x-auto max-w-full mb-8"
+        className="overflow-hidden max-w-full mb-8"
         style={{
           fontFamily: "monospace",
           lineHeight: 1.15,
@@ -169,7 +169,7 @@ export function NotFoundPage() {
         }}
       >
         <div
-          className="text-[4px] sm:text-[5px] md:text-[6px]"
+          className="text-[2.5px] sm:text-[4px] md:text-[5px] lg:text-[6px]"
           style={{ minWidth: "fit-content" }}
         >
           {mppLines.map((mppLine, lineIdx) => {


### PR DESCRIPTION
Two fixes for the 404 page:

1. **Logo swap** — `logo-light.svg` (white text) was the default, showing white-on-white in light mode. Swapped so `logo-dark.svg` is the default.
2. **Mobile overflow** — ASCII art caused horizontal scroll on small viewports. Changed to `overflow-hidden` and scaled font down progressively (`2.5px` → `4px` → `5px` → `6px`).