### PR TITLE
fix: add bottom padding on mobile for Ask AI bar

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -118,6 +118,13 @@ html {
   padding-bottom: 0;
 }
 
+/* Ensure content clears the fixed Ask AI bar on mobile */
+@media (max-width: 767px) {
+  [data-v-main] {
+    padding-bottom: 4rem;
+  }
+}
+
 /* Add vertical spacing inside tab panels so content breathes */
 [data-v-content] [role="tabpanel"] > *:not(:last-child) {
   margin-bottom: 1.25rem;
@@ -1005,6 +1012,16 @@ a[href*="/payment-methods/tempo"][class*="vocs:rounded-md"]
 :has(.landing-page) [data-v-main]::after,
 [data-layout="minimal"] [data-v-main]::after {
   display: none;
+}
+
+/* Ask AI popup — keep anchored near the trigger on mobile so it doesn't
+   jump to the top of the viewport (iOS Lockdown Mode disables some JS
+   positioning). Cap the popup height so it stays within the safe area. */
+@media (max-width: 767px) {
+  [data-v-ask-ai-container] [role="menu"] {
+    max-height: 70vh;
+    overflow-y: auto;
+  }
 }
 
 /* ---- Mobile navigation ----


### PR DESCRIPTION
## Summary
Fixes content being overlapped by the fixed Ask AI button on mobile.

## Motivation
Patrick reported that on mobile (especially iOS Lockdown Mode), the Ask AI bar and its gradient overlay cover the last paragraph of page content, making it unreadable. The popup menu also overflows above the viewport.

## Changes
- Added `padding-bottom: 4rem` to `[data-v-main]` on `max-width: 767px` so content clears the fixed bar
- Capped the Ask AI popup menu height to `70vh` on mobile with `overflow-y: auto`

## Testing
- `pnpm check:ci` — passes
- `pnpm check:types` — passes
- Build fails on SSG due to missing `MPP_SECRET_KEY` (pre-existing, unrelated to CSS changes)

Prompted by: zygis