### PR TITLE
chore: remove demo.sh title from terminal header

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2795,16 +2795,7 @@ function TerminalComponent({
               backgroundColor: "var(--term-gray4)",
             }}
           />
-          <span
-            style={{
-              flex: 1,
-              textAlign: "center",
-              fontSize: "0.9375rem",
-              color: "var(--term-gray6)",
-            }}
-          >
-            demo.sh
-          </span>
+          <span style={{ flex: 1 }} />
           <button
             type="button"
             onClick={() => {


### PR DESCRIPTION
Removes the "demo.sh" text from the terminal component's macOS-style title bar on the landing page.