### PR TITLE
docs: add session manager, proxy, MCP client, and server utility reference pages

### DIFF
--- a/src/pages/guides/pay-as-you-go.mdx
+++ b/src/pages/guides/pay-as-you-go.mdx
@@ -580,6 +580,29 @@ const res = await fetch('http://localhost:3000/api/sessions/photo')
 - The client handles the full session lifecycle automatically: channel open, voucher signing, and retry after `402` responses.
 - If the server sets `suggestedDeposit`, the client uses `min(suggestedDeposit, maxDeposit)`.
 
+### Closing the channel
+
+After you're done making requests, close the channel to settle on-chain and reclaim unspent deposit:
+
+```ts twoslash [client.ts]
+import { tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const session = tempo.session({
+  account: privateKeyToAccount('0x...'),
+  maxDeposit: '1',
+})
+
+const res = await session.fetch('http://localhost:3000/api/sessions/photo')
+
+// Settle on-chain and reclaim unspent deposit
+const receipt = await session.close()
+```
+
+:::info
+Channels remain open for reuse. Closing is not required between individual requests—only when you're done with the session entirely.
+:::
+
 ## Next steps
 
 <Cards>

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -586,6 +586,29 @@ for await (const word of stream) {
 - **`.sse()`** — Connects to an SSE endpoint. Automatically sends new vouchers when the server emits `payment-need-voucher` events.
 - **`maxDeposit: '1'`** — Locks up to 1 pathUSD. At $0.001/word, this covers ~1,000 words before the channel needs a top-up.
 
+### Closing the channel
+
+After streaming completes, close the channel to settle and reclaim unspent deposit:
+
+```ts twoslash [client.ts]
+import { tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const session = tempo.session({
+  account: privateKeyToAccount('0x...'),
+  maxDeposit: '1',
+})
+
+const stream = await session.sse('http://localhost:3000/api/sessions/poem')
+
+for await (const word of stream) {
+  process.stdout.write(word + ' ')
+}
+
+// Settle on-chain and reclaim unspent deposit
+const receipt = await session.close()
+```
+
 ## Next steps
 
 <Cards>

--- a/src/pages/payment-methods/tempo/session.mdx
+++ b/src/pages/payment-methods/tempo/session.mdx
@@ -65,6 +65,18 @@ Either party can close the channel. The server calls `close()` on the escrow con
 
 ::::
 
+## Session receipts
+
+Session Receipts differ from charge Receipts. The `reference` field contains the payment channel ID (a `bytes32` hash), not a transaction hash. The on-chain settlement transaction hash is only available after closing the channel.
+
+| Field | Charge receipt | Session receipt |
+|-------|---------------|-----------------|
+| `reference` | Transaction hash | Channel ID |
+| `status` | `"success"` | `"success"` |
+| `method` | `"tempo"` | `"tempo"` |
+
+To get the settlement transaction hash, close the channel via `session.close()` and read the `txHash` field from the returned receipt.
+
 ## High volume API billing
 
 Payment sessions match the billing model that high-volume APIs need: pay stablecoin tokens, receive API responses. The granularity of payment matches the granularity of consumption.
@@ -198,9 +210,15 @@ Mppx.create({
 })
 ```
 
-:::info
-See [`tempo.session` client reference](/sdk/typescript/client/Method.tempo.session) for the full parameter list.
+### Closing the channel
+
+Channels remain open for reuse across requests. Call `session.close()` to settle on-chain and reclaim unspent deposit.
+
+:::warning
+Channels do not close automatically. If you don't call `close()`, the deposit stays locked in the escrow contract until the channel expires or is manually closed.
 :::
+
+See [`tempo.session` manager](/sdk/typescript/client/Method.tempo.session-manager) for the full session lifecycle API.
 
   </div>
   </Tab>

--- a/src/pages/sdk/typescript/client/McpClient.wrap.mdx
+++ b/src/pages/sdk/typescript/client/McpClient.wrap.mdx
@@ -1,0 +1,71 @@
+# `McpClient.wrap` [Payment-aware MCP client]
+
+Wraps an MCP SDK client with automatic payment handling. When a tool call returns a `-32042` payment required error, the wrapper creates a Credential and retries the call.
+
+## Usage
+
+```ts
+import { Client } from '@modelcontextprotocol/sdk/client'
+import { McpClient, tempo } from 'mppx/mcp-sdk/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const client = new Client({ name: 'my-client', version: '1.0.0' })
+await client.connect(transport)
+
+const mcp = McpClient.wrap(client, {
+  methods: [tempo({ account: privateKeyToAccount('0x...') })],
+})
+
+const result = await mcp.callTool({ name: 'premium_tool', arguments: {} })
+// @log: { content: [...], receipt: { ... } }
+```
+
+### With call options
+
+Pass `context` and `timeout` through the second argument to `callTool`.
+
+```ts
+const result = await mcp.callTool(
+  { name: 'premium_tool', arguments: { query: 'hello' } },
+  { context: { foo: 'bar' }, timeout: 30_000 },
+)
+```
+
+## Return type
+
+`McpClient.wrap` returns an object that spreads the original client and overrides `callTool` with a payment-aware version.
+
+```ts
+type McpClient<client, methods> = Omit<client, 'callTool'> & {
+  callTool: (
+    params: {
+      arguments?: Record<string, unknown>
+      name: string
+      _meta?: Record<string, unknown>
+    },
+    options?: CallToolOptions<methods>,
+  ) => Promise<CallToolResult>
+}
+```
+
+The `CallToolResult` type extends the SDK's return type with a `receipt` field:
+
+```ts
+type CallToolResult = Awaited<ReturnType<Client['callTool']>> & {
+  receipt: Mcp.Receipt | undefined
+}
+```
+
+## Parameters
+
+### client
+
+- **Type:** `Pick<Client, 'callTool'>`
+
+The MCP SDK client instance to wrap. Must have a `callTool` method—typically an instance of `Client` from `@modelcontextprotocol/sdk/client`.
+
+### config.methods
+
+- **Type:** `readonly Method.AnyClient[]`
+
+Array of payment methods to use when handling payment Challenges. The wrapper matches Challenges from the server against installed methods by name and intent.

--- a/src/pages/sdk/typescript/client/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.mdx
@@ -35,6 +35,25 @@ Mppx.create({
 })
 ```
 
+### Standalone session manager
+
+`tempo.session()` also creates a standalone session manager with explicit `.fetch()`, `.close()`, and `.sse()` methods—no `Mppx.create` required:
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const session = tempo.session({
+  account: privateKeyToAccount('0x...'),
+  maxDeposit: '1',
+})
+
+const res = await session.fetch('https://api.example.com/resource')
+await session.close()
+```
+
+See [`tempo.session` manager](/sdk/typescript/client/Method.tempo.session-manager) for the full API.
+
 ## Return type
 
 ```ts

--- a/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
@@ -1,0 +1,282 @@
+# `tempo.session` [Standalone session manager]
+
+Creates a standalone session manager that handles the full payment channel lifecycle—open, fetch, stream, and close—without `Mppx.create` or `Fetch.from`.
+
+Use this when you need direct control over session state instead of automatic 402 handling.
+
+## Usage
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+const session = tempo.session({
+  account,
+  maxDeposit: '1',
+})
+
+// Make a paid request — opens a channel on first call
+const response = await session.fetch('https://api.example.com/resource')
+console.log(response.status)
+// @log: 200
+
+// Access payment metadata
+console.log(response.receipt)
+console.log(response.cumulative)
+
+// Close the channel and settle on-chain
+const receipt = await session.close()
+```
+
+:::warning
+Channels remain open until you call `session.close()`. Always close sessions when done to settle on-chain and reclaim unspent deposit.
+:::
+
+### Session resumption
+
+All channel state is held in memory. If the client process restarts, the session is lost and a new on-chain channel opens on the next request—the previous channel's deposit is orphaned until manually closed.
+
+When the server includes a `channelId` in the `402` Challenge, the client attempts to recover the channel by reading its on-chain state. If the channel has a positive deposit and is not finalized, it resumes from the on-chain settled amount.
+
+### With SSE streaming
+
+Stream server-sent events with automatic voucher handling. The session signs incremental vouchers as the server requests them during the stream.
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const session = tempo.session({
+  account: privateKeyToAccount('0x...'),
+  maxDeposit: '5',
+})
+
+const stream = await session.sse('https://api.example.com/stream', {
+  onReceipt(receipt) {
+    console.log('Receipt:', receipt)
+  },
+  signal: AbortSignal.timeout(30_000),
+})
+
+for await (const message of stream) {
+  console.log(message)
+}
+
+await session.close()
+```
+
+### With explicit open
+
+Open the channel before the first request. This separates the on-chain deposit transaction from the first API call.
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+const session = tempo.session({
+  account,
+  maxDeposit: '10',
+})
+
+// Trigger a 402 to receive the challenge
+await session.fetch('https://api.example.com/resource')
+
+// Open the channel explicitly
+await session.open()
+
+// Subsequent requests use the open channel
+const response = await session.fetch('https://api.example.com/resource')
+```
+
+## Return type
+
+`tempo.session()` returns a `SessionManager` object:
+
+```ts
+type SessionManager = {
+  readonly channelId: Hex | undefined
+  readonly cumulative: bigint
+  readonly opened: boolean
+  open(options?: { deposit?: bigint }): Promise<void>
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<PaymentResponse>
+  sse(
+    input: RequestInfo | URL,
+    init?: RequestInit & {
+      onReceipt?: (receipt: SessionReceipt) => void
+      signal?: AbortSignal
+    },
+  ): Promise<AsyncIterable<string>>
+  close(): Promise<SessionReceipt | undefined>
+}
+```
+
+### `PaymentResponse`
+
+`session.fetch()` returns a standard `Response` extended with payment metadata:
+
+```ts
+type PaymentResponse = Response & {
+  receipt: SessionReceipt | null
+  challenge: Challenge | null
+  channelId: Hex | null
+  cumulative: bigint
+}
+```
+
+### `SessionReceipt`
+
+The receipt returned by `session.close()` and available on `PaymentResponse.receipt`:
+
+```ts
+type SessionReceipt = {
+  method: 'tempo'
+  intent: 'session'
+  status: 'success'
+  timestamp: string
+  /** Payment channel ID (not a transaction hash). */
+  reference: string
+  challengeId: string
+  channelId: Hex
+  /** Highest cumulative voucher amount accepted by the server. */
+  acceptedCumulative: string
+  /** Total amount spent in this session. */
+  spent: string
+  /** Number of units consumed (if the server tracks units). */
+  units?: number
+  /** On-chain settlement transaction hash. Present after close. */
+  txHash?: Hex
+}
+```
+
+:::info
+The `reference` field contains the channel ID, not a transaction hash. To get the settlement transaction hash, read `txHash` from the receipt returned by `session.close()`.
+:::
+
+## Parameters
+
+### account (optional)
+
+- **Type:** `Account`
+
+Account to sign vouchers with.
+
+### authorizedSigner (optional)
+
+- **Type:** `Address`
+
+Address authorized to sign vouchers. Defaults to the account address. Use when a separate access key signs vouchers while the root account funds the channel.
+
+### client (optional)
+
+- **Type:** `Client`
+
+Viem client instance. Shorthand for `getClient: () => client`.
+
+### decimals (optional)
+
+- **Type:** `number`
+- **Default:** `6`
+
+Token decimals for parsing human-readable amounts like `maxDeposit`.
+
+### escrowContract (optional)
+
+- **Type:** `Address`
+
+Escrow contract address override. Derived from the server Challenge if not provided.
+
+### fetch (optional)
+
+- **Type:** `typeof globalThis.fetch`
+- **Default:** `globalThis.fetch`
+
+Custom fetch function to use for requests.
+
+### getClient (optional)
+
+- **Type:** `(parameters: { chainId: number }) => MaybePromise<Client>`
+
+Function that returns a viem client for the given chain ID.
+
+### maxDeposit (optional)
+
+- **Type:** `string`
+
+Maximum deposit in human-readable units (for example `"10"` for 10 tokens). Caps the server's suggested deposit and enables automatic channel management.
+
+## Methods
+
+### `session.close()`
+
+Closes the payment channel and settles on-chain. Returns the final `SessionReceipt` if available, or `undefined` if no channel was open.
+
+```ts
+const receipt = await session.close()
+```
+
+### `session.fetch(input, init?)`
+
+Makes a payment-aware request. Handles the 402 Challenge → Credential flow automatically, opening a channel on first use if needed.
+
+Returns a [`PaymentResponse`](#paymentresponse) with payment metadata attached.
+
+```ts
+const response = await session.fetch('https://api.example.com/resource')
+console.log(response.receipt)
+console.log(response.cumulative)
+```
+
+### `session.open(options?)`
+
+Opens the payment channel explicitly. You must make at least one `fetch()` or `sse()` call first to receive a 402 Challenge from the server.
+
+- **options.deposit** (`bigint`, optional) — Raw deposit amount in token units.
+
+```ts
+await session.fetch('https://api.example.com/resource')
+await session.open()
+```
+
+### `session.sse(input, init?)`
+
+Opens a server-sent events stream with automatic voucher signing. The server requests incremental vouchers via `payment-need-voucher` events, and the session signs them transparently.
+
+Returns an `AsyncIterable<string>` of message payloads.
+
+- **init.onReceipt** (`(receipt: SessionReceipt) => void`, optional) — Called when the server sends a payment Receipt during the stream.
+- **init.signal** (`AbortSignal`, optional) — Aborts the stream.
+
+```ts
+const stream = await session.sse('https://api.example.com/stream', {
+  onReceipt: (receipt) => console.log('paid:', receipt),
+  signal: AbortSignal.timeout(60_000),
+})
+
+for await (const message of stream) {
+  console.log(message)
+}
+```
+
+## Properties
+
+### `session.channelId`
+
+- **Type:** `Hex | undefined`
+
+The on-chain channel ID after the channel opens. `undefined` before the first successful payment.
+
+### `session.cumulative`
+
+- **Type:** `bigint`
+
+The cumulative amount paid across all vouchers in this session. Starts at `0n`.
+
+### `session.opened`
+
+- **Type:** `boolean`
+
+Whether the payment channel is currently open.

--- a/src/pages/sdk/typescript/client/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session.mdx
@@ -1,6 +1,10 @@
 # `Method.tempo.session` [Low-cost high-throughput payments]
 
-Creates a Tempo payment session method for client-side voucher signing.
+Creates a Tempo payment session method for client-side voucher signing. Pass the result to `Mppx.create` for automatic 402 handling.
+
+:::info
+For standalone session management with explicit `.fetch()`, `.close()`, and `.sse()` methods, see [`tempo.session` manager](/sdk/typescript/client/Method.tempo.session-manager).
+:::
 
 ## Usage
 
@@ -39,7 +43,7 @@ Mppx.create({
 
 ## Return type
 
-```ts
+```ts twoslash
 import type { Method } from 'mppx'
 
 type ReturnType = Method.Client

--- a/src/pages/sdk/typescript/proxy.mdx
+++ b/src/pages/sdk/typescript/proxy.mdx
@@ -1,0 +1,347 @@
+# Proxy [Paid API proxy]
+
+Gates upstream API services behind MPP `402` payments. The proxy handles routing, credential injection, and payment verification—you configure which endpoints require payment and which are free passthrough.
+
+## Install
+
+:::code-group
+
+```bash [npm]
+npm install mppx
+```
+
+```bash [pnpm]
+pnpm add mppx
+```
+
+```bash [bun]
+bun add mppx
+```
+
+:::
+
+## Usage
+
+Import `Proxy` and a service preset from `mppx/proxy`, then create an `Mppx` server instance from `mppx/server` to define payment intents.
+
+```ts twoslash [server.ts]
+import { Proxy, openai } from 'mppx/proxy'
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({ methods: [tempo()] })
+
+const proxy = Proxy.create({
+  services: [
+    openai({
+      apiKey: process.env.OPENAI_API_KEY!,
+      routes: {
+        'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
+        'GET /v1/models': true,
+      },
+    }),
+  ],
+})
+
+// Bun / Deno
+export default { fetch: proxy.fetch }
+
+// Node.js
+import { createServer } from 'node:http'
+createServer(proxy.listener).listen(3000)
+```
+
+The proxy returns two handlers:
+
+- **`fetch`** — Fetch API handler. Works with Bun, Deno, Next.js, Hono, Elysia, and SvelteKit.
+- **`listener`** — Node.js request listener. Works with Express, Fastify, and `http.createServer`.
+
+### Multiple services
+
+Pass multiple services to gate several upstream APIs behind a single proxy.
+
+```ts twoslash [server.ts]
+import { Proxy, anthropic, openai, stripe } from 'mppx/proxy'
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({ methods: [tempo()] })
+
+const proxy = Proxy.create({
+  description: 'Multi-service paid API proxy',
+  title: 'My Proxy',
+  services: [
+    openai({
+      apiKey: process.env.OPENAI_API_KEY!,
+      routes: {
+        'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
+      },
+    }),
+    anthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY!,
+      routes: {
+        'POST /v1/messages': mppx.charge({ amount: '0.03' }),
+      },
+    }),
+    stripe({
+      apiKey: process.env.STRIPE_API_KEY!,
+      routes: {
+        'POST /v1/charges': mppx.charge({ amount: '1' }),
+        'GET /v1/customers/:id': true,
+      },
+    }),
+  ],
+})
+```
+
+Each service is mounted at `/{serviceId}/`—for example, requests to `/openai/v1/chat/completions` route to `https://api.openai.com/v1/chat/completions`.
+
+## Built-in services
+
+### `openai`
+
+Creates an OpenAI service definition. Injects `Authorization: Bearer` header for upstream authentication.
+
+```ts [server.ts]
+import { openai } from 'mppx/proxy'
+
+openai({
+  apiKey: 'sk-...',
+  routes: {
+    'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
+    'POST /v1/embeddings': mppx.charge({ amount: '0.01' }),
+    'POST /v1/images/generations': mppx.charge({ amount: '0.10' }),
+    'GET /v1/models': true,
+  },
+})
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKey` | `string` | OpenAI API key. Used as `Authorization: Bearer` header. |
+| `baseUrl` (optional) | `string` | Base URL override. Defaults to `'https://api.openai.com'`. |
+| `routes` | `EndpointMap` | Route definitions for OpenAI endpoints. |
+
+**Typed routes:** `POST /v1/chat/completions`, `POST /v1/completions`, `POST /v1/embeddings`, `POST /v1/images/generations`, `POST /v1/images/edits`, `POST /v1/images/variations`, `POST /v1/audio/transcriptions`, `POST /v1/audio/translations`
+
+### `anthropic`
+
+Creates an Anthropic service definition. Injects `x-api-key` header for upstream authentication.
+
+```ts [server.ts]
+import { anthropic } from 'mppx/proxy'
+
+anthropic({
+  apiKey: 'sk-ant-...',
+  routes: {
+    'POST /v1/messages': mppx.charge({ amount: '0.03' }),
+    'POST /v1/complete': mppx.charge({ amount: '0.02' }),
+  },
+})
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKey` | `string` | Anthropic API key. Used as `x-api-key` header. |
+| `baseUrl` (optional) | `string` | Base URL override. Defaults to `'https://api.anthropic.com'`. |
+| `routes` | `EndpointMap` | Route definitions for Anthropic endpoints. |
+
+**Typed routes:** `POST /v1/messages`, `POST /v1/messages/batches`, `GET /v1/messages/batches`, `GET /v1/messages/batches/:batchId`, `POST /v1/complete`
+
+### `stripe`
+
+Creates a Stripe service definition. Injects `Authorization: Basic` header (API key as username) for upstream authentication. This is a proxy service for the Stripe API—not a payment method.
+
+```ts [server.ts]
+import { stripe } from 'mppx/proxy'
+
+stripe({
+  apiKey: 'sk-...',
+  routes: {
+    'POST /v1/charges': mppx.charge({ amount: '1' }),
+    'GET /v1/customers/:id': true,
+  },
+})
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKey` | `string` | Stripe API key. Used as Basic auth username. |
+| `baseUrl` (optional) | `string` | Base URL override. Defaults to `'https://api.stripe.com'`. |
+| `routes` | `EndpointMap` | Route definitions for Stripe endpoints. |
+
+**Typed routes:** `POST /v1/charges`, `POST /v1/customers`, `GET /v1/customers/:id`, `POST /v1/payment_intents`, `GET /v1/payment_intents/:id`, `POST /v1/subscriptions`, `GET /v1/subscriptions/:id`, `POST /v1/invoices`, `GET /v1/invoices/:id`
+
+## Custom services
+
+Use `Service.from` (or its alias `custom`) to define a service for any upstream API.
+
+### With `bearer` shorthand
+
+```ts twoslash [server.ts]
+import { Proxy, Service } from 'mppx/proxy'
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({ methods: [tempo()] })
+
+const proxy = Proxy.create({
+  services: [
+    Service.from('my-api', {
+      baseUrl: 'https://api.example.com',
+      bearer: process.env.MY_API_KEY!,
+      description: 'Example upstream API',
+      title: 'My API',
+      routes: {
+        'POST /v1/generate': mppx.charge({ amount: '0.01' }),
+        'GET /v1/status': true,
+      },
+    }),
+  ],
+})
+```
+
+### With `headers` shorthand
+
+```ts [server.ts]
+import { Service } from 'mppx/proxy'
+
+Service.from('custom-api', {
+  baseUrl: 'https://api.example.com',
+  headers: {
+    'X-API-Key': process.env.CUSTOM_API_KEY!,
+    'X-Org-Id': 'org-123',
+  },
+  routes: {
+    'POST /v1/query': mppx.charge({ amount: '0.02' }),
+  },
+})
+```
+
+### With `rewriteRequest`
+
+For full control over the upstream request, use `rewriteRequest`. The context includes per-endpoint options set via the `options` field on an endpoint definition.
+
+```ts [server.ts]
+import { Service } from 'mppx/proxy'
+
+Service.from('advanced-api', {
+  baseUrl: 'https://api.example.com',
+  rewriteRequest(request, ctx) {
+    request.headers.set('Authorization', `Token ${process.env.API_TOKEN}`)
+    return request
+  },
+  routes: {
+    'POST /v1/generate': mppx.charge({ amount: '0.05' }),
+  },
+})
+```
+
+## Discovery endpoints
+
+The proxy automatically serves discovery endpoints that describe available services and their routes. Coding agents and CLI tools use these endpoints to understand what the proxy offers.
+
+| Endpoint | Content-Type | Description |
+|----------|--------------|-------------|
+| `GET /discover` | `application/json` or `text/plain` | Lists all services. Returns JSON by default, markdown for AI user agents and terminal clients. |
+| `GET /discover/{id}` | `application/json` or `text/markdown` | Details for a single service, including routes and pricing. |
+| `GET /discover/{id}.md` | `text/markdown` | Markdown description of a single service. |
+| `GET /discover/all` | `application/json` or `text/markdown` | All services with full route details. |
+| `GET /discover/all.md` | `text/markdown` | Markdown listing of all services and routes. |
+| `GET /llms.txt` | `text/plain` | `llms.txt`-formatted overview of the proxy and its services. |
+| `GET /discover.md` | `text/plain` | Alias for `/llms.txt`. |
+
+The proxy returns markdown instead of JSON when the request comes from a known AI user agent (for example, `ChatGPT-User`, `ClaudeBot`, `PerplexityBot`) or a terminal client (for example, `curl`, `HTTPie`, `mppx`).
+
+## Parameters
+
+### `Proxy.create` config
+
+### basePath (optional)
+
+- **Type:** `string`
+
+Base path prefix to strip before routing (for example, `'/api/proxy'`). Use when the proxy is mounted at a sub-path.
+
+### description (optional)
+
+- **Type:** `string`
+
+Short description of the proxy shown in `llms.txt` and discovery endpoints.
+
+### fetch (optional)
+
+- **Type:** `typeof globalThis.fetch`
+
+Custom `fetch` implementation. Defaults to `globalThis.fetch`.
+
+### services
+
+- **Type:** `Service[]`
+
+Array of service definitions to proxy. Each service is mounted at `/{serviceId}/`.
+
+### title (optional)
+
+- **Type:** `string`
+
+Human-readable title for the proxy shown in `llms.txt` and discovery endpoints.
+
+## Service type reference
+
+### `Service.from` config
+
+### baseUrl
+
+- **Type:** `string`
+
+Base URL of the upstream service (for example, `'https://api.openai.com'`).
+
+### bearer (optional)
+
+- **Type:** `string`
+
+Shorthand: injects `Authorization: Bearer {token}` header on upstream requests.
+
+### description (optional)
+
+- **Type:** `string`
+
+Short description of the service, shown in discovery endpoints.
+
+### docsLlmsUrl (optional)
+
+- **Type:** `string | ((options: { route?: string }) => string | undefined)`
+
+Documentation URL for the service. Provide a string for a static URL, or a function that receives an optional route pattern and returns a per-endpoint docs URL.
+
+### headers (optional)
+
+- **Type:** `Record<string, string>`
+
+Shorthand: injects custom headers on upstream requests.
+
+### mutate (optional)
+
+- **Type:** `(req: Request) => Request | Promise<Request>`
+
+Shorthand: full request mutation function. Takes priority over `bearer` and `headers`.
+
+### rewriteRequest (optional)
+
+- **Type:** `(req: Request, ctx: Context) => Request | Promise<Request>`
+
+Hook to modify the upstream request before sending. Receives per-endpoint options via `ctx`.
+
+### routes
+
+- **Type:** `EndpointMap`
+
+Map of `"METHOD /pattern"` keys to endpoint definitions. Each value is one of:
+
+- **`IntentHandler`** — Payment required. The handler issues a `402` Challenge or verifies payment.
+- **`{ pay: IntentHandler, options: EndpointOptions }`** — Payment required with per-endpoint config overrides passed to `rewriteRequest` via `ctx`.
+- **`true`** — Free passthrough. No payment required; `rewriteRequest` is still applied.
+
+### title (optional)
+
+- **Type:** `string`
+
+Human-readable title for the service (for example, `'OpenAI'`).

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -56,6 +56,13 @@ Account used as the recipient and for session closure.
 
 Default amount to charge per unit.
 
+### channelStateTtl (optional)
+
+- **Type:** `number`
+- **Default:** `60000`
+
+TTL in milliseconds for cached on-chain channel state. After this duration, the server re-queries on-chain state during voucher handling to detect forced close requests.
+
 ### currency (optional)
 
 - **Type:** `Address`
@@ -138,4 +145,42 @@ Testnet mode.
 - **Type:** `string`
 
 Unit type label (for example, "token", "byte", "request").
+
+### waitForConfirmation (optional)
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to wait for open transactions to confirm on-chain before responding. When `false`, the transaction is simulated and broadcast without waiting for inclusion.
+
+## Related
+
+### `tempo.settle`
+
+One-shot settlement: reads the highest voucher from the store and submits it on-chain. Use this for periodic batch settlement outside the request handler.
+
+```ts
+import { tempo } from 'mppx/server'
+import { Store } from 'mppx/server'
+import { createClient, http } from 'viem'
+import { tempo as tempoChain } from 'viem/chains'
+
+const client = createClient({ chain: tempoChain, transport: http() })
+const store = Store.memory()
+
+// Settle a specific channel
+const txHash = await tempo.settle(store, client, '0xchannelId...')
+```
+
+#### Parameters
+
+- **store** — `ChannelStore` — The channel store instance.
+- **client** — `Client` — A viem client for on-chain interaction.
+- **channelId** — `Hex` — The channel to settle.
+- **options.escrowContract** (optional) — `Address` — Escrow contract override.
+- **options.feePayer** (optional) — `Account` — Fee payer account.
+
+#### Return type
+
+- **Type:** `Hex` — The settlement transaction hash.
 

--- a/src/pages/sdk/typescript/server/Request.toNodeListener.mdx
+++ b/src/pages/sdk/typescript/server/Request.toNodeListener.mdx
@@ -1,0 +1,46 @@
+# `Request.toNodeListener` [Convert Fetch handlers to Node.js]
+
+Converts a Fetch API handler into a Node.js HTTP request listener. Useful for running an MPP server on bare `node:http` without a framework.
+
+## Usage
+
+```ts
+import http from 'node:http'
+import { Mppx, Request, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({ methods: [tempo()] })
+
+const server = http.createServer(
+  Request.toNodeListener(mppx.request),
+)
+
+server.listen(3000)
+```
+
+### `Request.fromNodeListener`
+
+Converts a Node.js `IncomingMessage`/`ServerResponse` pair into a Fetch API `Request`. Useful when you need to manually construct a `Request` inside existing Node.js middleware.
+
+```ts
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { Request } from 'mppx/server'
+
+function middleware(req: IncomingMessage, res: ServerResponse) {
+  const request = Request.fromNodeListener(req, res)
+  // handle as a Fetch API Request
+}
+```
+
+## Parameters
+
+### handler
+
+- **Type:** `(request: Request) => Promise<Response> | Response`
+
+A Fetch API handler that receives a `Request` and returns a `Response`.
+
+### options (optional)
+
+- **Type:** `RequestListenerOptions`
+
+Options forwarded to the underlying adapter, including an optional error handler.

--- a/src/pages/sdk/typescript/server/Response.requirePayment.mdx
+++ b/src/pages/sdk/typescript/server/Response.requirePayment.mdx
@@ -1,0 +1,47 @@
+# `Response.requirePayment` [Create a 402 response]
+
+Creates a `402` Payment Required response with a `WWW-Authenticate: Payment` header. Optionally includes RFC 9457 Problem Details in the response body when an error is provided.
+
+## Usage
+
+```ts twoslash
+import { Challenge } from 'mppx'
+import { Response } from 'mppx/server'
+
+const challenge = Challenge.from({
+  id: 'challenge-123',
+  method: 'tempo',
+  intent: 'charge',
+  realm: 'api.example.com',
+  request: {
+    amount: '1.00',
+    currency: '0x20c0000000000000000000000000000000000000',
+    recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
+  },
+})
+
+const response = Response.requirePayment({ challenge })
+// @log: Response { status: 402, headers: { 'WWW-Authenticate': 'Payment ...' } }
+```
+
+## Return type
+
+```ts
+type ReturnType = Response
+```
+
+A standard `Response` with status `402` and a `WWW-Authenticate: Payment` header containing the serialized Challenge. When an `error` is provided, the body contains a JSON problem details object with `Content-Type: application/problem+json`.
+
+## Parameters
+
+### challenge
+
+- **Type:** `Challenge`
+
+The Challenge to serialize into the `WWW-Authenticate` header.
+
+### error (optional)
+
+- **Type:** `PaymentError`
+
+An error to include as RFC 9457 Problem Details in the response body.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -203,6 +203,10 @@ export default defineConfig({
                         link: "/sdk/typescript/client/Method.tempo.session",
                       },
                       {
+                        text: "tempo.session (manager)",
+                        link: "/sdk/typescript/client/Method.tempo.session-manager",
+                      },
+                      {
                         text: "stripe",
                         link: "/sdk/typescript/client/Method.stripe",
                       },
@@ -241,6 +245,16 @@ export default defineConfig({
                       {
                         text: ".mcp",
                         link: "/sdk/typescript/client/Transport.mcp",
+                      },
+                    ],
+                  },
+                  {
+                    text: "MCP",
+                    collapsed: true,
+                    items: [
+                      {
+                        text: "McpClient.wrap",
+                        link: "/sdk/typescript/client/McpClient.wrap",
                       },
                     ],
                   },
@@ -315,6 +329,20 @@ export default defineConfig({
                       },
                     ],
                   },
+                  {
+                    text: "Utilities",
+                    collapsed: true,
+                    items: [
+                      {
+                        text: "Response.requirePayment",
+                        link: "/sdk/typescript/server/Response.requirePayment",
+                      },
+                      {
+                        text: "Request.toNodeListener",
+                        link: "/sdk/typescript/server/Request.toNodeListener",
+                      },
+                    ],
+                  },
                 ],
               },
               {
@@ -337,6 +365,10 @@ export default defineConfig({
                     link: "/sdk/typescript/middlewares/nextjs",
                   },
                 ],
+              },
+              {
+                text: "Proxy",
+                link: "/sdk/typescript/proxy",
               },
               {
                 text: "Core reference",


### PR DESCRIPTION
Adds documentation for several undocumented SDK features and improves existing session docs.

## New pages

- **`Method.tempo.session-manager.mdx`** — Standalone SessionManager API (`.fetch()`, `.sse()`, `.open()`, `.close()`) with full type definitions for `PaymentResponse` and `SessionReceipt`
- **`proxy.mdx`** — `Proxy.create`, built-in service presets (OpenAI, Anthropic, Stripe), custom services via `Service.from`, and discovery endpoints (`/discover`, `/llms.txt`)
- **`McpClient.wrap.mdx`** — Payment-aware MCP SDK client wrapper with `-32042` error handling
- **`Response.requirePayment.mdx`** — Create `402` responses with `WWW-Authenticate: Payment` header
- **`Request.toNodeListener.mdx`** — Convert Fetch API handlers to Node.js `http.createServer` listeners

## Updated pages

- **`session.mdx`** — Added session receipts comparison table (`reference` = channelId, not txHash) and closing channel section
- **`pay-as-you-go.mdx`** — Added closing the channel section with `tempo.session()` example
- **`streamed-payments.mdx`** — Added closing the channel section after SSE streaming
- **`Method.tempo.session.mdx` (server)** — Added `tempo.settle` docs for batch settlement, fixed parameter alphabetization
- **`Method.tempo.mdx`** — Added standalone session manager cross-reference
- **`Method.tempo.session.mdx` (client)** — Added cross-link to session-manager page
- **`vocs.config.ts`** — Added all new pages to sidebar

## Verification

- `pnpm check:types` ✅
- `pnpm build` ✅ (with `checkDeadlinks: true`)
- All types and API surfaces verified against `node_modules/mppx/src/`
- Parameters alphabetized per AGENTS.md conventions