### PR TITLE
fix: use correct mainnet chain ID 4217

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,15 @@ Use `<Badge variant="...">` in tables to indicate status or maturity. Import fro
 | `note` | Custom/advanced options | `<Badge variant="note">Custom</Badge>` |
 | `gray` | Neutral metadata | `<Badge variant="gray">any time</Badge>` |
 
+## Tempo Chain IDs
+
+Always use these chain IDs when referencing Tempo networks:
+
+- **Mainnet**: `4217`
+- **Testnet (Moderato)**: `42431`
+
+Never use `98865`—that is a deprecated chain ID.
+
 ## Rules
 
 1. **Alphabetize everything** - Object properties in code examples and ### parameter headings must be alphabetically ordered

--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -106,6 +106,7 @@ type Page =
 | { path: '/payment-methods/card'; render: 'static' }
 | { path: '/intents/charge'; render: 'static' }
 | { path: '/guides/building-with-an-llm'; render: 'static' }
+| { path: '/guides/multiple-payment-methods'; render: 'static' }
 | { path: '/guides/one-time-payments'; render: 'static' }
 | { path: '/guides/pay-as-you-go'; render: 'static' }
 | { path: '/guides/streamed-payments'; render: 'static' }

--- a/src/pages/payment-methods/tempo/session.mdx
+++ b/src/pages/payment-methods/tempo/session.mdx
@@ -230,7 +230,7 @@ Sessions use the `TempoStreamChannel` escrow contract for on-chain deposits, set
 
 | Network | Chain ID | Contract Address |
 |---|---|---|
-| [Mainnet](https://explore.mainnet.tempo.xyz/address/0x33b901018174DDabE4841042ab76ba85D4e24f25?tab=contract) | 98865 | `0x33b901018174DDabE4841042ab76ba85D4e24f25` |
+| [Mainnet](https://explore.mainnet.tempo.xyz/address/0x33b901018174DDabE4841042ab76ba85D4e24f25?tab=contract) | 4217 | `0x33b901018174DDabE4841042ab76ba85D4e24f25` |
 | [Testnet (Moderato)](https://explore.testnet.tempo.xyz/address/0xe1c4d3dce17bc111181ddf716f75bae49e61a336?tab=contract) | 42431 | `0xe1c4d3dce17bc111181ddf716f75bae49e61a336` |
 
 ## Specification

--- a/src/pages/sdk/typescript/cli.mdx
+++ b/src/pages/sdk/typescript/cli.mdx
@@ -87,11 +87,11 @@ $ mppx init --force
 Sign a payment Challenge and output the `Authorization` header value without making a request. Accepts a challenge via `--challenge` or stdin.
 
 ```bash [terminal]
-$ mppx sign --challenge 'Payment method="tempo-session";chain-id=98865;...'
+$ mppx sign --challenge 'Payment method="tempo-session";chain-id=4217;...'
 ```
 
 ```bash [terminal]
-$ echo 'Payment method="tempo-session";chain-id=98865;...' | mppx sign
+$ echo 'Payment method="tempo-session";chain-id=4217;...' | mppx sign
 ```
 
 Use `--dry-run` to validate and parse a Challenge without signing:


### PR DESCRIPTION
Replace deprecated chain ID `98865` with `4217` across docs:

- `src/pages/payment-methods/tempo/session.mdx` — escrow contract table
- `src/pages/sdk/typescript/cli.mdx` — 2 `mppx sign` examples

Also adds a **Tempo Chain IDs** section to `AGENTS.md` to prevent future mistakes:
- Mainnet: `4217`
- Testnet (Moderato): `42431`