### PR TITLE
docs: remove authorize and subscription intent references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Prefer the normative Payment Auth specs at `/specs` for protocol-level details:
 
 - Core Payment HTTP Authentication Scheme
 - Payment methods
-- Payment intents (charge, authorize, subscription)
+- Payment intents (charge, session)
 - Transport bindings (HTTP, MCP)
 
 Current protocol context from this repo:

--- a/src/pages/_api/api/demo/chat.ts
+++ b/src/pages/_api/api/demo/chat.ts
@@ -6,7 +6,7 @@ const responses = [
     "Great question! MPP uses HTTP 402 to signal that a resource requires payment.",
     "When your client receives a 402, it automatically negotiates a payment channel.",
     "The server issues a Challenge, your wallet signs a Credential, and the stream begins.",
-    "Each token you consume is charged in real time—no upfront costs, no subscriptions.",
+    "Each token you consume is charged in real time—no upfront costs, no billing portals.",
     "It's like a pay-as-you-go meter, but for API calls.",
   ],
   [

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -74,7 +74,7 @@ Yes. See the [server quickstart](/quickstart/server) to start accepting payments
 
 ## Is MPP an IETF standard?
 
-The core [Payment HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/) is on the IETF standards track. Payment method and intent IETF Specification (charge, session, authorize) are separate documents that anyone can author and publish independently—they do not require IETF approval. This mirrors how the web works: HTTP is standardized, but content types and authentication schemes evolve independently.
+The core [Payment HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/) is on the IETF standards track. Payment method and intent IETF Specifications (for example, charge, session) are separate documents that anyone can author and publish independently—they do not require IETF approval. This mirrors how the web works: HTTP is standardized, but content types and authentication schemes evolve independently.
 
 ## Can I use MPP outside of HTTP?
 

--- a/src/pages/protocol/challenges.mdx
+++ b/src/pages/protocol/challenges.mdx
@@ -20,7 +20,7 @@ WWW-Authenticate: Payment id="qB3wErTyU7iOpAsD9fGhJk",
 | `id` | Unique challenge identifier, cryptographically bound to challenge parameters |
 | `realm` | Protection space identifier (typically the API domain) |
 | `method` | Payment method identifier (such as `tempo` or `stripe`) |
-| `intent` | Payment intent type (such as `charge` or `authorize`) |
+| `intent` | Payment intent type (such as `charge` or `session`) |
 | `request` | Base64url-encoded JSON with payment details |
 
 ### Optional parameters

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -83,10 +83,9 @@ Payment method specifications must define:
 Payment intents describe the type of payment being requested. Common intents include:
 
 - **`charge`**—One-time payment that settles immediately
-- **`authorize`**—Authorization that can be captured later
-- **`subscription`**—Recurring payment authorization
+- **`session`**—Streaming payment over a payment channel
 
-Intent Specification define:
+Intent Specifications define:
 
 - Required and optional `request` fields
 - `payload` requirements
@@ -96,7 +95,7 @@ Servers can offer multiple intents in separate challenges, allowing clients to c
 
 ```http
 WWW-Authenticate: Payment id="abc", method="tempo", intent="charge", ...
-WWW-Authenticate: Payment id="def", method="tempo", intent="authorize", ...
+WWW-Authenticate: Payment id="def", method="tempo", intent="session", ...
 ```
 
 ## Request body binding
@@ -218,7 +217,7 @@ These docs provide a practical overview. For the full Specification:
   </a>
   —Core protocol spec (draft-httpauth-payment-00)
 - [Payment Methods](https://tempoxyz.github.io/mpp-specs/)—Payment method definitions
-- [Payment Intents](https://tempoxyz.github.io/mpp-specs/)—Intent types (charge, authorize, subscription)
+- [Payment Intents](https://tempoxyz.github.io/mpp-specs/)—Intent type definitions (for example, `charge`, `session`)
 - <a
     href="https://tempoxyz.github.io/mpp-specs/draft-payment-transport-mcp-00"
     data-v="true"


### PR DESCRIPTION
These intent types are out of scope for launch. Removes mentions from protocol docs, FAQ, terminal demo, and chat demo responses.

**Changes:**
- Removed `authorize` and `subscription` from intent type lists in protocol overview
- Updated challenge parameter docs to only reference `charge`
- Cleaned up FAQ spec reference
- Replaced "subscriptions" in terminal demo and chat demo text
- Updated AGENTS.md to reflect current intent scope