### PR TITLE
With stripe example for tempo.charge

### DIFF
--- a/src/pages/payment-methods/tempo/charge.mdx
+++ b/src/pages/payment-methods/tempo/charge.mdx
@@ -77,7 +77,12 @@ When `feePayer` is `true`, the server adds a fee payer signature (domain `0x78`)
 ### With Stripe
 
 ```ts twoslash
+// @noErrors
 import { Mppx, tempo } from "mppx/server";
+
+function async createPayToAddress(request: Request) {
+   // Create Stripe PaymentIntent
+}
 
 export async function handler(request: Request) {
   const recipientAddress = await createPayToAddress(request)


### PR DESCRIPTION
Adds a "With Stripe" section to continue the examples listed on the Tempo.charge integration path (i.e. "With fee sponsorship", etc.)

Links to the same verbiage as the full Stripe guide in "To learn more, read the [Stripe documentation](https://docs.stripe.com/payments/machine/mpp) on accepting MPP."