### PR TITLE
feat: add amountHint field for dynamic endpoint pricing hints

### DIFF
--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -2473,7 +2473,8 @@
             "currency": "0x20c000000000000000000000b9537d11c60e8b50",
             "decimals": 6,
             "description": "Multi-hop web research task - price varies by processor",
-            "dynamic": true
+            "dynamic": true,
+            "amountHint": "$0.10 – $0.30"
           }
         }
       ]

--- a/schemas/discovery.schema.json
+++ b/schemas/discovery.schema.json
@@ -197,6 +197,10 @@
           "const": true,
           "description": "When present (always true), indicates dynamic pricing — the price is determined at request time based on factors such as model, token count, or content size. The amount field may be omitted or may represent a base/minimum price."
         },
+        "amountHint": {
+          "type": "string",
+          "description": "Freeform pricing hint for dynamic endpoints (e.g. '$0.10 – $0.30 depending on processor'). Only valid when dynamic is true."
+        },
         "description": {
           "type": "string",
           "description": "Human-readable pricing note."

--- a/schemas/services.test.ts
+++ b/schemas/services.test.ts
@@ -172,6 +172,14 @@ describe("services registry", () => {
               );
             }
           });
+
+          it("does not have amountHint without dynamic", () => {
+            if (ep.amountHint !== undefined && ep.dynamic !== true) {
+              expect.fail(
+                `Endpoint "${ep.route}" has amountHint without dynamic: true`,
+              );
+            }
+          });
         });
       }
     });

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -73,6 +73,8 @@ export interface EndpointDef {
   amount?: string;
   /** Dynamic pricing — price computed at runtime based on model/tokens/size */
   dynamic?: true;
+  /** Freeform pricing hint for dynamic endpoints (e.g. "$0.10 – $0.30 depending on processor") */
+  amountHint?: string;
   /** Override service-level default intent */
   intent?: Intent;
   /** Unit type (e.g., "request") */
@@ -1042,6 +1044,7 @@ export const services: ServiceDef[] = [
         route: "POST /api/task",
         desc: "Multi-hop web research task - price varies by processor",
         dynamic: true,
+        amountHint: "$0.10 – $0.30",
       },
     ],
   },

--- a/scripts/generate-discovery.ts
+++ b/scripts/generate-discovery.ts
@@ -84,7 +84,9 @@ export function buildPayment(
   };
 
   if (ep.dynamic) {
-    return { ...base, dynamic: true };
+    const dyn: Record<string, unknown> = { ...base, dynamic: true };
+    if (ep.amountHint) dyn.amountHint = ep.amountHint;
+    return dyn;
   }
 
   const payment: Record<string, unknown> = { ...base, amount: ep.amount };
@@ -131,6 +133,13 @@ export function validateServices(svcs: ServiceDef[]): void {
       if (ep.amount && ep.dynamic) {
         throw new Error(
           `Endpoint "${ep.route}" in service "${svc.id}" has both amount and dynamic`,
+        );
+      }
+
+      // amountHint requires dynamic
+      if (ep.amountHint && !ep.dynamic) {
+        throw new Error(
+          `Endpoint "${ep.route}" in service "${svc.id}" has amountHint without dynamic: true`,
         );
       }
 

--- a/src/components/ServiceDiscovery.tsx
+++ b/src/components/ServiceDiscovery.tsx
@@ -865,7 +865,7 @@ function ServiceDetailModal({
 
   function formatPrice(ep: Endpoint): string {
     const p = ep.payment;
-    if (!p?.amount) return "—";
+    if (!p?.amount) return p?.amountHint ?? "—";
     const v = Number(p.amount) / 10 ** (p.decimals ?? 0);
     if (Number.isNaN(v)) return "—";
     if (v >= 0.01) return `$${v.toFixed(2)}`;

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -41,7 +41,7 @@ export function allCategories(s: Service): Category[] {
 export function formatPrice(ep: Endpoint): string {
   const p = ep.payment;
   if (!p) return "\u2014";
-  if (!p.amount) return "\u2014";
+  if (!p.amount) return p.amountHint ?? "\u2014";
   const v = Number(p.amount) / 10 ** (p.decimals ?? 0);
   if (Number.isNaN(v)) return "\u2014";
   if (v === 0) return "$0";

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -33,6 +33,7 @@ export interface EndpointPayment {
   unitType?: string;
   description?: string;
   dynamic?: true;
+  amountHint?: string;
 }
 
 export interface Endpoint {


### PR DESCRIPTION
Adds an optional `amountHint` string to dynamic endpoints, allowing services to provide freeform pricing guidance (e.g. "$0.10 – $0.30") when the exact amount is determined at runtime.

### Changes

- **`EndpointDef.amountHint`** — new optional string field, only valid when `dynamic: true`
- **Generator** — propagates `amountHint` into discovery JSON; validates it requires `dynamic`
- **JSON Schema** — added `amountHint` to `EndpointPayment` definition
- **UI** — `formatPrice()` shows `amountHint` instead of `—` for dynamic endpoints
- **Parallel `/api/task`** — first usage: `"$0.10 – $0.30"`

### Validation

- `amountHint` without `dynamic: true` → build error + test failure
- All 2945 tests pass