### PR TITLE
docs: add 'Identifying the payer' to middleware pages

### DIFF
--- a/src/pages/sdk/typescript/middlewares/express.mdx
+++ b/src/pages/sdk/typescript/middlewares/express.mdx
@@ -55,3 +55,26 @@ app.get(
   (req, res) => res.json({ data: 'session content' }),
 )
 ```
+
+### Identifying the payer
+
+After the middleware verifies payment, the `Authorization` header is still on the request. Parse it with `Credential.deserialize` to read the payer's identity from the `source` field—a DID such as `did:pkh:eip155:1:0x...`.
+
+```ts [server.ts]
+import express from 'express'
+import { Credential } from 'mppx'
+import { Mppx, tempo } from 'mppx/express'
+
+const app = express()
+const mppx = Mppx.create({ methods: [tempo()] })
+
+app.get(
+  '/premium',
+  mppx.charge({ amount: '1' }),
+  (req, res) => {
+    const credential = Credential.deserialize(req.headers.authorization!)
+    const payer = credential.source // "did:pkh:eip155:1:0x..."
+    res.json({ payer })
+  },
+)
+```

--- a/src/pages/sdk/typescript/middlewares/hono.mdx
+++ b/src/pages/sdk/typescript/middlewares/hono.mdx
@@ -55,3 +55,26 @@ app.get(
   (c) => c.json({ data: 'session content' }),
 )
 ```
+
+### Identifying the payer
+
+After the middleware verifies payment, the `Authorization` header is still on the request. Parse it with `Credential.deserialize` to read the payer's identity from the `source` field—a DID such as `did:pkh:eip155:1:0x...`.
+
+```ts [server.ts]
+import { Hono } from 'hono'
+import { Credential } from 'mppx'
+import { Mppx, tempo } from 'mppx/hono'
+
+const app = new Hono()
+const mppx = Mppx.create({ methods: [tempo()] })
+
+app.get(
+  '/premium',
+  mppx.charge({ amount: '1' }),
+  (c) => {
+    const credential = Credential.deserialize(c.req.header('Authorization')!)
+    const payer = credential.source // "did:pkh:eip155:1:0x..."
+    return c.json({ payer })
+  },
+)
+```

--- a/src/pages/sdk/typescript/middlewares/nextjs.mdx
+++ b/src/pages/sdk/typescript/middlewares/nextjs.mdx
@@ -47,3 +47,22 @@ export const GET =
   mppx.session({ amount: '1', unitType: 'token' })
   (() => Response.json({ data: 'session content' }))
 ```
+
+### Identifying the payer
+
+After the handler verifies payment, the `Authorization` header is still on the request. Parse it with `Credential.deserialize` to read the payer's identity from the `source` field—a DID such as `did:pkh:eip155:1:0x...`.
+
+```ts twoslash [app/api/premium/route.ts]
+import { Credential } from 'mppx'
+import { Mppx, tempo } from 'mppx/nextjs'
+
+const mppx = Mppx.create({ methods: [tempo()] })
+
+export const GET =
+  mppx.charge({ amount: '1' })
+  ((request) => {
+    const credential = Credential.deserialize(request.headers.get('Authorization')!)
+    const payer = credential.source // "did:pkh:eip155:1:0x..."
+    return Response.json({ payer })
+  })
+```


### PR DESCRIPTION
Adds an "Identifying the payer" section to the Hono, Express, and Next.js middleware docs showing how to use `Credential.deserialize` on the `Authorization` header to extract `credential.source` (the payer DID).