### PR TITLE
ci: enforce biome formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
-      - run: pnpm check
+      - run: pnpm check:ci
 
   typecheck:
     name: Typecheck

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "node scripts/generate-discovery.ts && node scripts/build-diagrams.ts && node scripts/copy-vocs-theme.ts && node scripts/generate-cli-help.ts && vite build",
     "check": "biome check --write",
+    "check:ci": "biome check",
     "check:sdk-drift": "npx tsx .github/actions/sdk-drift-check/check-sdk-drift.ts",
     "check:types": "tsc --noEmit",
     "dev": "vite dev",


### PR DESCRIPTION
CI currently runs `pnpm check` → `biome check --write`, which auto-fixes formatting and always passes. This means formatting violations never actually fail the build.

Adds a `check:ci` script that runs `biome check` without `--write` so CI fails on unformatted code. The local `check` script keeps `--write` for the git hook auto-fix behavior.