### PR TITLE
docs: add escrow contract addresses to session page

### DIFF
--- a/scripts/check-addresses.test.ts
+++ b/scripts/check-addresses.test.ts
@@ -28,7 +28,8 @@ const ALLOWED_ADDRESSES: ReadonlySet<string> = new Set(
     "0x20C000000000000000000000b9537d11c60E8b50", // USDC on Tempo
     "0x0000000000000000000000000000000000000001", // native token
     "0x33b901018174DDabE4841042ab76ba85D4e24f25", // Mainnet payment channel
-    "0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70", // Testnet payment channel
+    "0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70", // Testnet payment channel (deprecated)
+    "0xe1c4d3dce17bc111181ddf716f75bae49e61a336", // Testnet payment channel
 
     // Placeholder/example addresses
     "0x1234567890abcdef1234567890abcdef12345678", // generic placeholder

--- a/src/pages/payment-methods/tempo/session.mdx
+++ b/src/pages/payment-methods/tempo/session.mdx
@@ -231,7 +231,7 @@ Sessions use the `TempoStreamChannel` escrow contract for on-chain deposits, set
 | Network | Chain ID | Contract Address |
 |---|---|---|
 | [Mainnet](https://explore.mainnet.tempo.xyz/address/0x33b901018174DDabE4841042ab76ba85D4e24f25?tab=contract) | 98865 | `0x33b901018174DDabE4841042ab76ba85D4e24f25` |
-| [Testnet (Moderato)](https://explore.testnet.tempo.xyz/address/0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70?tab=contract) | 42431 | `0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70` |
+| [Testnet (Moderato)](https://explore.testnet.tempo.xyz/address/0xe1c4d3dce17bc111181ddf716f75bae49e61a336?tab=contract) | 42431 | `0xe1c4d3dce17bc111181ddf716f75bae49e61a336` |
 
 ## Specification
 


### PR DESCRIPTION
Adds an **Escrow contract** section to the Tempo session payment method page with:

- Link to the `TempoStreamChannel` [reference implementation](https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/TempoStreamChannel.sol) in `tempoxyz/tempo`
- Mainnet contract address (`0x33b901018174DDabE4841042ab76ba85D4e24f25`) linked to explorer
- Testnet (Moderato) contract address (`0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70`) linked to explorer