### PR TITLE
feat: add Telegram social link for mpp_devs

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -510,6 +510,7 @@ export default defineConfig({
   socials: [
     { icon: "x", link: "https://x.com/mpp" },
     { icon: "github", link: "https://github.com/tempoxyz/mpp-specs" },
+    { icon: "telegram", link: "https://t.me/mpp_devs" },
   ],
   title: "Machine Payments Protocol",
   titleTemplate: "%s | MPP",


### PR DESCRIPTION
Adds a Telegram icon linking to [t.me/mpp_devs](https://t.me/mpp_devs) in the site header socials, alongside the existing X and GitHub links.