### PR TITLE
fix(docs): correct secretKey default behavior and env var name

### DIFF
--- a/src/pages/sdk/typescript/server/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.create.mdx
@@ -73,7 +73,7 @@ const payment = Mppx.create({
 ### secretKey (optional)
 
 - **Type:** `string`
-- **Default:** Auto-detected from `MPP_SECRET_KEY` environment variable, falling back to a random key.
+- **Default:** Auto-detected from `MPP_SECRET_KEY` environment variable. Throws if neither provided nor set.
 
 Secret key for HMAC-bound challenge IDs. Enables stateless verification—the server verifies that a Challenge was issued by itself without storing state.
 
@@ -82,7 +82,7 @@ import { Mppx, tempo } from 'mppx/server'
 
 const payment = Mppx.create({
   methods: [tempo()],
-  secretKey: process.env.MPPX_SECRET_KEY!, // [!code focus]
+  secretKey: process.env.MPP_SECRET_KEY!, // [!code focus]
 })
 ```
 


### PR DESCRIPTION
The `Mppx.create` server docs had two issues:

1. **Wrong default behavior**: Docs said `secretKey` falls back to a random key, but the SDK actually throws if neither `secretKey` nor `MPP_SECRET_KEY` env var is set
2. **Wrong env var name**: Example used `MPPX_SECRET_KEY` but the actual env var is `MPP_SECRET_KEY`