### PR TITLE
fix: use VERCEL_URL for preview baseUrl to prevent CORS errors

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -3,8 +3,6 @@ import { defineConfig, McpSource } from "vocs/config";
 const baseUrl = (() => {
   if (process.env.VERCEL_ENV === "production")
     return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
-  if (process.env.VERCEL_BRANCH_URL)
-    return `https://${process.env.VERCEL_BRANCH_URL}`;
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
   if (process.env.NODE_ENV !== "production") return "http://localhost:5173";
   return "";


### PR DESCRIPTION
## Problem

Preview deployments show **"Failed to load services — Failed to fetch"** on the /services page. All relative fetches (`/api/services`, RSC requests) fail with CORS errors.

## Root Cause

Vocs injects a `<base href="...">` tag using the configured `baseUrl`. For preview builds, this was set to `VERCEL_BRANCH_URL` (e.g. `mpp-git-branchname-tempoxyz.vercel.app`). When visiting via the deployment-specific URL (`mpp-{hash}-tempoxyz.vercel.app`), all relative fetches resolve against the wrong origin → CORS blocks them.

This was previously masked by **Vercel Deployment Protection** (password auth), which canonicalized all traffic through the branch URL. After removing password auth, the origin mismatch is exposed.

## Fix

Remove the `VERCEL_BRANCH_URL` preference and use `VERCEL_URL` (the deployment-specific URL) instead. `VERCEL_URL` always matches the URL being visited, so the `<base>` tag resolves correctly.