### PR TITLE
feat: change demo placeholder URL from stripe.com to stratechery.com

### DIFF
--- a/e2e/terminal.test.ts
+++ b/e2e/terminal.test.ts
@@ -228,7 +228,7 @@ describe("terminal", () => {
     });
 
     // The URL input is a focused BlockCursorInput — type into it via the page
-    await page.keyboard.type("stripe.com");
+    await page.keyboard.type("stratechery.com");
     await page.keyboard.press("Enter");
 
     await playwrightExpect(
@@ -278,7 +278,7 @@ describe("terminal", () => {
     await page.keyboard.press("Enter");
 
     await playwrightExpect(
-      page.getByText("Enter URL: https://stripe.com", { exact: true }),
+      page.getByText("Enter URL: https://stratechery.com", { exact: true }),
     ).toBeVisible({ timeout: 5_000 });
     await playwrightExpect(
       page.getByText("Card number:", { exact: false }),
@@ -424,7 +424,7 @@ describe("terminal (classic mode)", () => {
       timeout: 5_000,
     });
 
-    await page.keyboard.type("stripe.com");
+    await page.keyboard.type("stratechery.com");
     await page.keyboard.press("Enter");
 
     await playwrightExpect(

--- a/src/components/Terminal.test.tsx
+++ b/src/components/Terminal.test.tsx
@@ -348,6 +348,7 @@ describe("constants", () => {
   });
 
   it("COMPANIES contains expected domains", () => {
+    expect(Object.keys(COMPANIES)).toContain("stratechery.com");
     expect(Object.keys(COMPANIES)).toContain("stripe.com");
     expect(Object.keys(COMPANIES)).toContain("tempo.xyz");
     expect(Object.keys(COMPANIES)).toContain("openai.com");

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -416,6 +416,11 @@ export function randomTxHash() {
 
 export const COMPANIES: Record<string, { title: string; description: string }> =
   {
+    "stratechery.com": {
+      title: "Stratechery by Ben Thompson",
+      description:
+        "Stratechery provides analysis of the strategy and business side of technology and media.",
+    },
     "stripe.com": {
       title: "Stripe | Financial Infrastructure for the Internet",
       description:

--- a/src/components/terminal-steps.ts
+++ b/src/components/terminal-steps.ts
@@ -270,7 +270,7 @@ export function article(): PaymentStepConfig {
       cost: LOOKUP_COST,
       prompt: {
         label: "Enter URL",
-        placeholder: "stripe.com",
+        placeholder: "stratechery.com/2025/the-agentic-web-and-original-sin/",
         prefix: "https://",
       },
       pickOutput: pickArticle,
@@ -315,7 +315,7 @@ export function lookup(): PaymentStepConfig {
     cost: LOOKUP_COST,
     prompt: {
       label: "Enter URL",
-      placeholder: "stripe.com",
+      placeholder: "stratechery.com/2025/the-agentic-web-and-original-sin/",
       prefix: "https://",
     },
     pickOutput: pickArticle,

--- a/src/pages/_api/api/demo/article.ts
+++ b/src/pages/_api/api/demo/article.ts
@@ -2,6 +2,13 @@ import { getProxyFetch } from "../../../../mppx-proxy-client";
 import { stripeMppx } from "../../../../mppx-stripe.server";
 
 const SUMMARIES: Record<string, string[]> = {
+  "stratechery.com": [
+    "  Ben Thompson argues the web's original sin was ad-supported",
+    "  free content, and that AI agents break this model entirely.",
+    "  Agents don't see ads, can't click them, and need to pay for",
+    "  content directly—making HTTP 402 and machine payments the",
+    "  foundation of the agentic web.",
+  ],
   "stripe.com": [
     "  Stripe processes hundreds of billions of dollars annually",
     "  across 195+ countries. The platform provides unified APIs for",
@@ -56,6 +63,12 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const input = url.searchParams.get("url") ?? "";
   const domain = normalizeUrl(input);
+
+  // Prefer curated summaries for known domains so the demo is consistent.
+  const canned = SUMMARIES[domain];
+  if (canned) {
+    return result.withReceipt(Response.json({ lines: canned }));
+  }
 
   const proxyFetch = getProxyFetch();
   const fullUrl = input.startsWith("http") ? input : `https://${input}`;

--- a/src/pages/_api/api/demo/lookup.ts
+++ b/src/pages/_api/api/demo/lookup.ts
@@ -1,6 +1,11 @@
 import { stripeMppx } from "../../../../mppx-stripe.server";
 
 const COMPANIES: Record<string, { title: string; description: string }> = {
+  "stratechery.com": {
+    title: "Stratechery by Ben Thompson",
+    description:
+      "Stratechery provides analysis of the strategy and business side of technology and media.",
+  },
   "stripe.com": {
     title: "Stripe | Financial Infrastructure for the Internet",
     description:


### PR DESCRIPTION
Updates the terminal demo's default URL from `stripe.com` to `stratechery.com/2025/the-agentic-web-and-original-sin/` (Ben Thompson's [The Agentic Web and Original Sin](https://stratechery.com/2025/the-agentic-web-and-original-sin/)).

**Changes:**
- `terminal-steps.ts` — placeholder in article and lookup steps now uses the full Stratechery article URL
- `Terminal.tsx` — added `stratechery.com` to client-side COMPANIES map
- `article.ts` — added canned summary; curated summaries now take priority over live Parallel extraction for consistent demo behavior
- `lookup.ts` — added canned company entry
- Unit and e2e tests updated

Types check and all 2675 unit tests pass.