### PR TITLE
chore: move Stripe demo to second position

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -15,9 +15,9 @@ const TERMINAL_STEPS = [
   Terminal.commands(["./demo.sh"]),
   Terminal.wizard([
     Terminal.chat(),
+    Terminal.article(),
     Terminal.image(),
     Terminal.search(),
-    Terminal.article(),
   ]),
 ];
 


### PR DESCRIPTION
Moves the Stripe demo ('Summarize an article using Parallel') to be the second menu item, right after 'Chat with OpenAI', so both payment methods (Tempo + Stripe) are highlighted early.