### PR TITLE
docs: document feePayer URL option for remote fee sponsorship

### DIFF
--- a/src/pages/payment-methods/tempo/index.mdx
+++ b/src/pages/payment-methods/tempo/index.mdx
@@ -50,19 +50,27 @@ Tempo is purpose-built for the payment patterns MPP enables:
 
 Tempo supports server-paid transaction fees for both charge and session intents. When enabled, the client signs only the payment authorization and the server covers gas costs. The client doesn't need to hold gas tokens or understand fee mechanics.
 
-Set `feePayer: true` in the Challenge request to enable this:
+Pass a `feePayer` account to `tempo()` to enable this:
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({
+  methods: [tempo({
+    feePayer: privateKeyToAccount('0x…'), // [!code hl]
+  })],
+})
+```
 
-declare const request: Request
-// ---cut---
-const response = await mppx.charge({
-  amount: '0.1',
-  currency: '0x20c0000000000000000000000000000000000000',
-  feePayer: true, // [!code hl]
-  recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-})(request)
+It is also possible to point the `feePayer` to a fee service that supports the [`Handler.feePayer`](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer) endpoint:
+
+```ts
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    feePayer: 'https://sponsor.example.com', // [!code hl]
+  })],
+})
 ```

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -243,7 +243,21 @@ const mppx = Mppx.create({
 })
 ```
 
-When a pull-mode client submits a signed transaction, the server co-signs with the fee payer account before broadcasting. Push-mode clients pay their own gas, so `feePayer` is ignored for those requests.
+It is possible to pass a [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer) URL instead:
+
+```ts
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    currency: '0x20c0000000000000000000000000000000000000',
+    feePayer: 'https://sponsor.example.com', // [!code focus]
+    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  })],
+})
+```
+
+When a pull-mode client submits a signed transaction, the server co-signs with the fee payer account (or delegates to the relay) before broadcasting. Push-mode clients pay their own gas, so `feePayer` is ignored for those requests.
 
 ### Optimistic verification
 

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -99,9 +99,9 @@ External identifier for the payment.
 
 ### feePayer (optional)
 
-- **Type:** `Account`
+- **Type:** `Account | string | true`
 
-Account for sponsoring transaction fees.
+Account or URL for sponsoring transaction fees. Pass a viem `Account` to co-sign locally, a URL string to delegate to a remote [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer), or `true` when the `account` parameter doubles as the fee payer.
 
 ### getClient (optional)
 

--- a/src/pages/sdk/typescript/server/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.mdx
@@ -56,9 +56,9 @@ Decimal places for amount parsing.
 
 ### feePayer (optional)
 
-- **Type:** `Account`
+- **Type:** `Account | string | true`
 
-Account for sponsoring transaction fees.
+Account or URL for sponsoring transaction fees. Pass a viem `Account` to co-sign locally, a URL string to delegate to a remote [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer), or `true` when the `account` parameter doubles as the fee payer.
 
 ### getClient (optional)
 

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -84,9 +84,9 @@ Escrow contract address for the payment channel. Defaults to the canonical escro
 
 ### feePayer (optional)
 
-- **Type:** `Account`
+- **Type:** `Account | string | true`
 
-Account for sponsoring open and top-up transaction fees.
+Account or URL for sponsoring open and top-up transaction fees. Pass a viem `Account` to co-sign locally, a URL string to delegate to a remote [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer), or `true` when the `account` parameter doubles as the fee payer.
 
 ### getClient (optional)
 
@@ -178,7 +178,7 @@ const txHash = await tempo.settle(store, client, '0xchannelId...')
 - **client** — `Client` — A viem client for on-chain interaction.
 - **channelId** — `Hex` — The channel to settle.
 - **options.escrowContract** (optional) — `Address` — Escrow contract override.
-- **options.feePayer** (optional) — `Account` — Fee payer account.
+- **options.feePayer** (optional) — `Account | string` — Fee payer account or relay URL.
 
 #### Return type
 


### PR DESCRIPTION
Documents that `feePayer` accepts a URL string pointing to a remote [`Handler.feePayer`](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer) service, in addition to a viem `Account` or `true`.

**Changes:**
- Updated `feePayer` type to `Account | string | true` on `tempo()`, `tempo.charge()`, and `tempo.session()` server reference pages
- Added URL-based fee payer example to the Tempo overview fee sponsorship section
- Added URL-based fee payer example to the quickstart server guide
- Updated `tempo.settle` options to reflect `Account | string` for `feePayer`