### PR TITLE
docs: update overview, terminal demo, and CLI references

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -530,12 +530,12 @@ function Hero() {
               }}
               onClick={() =>
                 captureEvent(AnalyticsEvents.LANDING_CTA_CLICKED, {
-                  cta_label: "Monetize a service",
+                  cta_label: "Monetize your API",
                   href: "/quickstart/server",
                 })
               }
             >
-              Monetize a service
+              Monetize your API
             </Link>
           </div>
         </div>

--- a/src/components/PromptBlock.tsx
+++ b/src/components/PromptBlock.tsx
@@ -28,7 +28,7 @@ export function PromptBlock({ children }: { children: string }) {
         <pre
           className="vocs:relative vocs:select-none"
           data-v
-          style={{ cursor: "pointer" }}
+          style={{ cursor: "pointer", whiteSpace: "pre-wrap", wordBreak: "break-word" }}
         >
           <code className="language-txt">{children}</code>
           <span

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -2549,7 +2549,7 @@ function WalletSteps() {
         label="Install Tempo tools"
         desc="Install the CLI. You will be asked to sign in or create a passkey-based wallet in your browser."
       >
-        curl -L https://tempo.xyz/install | bash
+        curl -L https://tempo.xyz/install | bash && tempo add wallet
       </CliSnippet>
       <CliSnippet
         label="Prompt your agent"

--- a/src/components/Terminal.test.tsx
+++ b/src/components/Terminal.test.tsx
@@ -354,10 +354,10 @@ describe("constants", () => {
   });
 
   it("step builders have correct methodLabels", () => {
-    expect(Terminal.chat().methodLabel).toBe("Tempo session");
-    expect(Terminal.image().methodLabel).toBe("Tempo charge");
-    expect(Terminal.search().methodLabel).toBe("Tempo charge");
-    expect(Terminal.article().methodLabel).toBe("Stripe charge");
+    expect(Terminal.chat().methodLabel).toBe("Tempo session + OpenAI");
+    expect(Terminal.image().methodLabel).toBe("Tempo charge + fal.ai");
+    expect(Terminal.search().methodLabel).toBe("Tempo session + Parallel");
+    expect(Terminal.article().methodLabel).toBe("Stripe charge + Parallel");
     expect(Terminal.poem().methodLabel).toBe("Tempo session");
     expect(Terminal.lookup().methodLabel).toBe("Stripe charge");
   });

--- a/src/components/terminal-steps.ts
+++ b/src/components/terminal-steps.ts
@@ -206,59 +206,77 @@ export function stripe({
 // ---------------------------------------------------------------------------
 
 export function chat(): PaymentStepConfig {
-  return session({
-    label: "Chat with AI",
-    description: "Chat with AI and pay per token streamed",
-    endpoint: "/api/chat",
-    liveEndpoint: (input) =>
-      `/api/demo/chat?prompt=${encodeURIComponent(input)}`,
-    prompt: { label: "Enter prompt", placeholder: "what are micropayments?" },
-    pickOutput: pickChat,
-  });
+  return {
+    ...session({
+      label: "Chat with AI",
+      description: "Chat with AI and pay per token streamed",
+      endpoint: "/api/chat",
+      liveEndpoint: (input) =>
+        `/api/demo/chat?prompt=${encodeURIComponent(input)}`,
+      prompt: {
+        label: "Enter prompt",
+        placeholder: "what are micropayments?",
+      },
+      pickOutput: pickChat,
+    }),
+    methodLabel: "Tempo session + OpenAI",
+  };
 }
 
 export function image(): PaymentStepConfig {
-  return charge({
-    label: "Generate image",
-    description: "Generate an image and pay per request",
-    endpoint: "/api/image",
-    liveEndpoint: (input) =>
-      `/api/demo/image?prompt=${encodeURIComponent(input)}`,
-    cost: 0.003,
-    prompt: { label: "Enter prompt", placeholder: "a neon cityscape at night" },
-    pickOutput: pickImage,
-    outputMode: "photo",
-  });
+  return {
+    ...charge({
+      label: "Generate image",
+      description: "Generate an image and pay per request",
+      endpoint: "/api/image",
+      liveEndpoint: (input) =>
+        `/api/demo/image?prompt=${encodeURIComponent(input)}`,
+      cost: 0.003,
+      prompt: {
+        label: "Enter prompt",
+        placeholder: "a neon cityscape at night",
+      },
+      pickOutput: pickImage,
+      outputMode: "photo",
+    }),
+    methodLabel: "Tempo charge + fal.ai",
+  };
 }
 
 export function search(): PaymentStepConfig {
-  return charge({
-    label: "Search the web",
-    description: "Search the web and pay per request",
-    endpoint: "/api/search",
-    liveEndpoint: (input) =>
-      `/api/demo/search?query=${encodeURIComponent(input)}`,
-    cost: 0.005,
-    prompt: { label: "Enter query", placeholder: "Machine Payments" },
-    pickOutput: pickSearch,
-  });
+  return {
+    ...session({
+      label: "Search the web",
+      description: "Search the web and pay per query",
+      endpoint: "/api/search",
+      liveEndpoint: (input) =>
+        `/api/demo/search?query=${encodeURIComponent(input)}`,
+      cost: () => 0.005,
+      prompt: { label: "Enter query", placeholder: "Machine Payments" },
+      pickOutput: pickSearch,
+    }),
+    methodLabel: "Tempo session + Parallel",
+  };
 }
 
 export function article(): PaymentStepConfig {
-  return stripe({
-    label: "Summarize article",
-    description: "Summarize an article and pay with Stripe",
-    endpoint: "/api/article",
-    liveEndpoint: (input) =>
-      `/api/demo/article?url=${encodeURIComponent(input)}`,
-    cost: LOOKUP_COST,
-    prompt: {
-      label: "Enter URL",
-      placeholder: "stripe.com",
-      prefix: "https://",
-    },
-    pickOutput: pickArticle,
-  });
+  return {
+    ...stripe({
+      label: "Summarize article",
+      description: "Summarize an article and pay with Stripe",
+      endpoint: "/api/article",
+      liveEndpoint: (input) =>
+        `/api/demo/article?url=${encodeURIComponent(input)}`,
+      cost: LOOKUP_COST,
+      prompt: {
+        label: "Enter URL",
+        placeholder: "stripe.com",
+        prefix: "https://",
+      },
+      pickOutput: pickArticle,
+    }),
+    methodLabel: "Stripe charge + Parallel",
+  };
 }
 
 export function poem(): PaymentStepConfig {

--- a/src/pages/_api/api/demo/search.ts
+++ b/src/pages/_api/api/demo/search.ts
@@ -37,9 +37,9 @@ const searchResults = [
     "     https://stripe.com/blog/stablecoins-machine-payments",
     "     No chargebacks, no minimums, no merchant accounts. Stablecoins are the native currency of the API economy...",
     "",
-    "  3. Exa Search API: Semantic Search for LLMs",
-    "     https://docs.exa.ai/reference/search",
-    "     Neural search engine designed for AI applications, returning clean content from across the web...",
+    "  3. Parallel Search API: AI-Native Web Search",
+    "     https://docs.parallel.ai/reference/search",
+    "     AI-native search engine designed for agents, returning structured content from across the web...",
   ],
   [
     "  1. Payment Auth: An HTTP Authentication Scheme for Payments",

--- a/src/pages/guides/one-time-payments.mdx
+++ b/src/pages/guides/one-time-payments.mdx
@@ -19,7 +19,7 @@ Try the payment-gated image generation API. Click **Run demo** to create a walle
 
 ## Prompt mode
 
-Paste this into your coding agent to build the entire guide in one shot:
+Paste this into your coding agent to build the entire guide in one prompt:
 
 <PromptBlock>
 {`Use https://mpp.dev/guides/one-time-payments.md as reference.

--- a/src/pages/guides/pay-as-you-go.mdx
+++ b/src/pages/guides/pay-as-you-go.mdx
@@ -24,7 +24,7 @@ Try the payment-gated photo gallery API. Click **Run demo** to create a wallet, 
 
 ## Prompt mode
 
-Paste this into your coding agent to build the entire guide in one shot:
+Paste this into your coding agent to build the entire guide in one prompt:
 
 <PromptBlock>
 {`Use https://mpp.dev/guides/pay-as-you-go.md as reference.

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -25,7 +25,7 @@ Try the payment-gated poetry API. Click **Run demo** to create a wallet, fund it
 
 ## Prompt mode
 
-Paste this into your coding agent to build the entire guide in one shot:
+Paste this into your coding agent to build the entire guide in one prompt:
 
 <PromptBlock>
   {`Use https://mpp.dev/guides/streamed-payments.md as reference.

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -6,7 +6,7 @@ import { PaymentFlowDiagram } from '../components/PaymentFlowDiagram'
 
 # Machine Payments Protocol [The open protocol for internet-native payments]
 
-The Machine Payments Protocol (MPP) lets you accept payments from any client— agents, apps, or humans—using standard HTTP control flows. Clients pay inline with their request, and you receive payment confirmation before delivering the response.
+The Machine Payments Protocol (MPP) lets any client—agents, apps, or humans—pay for any service, inline, over HTTP. Developers use MPP to let their agents pay for services. Service operators use MPP to monetize their APIs.
 
 MPP is built around a simple extensible core and is designed to be neutral to the implementation of underlying payment flows and methods.
 
@@ -15,6 +15,14 @@ MPP is built around a simple extensible core and is designed to be neutral to th
 - **Multi rail**—Stablecoins, cards, bank transfers, and digital wallets. All payment methods can be supported through one protocol and flexible control flow
 - **Multi currency**—The protocol is currency agnostic, allowing for transactions in USD, EUR, BRL, USDC, BTC, or any other asset
 - **Composable and designed for extension**—A flexible core allows advanced flows like disputes or additional primitives like identity to be gradually introduced
+
+## Who is MPP for?
+
+MPP involves three parties:
+
+- **Developers** build apps and agents that consume paid services. You integrate an MPP client so your agent can discover, pay for, and use third-party APIs without manual signup or API keys.
+- **Agents** are the entities that take action—calling APIs, generating images, querying data. They pay for services autonomously on behalf of your users.
+- **Services** operate APIs that charge for access—LLM inference, image generation, web search, and more. You integrate an MPP server to accept payments inline with zero onboarding friction.
 
 ## The problem with payments on the internet
 
@@ -36,9 +44,10 @@ See the full payment flow in action. The terminal creates an ephemeral wallet, f
 
 ## Use cases
 
-* **Paid APIs**—Accept payments inline without requiring API keys, billing accounts, or manual signup. Clients pay per request.
-* **MCP servers**—Monetize tool calls served through the Model Context Protocol (MCP). Clients pay autonomously without complicated OAuth or account setup.
-* **Digital content**—Monetize articles, data, or media without subscription paywalls. Charge per access or per query.
+* **Pay for LLM usage**—Your agent calls LLM providers through MPP, paying per token over a Tempo session. No API key management needed.
+* **Generate an image**—Request image generation from fal.ai or ElevenLabs audio, paying per request with a Tempo charge. The agent gets the result inline.
+* **Search the web**—Query Parallel for real-time search results, paying per query over a Tempo session. Results flow back in the same HTTP response.
+* **Monetize your API**—Accept payments from any client—agents, apps, or humans—without requiring signups, billing accounts, or API keys.
 
 ## Payment flow
 

--- a/src/pages/quickstart/client.mdx
+++ b/src/pages/quickstart/client.mdx
@@ -13,7 +13,7 @@ Polyfill the global `fetch` to handle `402` responses. Your existing code works 
 
 ## Prompt mode
 
-Paste this into your coding agent to set up your client with `mppx` in one shot:
+Paste this into your coding agent to set up your client with `mppx` in one prompt:
 
 <ClientPrompt />
 

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -2,19 +2,19 @@ import { Badge, Cards } from 'vocs'
 import { ServerPrompt } from '../../components/QuickstartPrompt'
 import { ClientQuickstartCard, TempoMethodCard, MppxCreateReferenceCard } from '../../components/cards'
 
-# Monetize your service [Charge for resources and verify payment credentials]
+# Monetize your API [Charge for access to protected resources]
 
 ## Overview
 
 This quickstart demonstrates how to plug MPP into any server framework to accept payments for protected resources. Pick the path that suits you:
 
-- [**Prompt mode**](#prompt-mode): paste a prompt into your coding agent and one shot
+- [**Prompt mode**](#prompt-mode): paste a prompt into your coding agent and build in one prompt
 - [**Framework mode**](#framework-mode): use `mppx` middleware for Next.js, Hono, Elysia, or Express
 - [**Manual mode**](#manual-mode): call `mppx/server` directly with the Fetch API
 
 ## Prompt mode
 
-Paste this into your coding agent to set up a server with `mppx` in one shot:
+Paste this into your coding agent to set up a server with `mppx` in one prompt:
 
 <ServerPrompt />
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -90,9 +90,9 @@ export default defineConfig({
         text: "Quick Start",
         items: [
           { text: "Overview", link: "/quickstart" },
-          { text: "Use with your app", link: "/quickstart/client" },
           { text: "Monetize your service", link: "/quickstart/server" },
           { text: "Use with agents", link: "/quickstart/agent" },
+          { text: "Use with your app", link: "/quickstart/client" },
         ],
       },
       {


### PR DESCRIPTION
## Changes

### Landing page
- CTA renamed from "Add to your API" → **"Monetize your API"**

### Overview page
- Intro rewritten to address both developers and service operators (neutral "you")
- New **"Who is MPP for?"** section establishing three parties: developers, agents, services
- **Use cases** rewritten with concrete "do X with service Y" examples (OpenAI, fal.ai, Parallel)

### Terminal demo
- Method labels now show the underlying service: `Tempo session + OpenAI`, `Tempo charge + fal.ai`, etc.
- "Search the web" corrected from Tempo charge → **Tempo session** (matches Parallel)
- Canned Exa search result → Parallel

### Server quickstart
- Page title updated to "Monetize your API"

### CLI install instructions (from merged PR #297)
- Install URL: `https://tempo.xyz/install`
- Added `tempo add wallet` step
- `tempo-wallet` → `tempo wallet` (identity) / `tempo mpp` (requests)
- Renamed all `presto`/`Presto` internal variables → `wallet`/`Wallet`
- Fixed stale `presto` reference in FAQ