### PR TITLE
docs: add Card payment method to sidebar

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -163,6 +163,14 @@ export default defineConfig({
             ],
           },
           {
+            text: "Card",
+            collapsed: true,
+            items: [
+              { text: "Overview", link: "/payment-methods/card" },
+              { text: "Charge", link: "/payment-methods/card/charge" },
+            ],
+          },
+          {
             text: "Lightning",
             collapsed: true,
             items: [


### PR DESCRIPTION
Adds the Card payment method to the sidebar navigation, positioned above Lightning (after Stripe). Links to the overview and charge pages added in #334.