### PR TITLE
fix: site copy — hero text, LLM heading, JSON-RPC transport

### DIFF
--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -1171,7 +1171,7 @@ export function ServicesPage() {
                 marginTop: "-0.5rem",
               }}
             >
-              Use MPP-enabled APIs seamlessly with your agent.
+              Seamlessly use MPP-enabled services with your agent.
             </p>
           </div>
           <div className="page-header-ctas" style={{ display: "none" }} />

--- a/src/pages/guides/building-with-an-llm.mdx
+++ b/src/pages/guides/building-with-an-llm.mdx
@@ -1,11 +1,11 @@
 ---
-title: Building with an LLM
+title: Build with an LLM
 description: Use llms-full.txt to give your coding agent complete MPP context.
 ---
 
 import { Card, Cards } from 'vocs'
 
-# Building with an LLM [Give your agent MPP context]
+# Build with an LLM [Give your agent MPP context]
 
 Point your coding agent at <a href="/llms-full.txt" target="_self">`llms-full.txt`</a>, a single file containing the complete documentation.
 

--- a/src/pages/protocol/transports/index.mdx
+++ b/src/pages/protocol/transports/index.mdx
@@ -1,6 +1,6 @@
 # Transports [HTTP and MCP bindings for payment flows]
 
-MPP defines how the Payment authentication scheme operates over different transport protocols. The core protocol targets HTTP, with extensions for other transports like MCP.
+MPP defines how the Payment authentication scheme operates over different transport protocols. The core protocol targets HTTP, with extensions for other transports like MCP and JSON-RPC.
 
 ## Available transports
 
@@ -8,6 +8,7 @@ MPP defines how the Payment authentication scheme operates over different transp
 |-----------|----------|------|
 | [HTTP](/protocol/transports/http) | REST APIs, web resources | [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-11) |
 | [MCP](/protocol/transports/mcp) | AI tool calls using Model Context Protocol | [MCP Transport Spec](https://paymentauth.org) |
+| JSON-RPC | Non-MCP JSON-RPC services | [JSON-RPC 2.0](https://www.jsonrpc.org/specification) |
 
 ## Transport-agnostic design
 
@@ -16,4 +17,4 @@ MPP's core concepts—Challenges, Credentials, and Receipts—remain the same ac
 - **HTTP** uses standard headers (`WWW-Authenticate`, `Authorization`, `Payment-Receipt`)
 - **MCP** uses JSON-RPC error codes and `_meta` fields
 
-Choose the transport that matches your protocol. HTTP for REST APIs, MCP for AI agent tool calls.
+Choose the transport that matches your protocol. HTTP for REST APIs, MCP for AI agent tool calls, or JSON-RPC for non-MCP JSON-RPC services.


### PR DESCRIPTION
## Changes

1. **ServicesPage hero** — "Seamlessly use MPP-enabled services with your agent."
2. **LLM guide heading** — "Building with an LLM" → "Build with an LLM" (imperative mood)
3. **Transports page** — Added JSON-RPC row to table, updated intro and closing text to mention both MCP and JSON-RPC