### PR TITLE
feat: add EVM payment method with Permit2 support

### DIFF
--- a/src/components/cards.tsx
+++ b/src/components/cards.tsx
@@ -264,6 +264,28 @@ export function StripeMethodCard() {
   );
 }
 
+export function EvmMethodCard() {
+  return (
+    <Card
+      description="Any ERC-20 on any EVM chain via Permit2"
+      icon="lucide:blocks"
+      title="EVM"
+      to="/payment-methods/evm"
+    />
+  );
+}
+
+export function EvmChargeCard() {
+  return (
+    <Card
+      description="One-time ERC-20 transfers via Permit2"
+      icon="lucide:blocks"
+      title="EVM charge"
+      to="/payment-methods/evm/charge"
+    />
+  );
+}
+
 export function CustomMethodCard() {
   return (
     <Card

--- a/src/pages/payment-methods/evm/charge.mdx
+++ b/src/pages/payment-methods/evm/charge.mdx
@@ -1,0 +1,192 @@
+import { Cards } from 'vocs'
+import { SpecCard } from '../../../components/SpecCard'
+
+# EVM charge [One-time ERC-20 transfers via Permit2]
+
+The EVM implementation of the [charge](/intents/charge) intent.
+
+The client signs a Permit2 `PermitTransferFrom` message authorizing a token transfer. The server calls `permitTransferFrom` on the Permit2 contract to execute the transfer on-chain. Settlement time depends on the target chain's finality.
+
+Use this method for single API calls, content access, or one-off purchases where you want to accept any ERC-20 on any EVM chain.
+
+## Server
+
+Use `evm.charge` to gate an endpoint behind a one-time ERC-20 payment. The method handles Challenge generation, Credential verification, Permit2 transaction submission, and Receipt creation.
+
+```ts twoslash
+// @noErrors
+import { Mppx, evm } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    evm.charge({
+      chainId: 8453, // Base
+      permit2Address: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+      rpcUrl: process.env.BASE_RPC_URL!,
+    }),
+  ],
+})
+
+export async function handler(request: Request) {
+  const result = await mppx.charge({
+    amount: '1000000', // 1 USDC (6 decimals)
+    currency: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // USDC on Base
+    recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
+  })(request)
+
+  if (result.status === 402) return result.challenge
+
+  return result.withReceipt(Response.json({ data: '...' }))
+}
+```
+
+### With expiry
+
+```ts twoslash
+// @noErrors
+import { Expires } from 'mppx'
+import { Mppx, evm } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    evm.charge({
+      chainId: 8453,
+      permit2Address: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+      rpcUrl: process.env.BASE_RPC_URL!,
+    }),
+  ],
+})
+
+export async function handler(request: Request) {
+  const result = await mppx.charge({
+    amount: '1000000',
+    currency: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    expires: Expires.minutes(10), // [!code hl]
+    recipient: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
+  })(request)
+
+  if (result.status === 402) return result.challenge
+  return result.withReceipt(Response.json({ data: '...' }))
+}
+```
+
+### With facilitator
+
+Offload Permit2 transaction submission to a third-party facilitator instead of submitting on-chain directly from the server.
+
+```ts twoslash
+// @noErrors
+import { Mppx, evm } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    evm.charge({
+      chainId: 8453,
+      facilitatorUrl: 'https://facilitator.example.com', // [!code hl]
+      permit2Address: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+    }),
+  ],
+})
+```
+
+When `facilitatorUrl` is set, the server forwards the signed Permit2 data to the facilitator for on-chain settlement instead of calling the Permit2 contract directly.
+
+## Client
+
+Use `evm.charge` with `Mppx.create` to automatically handle `402` responses. The client parses the Challenge, signs a Permit2 `PermitTransferFrom` message, and retries with the Credential.
+
+```ts twoslash
+// @noErrors
+import { Mppx, evm } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0xabc…123')
+
+Mppx.create({
+  methods: [
+    evm.charge({
+      account,
+    }),
+  ],
+})
+
+const response = await fetch('https://api.example.com/resource')
+```
+
+### With a wallet client
+
+Use a viem wallet client for browser-based or injected wallet signing:
+
+```ts twoslash
+// @noErrors
+import { createWalletClient, http } from 'viem'
+import { base } from 'viem/chains'
+import { Mppx, evm } from 'mppx/client'
+
+const walletClient = createWalletClient({
+  chain: base,
+  transport: http(),
+})
+
+Mppx.create({
+  methods: [
+    evm.charge({
+      walletClient, // [!code hl]
+    }),
+  ],
+})
+```
+
+### Without polyfill
+
+If you don't want to patch `globalThis.fetch`, use `mppx.fetch` directly:
+
+```ts twoslash
+// @noErrors
+import { Mppx, evm } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0xabc…123')
+
+const mppx = Mppx.create({
+  methods: [evm.charge({ account })],
+  polyfill: false,
+})
+
+const response = await mppx.fetch('https://api.example.com/resource')
+```
+
+## Challenge request fields
+
+The Challenge request includes chain and Permit2 details alongside the base charge fields.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `amount` | `string` | Required | Amount in the token's smallest unit (for example, `1000000` for 1 USDC) |
+| `chainId` | `number` | Required | EIP-155 chain ID of the target network |
+| `currency` | `string` | Required | ERC-20 token contract address |
+| `expires` | `string` | Optional | ISO 8601 expiration timestamp |
+| `permit2Address` | `string` | Required | Address of the Permit2 contract on the target chain |
+| `recipient` | `string` | Required | Recipient address for the token transfer |
+
+## Credential payload
+
+The Credential payload contains the Permit2 signature and transfer details.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `deadline` | `string` | Required | Unix timestamp after which the permit signature expires |
+| `nonce` | `string` | Required | Unique Permit2 nonce for replay protection |
+| `signature` | `string` | Required | EIP-712 signature over the `PermitTransferFrom` struct |
+
+## Supported chains
+
+The EVM payment method works on any chain where the [Permit2 contract](https://github.com/Uniswap/permit2) is deployed. Common chains include:
+
+| Chain | Chain ID | Permit2 address |
+| --- | --- | --- |
+| Ethereum | `1` | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+| Base | `8453` | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+| Arbitrum | `42161` | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+| Optimism | `10` | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+| Polygon | `137` | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |

--- a/src/pages/payment-methods/evm/index.mdx
+++ b/src/pages/payment-methods/evm/index.mdx
@@ -1,0 +1,73 @@
+import { Badge, Cards } from 'vocs'
+import { EvmChargeCard } from '../../../components/cards'
+import { MermaidDiagram } from '../../../components/MermaidDiagram'
+
+# EVM [Any ERC-20 on any EVM chain via Permit2]
+
+The EVM payment method enables payments using any ERC-20 token on any EVM-compatible blockchain through [Permit2](https://github.com/Uniswap/permit2). This extends MPP beyond Tempo to Ethereum, Base, Arbitrum, Optimism, Polygon, and every chain where Permit2 is deployed.
+
+Permit2's `SignatureTransfer` contract lets clients authorize token transfers with an off-chain signature—no per-spender approval transactions required. The server (or a facilitator) submits the signed transfer on-chain.
+
+## How it works
+
+<MermaidDiagram chart={`sequenceDiagram
+    participant Client
+    participant Server
+    participant Permit2
+    participant ERC20
+    Client->>Server: (1) GET /resource
+    Server-->>Client: (2) 402 + Challenge
+    Client->>Client: (3) Sign Permit2 transfer
+    Client->>Server: (4) GET /resource + Credential
+    Server->>Permit2: (5) permitTransferFrom(signed)
+    Permit2->>ERC20: (6) transferFrom(client, recipient)
+    Server-->>Client: (7) 200 OK + Receipt
+`} />
+
+1. **Client** requests a resource. The **server** responds with `402` and a Challenge containing the amount, token address, chain ID, and recipient.
+2. **Client** signs a Permit2 `PermitTransferFrom` message (EIP-712 typed data) authorizing the transfer.
+3. **Client** sends a Credential containing the signature and permit details.
+4. **Server** calls `permitTransferFrom` on the Permit2 contract to execute the transfer.
+5. **Server** returns the resource with a Receipt referencing the transaction hash.
+
+## Prerequisites
+
+Before a client can pay via the EVM method, they need a one-time ERC-20 approval to the Permit2 contract:
+
+```solidity
+USDC.approve(PERMIT2_ADDRESS, type(uint256).max);
+```
+
+This is a standard pattern—most wallets and applications already have Permit2 approvals in place from interacting with Uniswap and other protocols.
+
+:::info
+The Permit2 contract is deployed at `0x000000000022D473030F116dDEE9F6B43aC78BA3` on all major EVM chains. See [Permit2 deployments](https://github.com/Uniswap/permit2#deployments) for the full list.
+:::
+
+## Payments on EVM chains
+
+The EVM payment method brings several properties to MPP:
+
+- **Any ERC-20 token**—Pay with USDC, USDT, DAI, or any ERC-20 on any supported chain
+- **Any EVM chain**—Works on Ethereum, Base, Arbitrum, Optimism, Polygon, and every chain with Permit2
+- **Signature-based transfers**—Clients sign an off-chain message instead of submitting a transaction, reducing client-side complexity
+- **Single approval**—One Permit2 approval per token covers all MPP interactions, unlike per-spender ERC-20 approvals
+- **Replay protection**—Permit2 uses unique nonces per signature, preventing double-spend
+
+## Gasless extensions
+
+Two approaches eliminate gas costs for clients:
+
+### Facilitator-submitted transactions
+
+The server or a third-party facilitator submits the `permitTransferFrom` transaction on behalf of the client. The client signs, the facilitator pays gas and submits. This is the default pattern in MPP—the server already holds the signature and submits it as part of Credential verification.
+
+### EIP-3009 (transferWithAuthorization)
+
+For tokens that natively support [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) (such as USDC and USDT on most chains), the server can use `transferWithAuthorization` directly—bypassing Permit2 entirely. This removes the one-time approval step, making the flow fully gasless from the client's perspective.
+
+## Intents
+
+<Cards>
+  <EvmChargeCard />
+</Cards>

--- a/src/pages/payment-methods/index.mdx
+++ b/src/pages/payment-methods/index.mdx
@@ -1,5 +1,5 @@
 import { Cards, Tab, Tabs } from 'vocs'
-import { TempoMethodCard, LightningMethodCard, StripeMethodCard, CustomMethodCard } from '../../components/cards'
+import { TempoMethodCard, EvmMethodCard, LightningMethodCard, StripeMethodCard, CustomMethodCard } from '../../components/cards'
 
 # Payment methods [Available methods and how to choose one]
 
@@ -22,6 +22,12 @@ HTTP/1.1 402 Payment Required
 WWW-Authenticate: Payment method="stripe", intent="charge", ...
 ```
   </Tab>
+  <Tab title="EVM">
+```http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment method="evm", intent="charge", ...
+```
+  </Tab>
   <Tab title="Lightning">
 ```http
 HTTP/1.1 402 Payment Required
@@ -34,6 +40,7 @@ WWW-Authenticate: Payment method="lightning", intent="charge", ...
 
 <Cards>
   <TempoMethodCard />
+  <EvmMethodCard />
   <StripeMethodCard />
   <LightningMethodCard />
   <CustomMethodCard />

--- a/src/pages/protocol/challenges.mdx
+++ b/src/pages/protocol/challenges.mdx
@@ -19,7 +19,7 @@ WWW-Authenticate: Payment id="qB3wErTyU7iOpAsD9fGhJk",
 |-----------|-------------|
 | `id` | Unique challenge identifier, cryptographically bound to challenge parameters |
 | `realm` | Protection space identifier (typically the API domain) |
-| `method` | Payment method identifier (such as `tempo` or `stripe`) |
+| `method` | Payment method identifier (such as `tempo`, `evm`, or `stripe`) |
 | `intent` | Payment intent type (such as `charge` or `session`) |
 | `request` | Base64url-encoded JSON with payment details |
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -155,6 +155,14 @@ export default defineConfig({
             ],
           },
           {
+            text: "EVM",
+            collapsed: true,
+            items: [
+              { text: "Overview", link: "/payment-methods/evm" },
+              { text: "Charge", link: "/payment-methods/evm/charge" },
+            ],
+          },
+          {
             text: "Stripe",
             collapsed: true,
             items: [


### PR DESCRIPTION
## Summary

Adds a new `evm` payment method to the MPP spec—enabling payments with any ERC-20 token on any EVM chain via Uniswap's [Permit2](https://github.com/Uniswap/permit2) `SignatureTransfer` contract.

Context: x402 [just shipped Permit2 support](https://x.com/fabdarice/status/2033900456427368791). This PR brings the same capability to the MPP spec.

## Changes

- `src/pages/payment-methods/evm/index.mdx` — Overview page with Permit2 flow diagram, prerequisites, gasless extensions (facilitator-submitted txs, EIP-3009)
- `src/pages/payment-methods/evm/charge.mdx` — Charge intent with server/client SDK examples, Challenge request fields, Credential payload spec, supported chains table
- `src/components/cards.tsx` — `EvmMethodCard` and `EvmChargeCard` components
- `src/pages/payment-methods/index.mdx` — Added EVM tab and card to the payment methods overview
- `src/pages/protocol/challenges.mdx` — Added `evm` to the method identifier examples
- `vocs.config.ts` — Sidebar entry for EVM payment method

## Testing

- `pnpm check:types` — passes
- `pnpm check` (biome) — passes
- `pnpm build` — SSG step fails due to missing `MPP_SECRET_KEY` env var (pre-existing, unrelated to this PR)

Prompted by: georgios