### PR TITLE
fix: add padding to hero CTA buttons on mobile

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -499,10 +499,10 @@ function Hero() {
         </div>
         <div className="hero-right">
           <Tagline />
-          <div className="flex items-center gap-4 mt-3 landing-ctas">
+          <div className="flex items-center gap-3 sm:gap-4 mt-3 px-4 sm:px-0 landing-ctas">
             <Link
               to="/quickstart/agent"
-              className="no-underline! px-5 py-2.5 rounded-lg transition-opacity hover:opacity-80"
+              className="no-underline! px-3 sm:px-5 py-2.5 rounded-lg transition-opacity hover:opacity-80"
               style={{
                 fontSize: "0.9375rem",
                 fontWeight: 500,
@@ -521,7 +521,7 @@ function Hero() {
             </Link>
             <Link
               to="/quickstart/server"
-              className="no-underline! px-5 py-2.5 rounded-lg transition-opacity hover:opacity-80"
+              className="no-underline! px-3 sm:px-5 py-2.5 rounded-lg transition-opacity hover:opacity-80"
               style={{
                 fontSize: "0.9375rem",
                 fontWeight: 500,


### PR DESCRIPTION
Adds responsive padding so the hero CTA buttons don't sit edge-to-edge on mobile.

- Container: `px-4 sm:px-0` for side breathing room
- Button padding: `px-3 sm:px-5`
- Gap: `gap-3 sm:gap-4`