### PR TITLE
chore: simplify demo menu labels

### DIFF
--- a/e2e/terminal.test.ts
+++ b/e2e/terminal.test.ts
@@ -75,7 +75,7 @@ describe("terminal", () => {
 
     await waitForWizard(page);
 
-    await playwrightExpect(page.getByText("Chat with AI")).toBeVisible();
+    await playwrightExpect(page.getByText("Chat with OpenAI")).toBeVisible();
 
     await page.close();
   });
@@ -86,10 +86,16 @@ describe("terminal", () => {
 
     await waitForWizard(page);
 
-    await playwrightExpect(page.getByText("Chat with AI")).toBeVisible();
-    await playwrightExpect(page.getByText("Generate image")).toBeVisible();
-    await playwrightExpect(page.getByText("Search the web")).toBeVisible();
-    await playwrightExpect(page.getByText("Summarize article")).toBeVisible();
+    await playwrightExpect(page.getByText("Chat with OpenAI")).toBeVisible();
+    await playwrightExpect(
+      page.getByText("Generate an image using fal.ai"),
+    ).toBeVisible();
+    await playwrightExpect(
+      page.getByText("Search the web using Parallel"),
+    ).toBeVisible();
+    await playwrightExpect(
+      page.getByText("Summarize an article using Parallel"),
+    ).toBeVisible();
 
     await page.close();
   });
@@ -112,7 +118,7 @@ describe("terminal", () => {
     await page.close();
   });
 
-  it.concurrent('selects "Chat with AI" and shows payment channel steps', async () => {
+  it.concurrent('selects "Chat with OpenAI" and shows payment channel steps', async () => {
     const page = await newPage();
     await page.goto(`http://localhost:${port}`);
     await waitForWizard(page);
@@ -149,7 +155,7 @@ describe("terminal", () => {
     await page.close();
   });
 
-  it.concurrent('selects "Generate image" via arrow key and shows charge steps', async () => {
+  it.concurrent('selects "Generate an image using fal.ai" via arrow key and shows charge steps', async () => {
     const page = await newPage();
     await page.goto(`http://localhost:${port}`);
     await waitForWizard(page);
@@ -207,7 +213,7 @@ describe("terminal", () => {
     await page.close();
   });
 
-  it.concurrent('selects "Summarize article" and enters a URL', async () => {
+  it.concurrent('selects "Summarize an article using Parallel" and enters a URL', async () => {
     const page = await newPage();
     await page.goto(`http://localhost:${port}`);
     await waitForWizard(page);

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -79,7 +79,11 @@ export function LandingPage() {
                   position: "relative",
                 }}
               >
-                <Terminal className="absolute inset-0" steps={TERMINAL_STEPS} />
+                <Terminal
+                  className="absolute inset-0"
+                  steps={TERMINAL_STEPS}
+                  showLastVisit={false}
+                />
                 <div className="designed-by-desktop">
                   <DesignedBy />
                 </div>

--- a/src/components/Terminal.test.tsx
+++ b/src/components/Terminal.test.tsx
@@ -354,10 +354,10 @@ describe("constants", () => {
   });
 
   it("step builders have correct methodLabels", () => {
-    expect(Terminal.chat().methodLabel).toBe("Tempo session + OpenAI");
-    expect(Terminal.image().methodLabel).toBe("Tempo charge + fal.ai");
-    expect(Terminal.search().methodLabel).toBe("Tempo session + Parallel");
-    expect(Terminal.article().methodLabel).toBe("Stripe charge + Parallel");
+    expect(Terminal.chat().methodLabel).toBe("Tempo");
+    expect(Terminal.image().methodLabel).toBe("Tempo");
+    expect(Terminal.search().methodLabel).toBe("Tempo");
+    expect(Terminal.article().methodLabel).toBe("Stripe");
     expect(Terminal.poem().methodLabel).toBe("Tempo session");
     expect(Terminal.lookup().methodLabel).toBe("Stripe charge");
   });

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1839,7 +1839,9 @@ function Wizard({
                     "  "
                   )}
                   {item.label}
-                  <span className="ml-2">({item.methodLabel})</span>
+                  <span className="ml-2" style={{ color: "var(--term-gray5)" }}>
+                    ({item.methodLabel})
+                  </span>
                 </p>
               );
             })}
@@ -1898,7 +1900,9 @@ function Wizard({
                   "  "
                 )}
                 {item.label}
-                <span className="ml-2">({item.methodLabel})</span>
+                <span className="ml-2" style={{ color: "var(--term-gray5)" }}>
+                  ({item.methodLabel})
+                </span>
               </button>
             ))}
           </div>
@@ -2603,9 +2607,11 @@ function SingleStep({
 function TerminalComponent({
   className,
   steps,
+  showLastVisit = true,
 }: {
   className?: string;
   steps: StepConfig[];
+  showLastVisit?: boolean;
 }) {
   const { client: demoClient } = useDemoClient();
 
@@ -2652,6 +2658,7 @@ function TerminalComponent({
     if (stored) return fmt(new Date(stored));
     return "Oct 29 1969 22:30:00";
   });
+
   const walletState: WalletState = {
     address,
     balance,
@@ -2912,7 +2919,7 @@ function TerminalComponent({
               mpp.dev@{__COMMIT_SHA__.slice(0, 7)} (released{" "}
               {timeAgo(__COMMIT_TIMESTAMP__)})
             </p>
-            {showLogin && (
+            {showLastVisit && showLogin && (
               <p
                 className="hidden md:block"
                 style={{ color: "var(--term-gray6)" }}

--- a/src/components/terminal-steps.ts
+++ b/src/components/terminal-steps.ts
@@ -208,7 +208,7 @@ export function stripe({
 export function chat(): PaymentStepConfig {
   return {
     ...session({
-      label: "Chat with AI",
+      label: "Chat with OpenAI",
       description: "Chat with AI and pay per token streamed",
       endpoint: "/api/chat",
       liveEndpoint: (input) =>
@@ -219,14 +219,14 @@ export function chat(): PaymentStepConfig {
       },
       pickOutput: pickChat,
     }),
-    methodLabel: "Tempo session + OpenAI",
+    methodLabel: "Tempo",
   };
 }
 
 export function image(): PaymentStepConfig {
   return {
     ...charge({
-      label: "Generate image",
+      label: "Generate an image using fal.ai",
       description: "Generate an image and pay per request",
       endpoint: "/api/image",
       liveEndpoint: (input) =>
@@ -239,14 +239,14 @@ export function image(): PaymentStepConfig {
       pickOutput: pickImage,
       outputMode: "photo",
     }),
-    methodLabel: "Tempo charge + fal.ai",
+    methodLabel: "Tempo",
   };
 }
 
 export function search(): PaymentStepConfig {
   return {
     ...session({
-      label: "Search the web",
+      label: "Search the web using Parallel",
       description: "Search the web and pay per query",
       endpoint: "/api/search",
       liveEndpoint: (input) =>
@@ -255,14 +255,14 @@ export function search(): PaymentStepConfig {
       prompt: { label: "Enter query", placeholder: "Machine Payments" },
       pickOutput: pickSearch,
     }),
-    methodLabel: "Tempo session + Parallel",
+    methodLabel: "Tempo",
   };
 }
 
 export function article(): PaymentStepConfig {
   return {
     ...stripe({
-      label: "Summarize article",
+      label: "Summarize an article using Parallel",
       description: "Summarize an article and pay with Stripe",
       endpoint: "/api/article",
       liveEndpoint: (input) =>
@@ -275,7 +275,7 @@ export function article(): PaymentStepConfig {
       },
       pickOutput: pickArticle,
     }),
-    methodLabel: "Stripe charge + Parallel",
+    methodLabel: "Stripe",
   };
 }
 


### PR DESCRIPTION
Incorporates feedback from team on demo text clarity:

- **Labels**: service name moved into label with 'using' (e.g. 'Generate an image using fal.ai')
- **Method labels**: simplified to just payment rail — 'Tempo' or 'Stripe' (dropped 'session/charge')
- **Styling**: method label parenthetical rendered in dimmed gray
- **Removed**: 'Last visit' line from terminal header
- **Kept**: version/release line

Menu now reads:
```
Chat with OpenAI (Tempo)
Generate an image using fal.ai (Tempo)
Search the web using Parallel (Tempo)
Summarize an article using Parallel (Stripe)
```