### PR TITLE
fix: eliminate sidebar navigation scroll bounce

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -424,7 +424,7 @@ export default function Layout(props: React.PropsWithChildren) {
       <script
         // biome-ignore lint/security/noDangerouslySetInnerHtml: inline perf fix
         dangerouslySetInnerHTML={{
-          __html: `(function(){var o=Element.prototype.scrollTo;Element.prototype.scrollTo=function(a){if(a&&typeof a==='object'&&this.matches&&this.matches('[data-v-sidebar-container]')){a=Object.assign({},a,{behavior:'instant'})}return o.apply(this,arguments)};})();`,
+          __html: `(function(){var o=Element.prototype.scrollTo;Element.prototype.scrollTo=function(a){if(a&&typeof a==='object'&&this.matches&&this.matches('[data-v-sidebar-container]')){a=Object.assign({},a,{behavior:'instant'})}return o.apply(this,arguments)};var w=window.scrollTo.bind(window);window.scrollTo=function(){var top=arguments[0]&&typeof arguments[0]==='object'?arguments[0].top:arguments.length>=2?arguments[1]:undefined;if(top===0&&window.scrollY===0)return;return w.apply(window,arguments)};})();`,
         }}
       />
       <meta

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -1184,23 +1184,7 @@ a[href*="/payment-methods/tempo"][class*="vocs:rounded-md"]
   }
 }
 
-/* ---- Page content opacity transition on route change ----
-   Smooth fade-in for main content area; header/nav stays static. */
-@keyframes pageContentFadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-[data-v-content],
-[data-layout="minimal"] main > article {
-  animation: pageContentFadeIn 0.25s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-/* Minimal-layout pages (services, etc.) manage their own entrance animations.
-   Remove the page fade so the article doesn't create a stacking context that
-   traps sticky elements below the nav (z-index: 50). */
-[data-layout="minimal"] main > article {
-  animation: none;
-}
+/* Minimal-layout pages manage their own entrance animations.
+   No page-level fade — it causes a visible bounce on SPA navigations
+   because React re-mounts [data-v-content], re-triggering the animation
+   and flashing content to opacity: 0. */


### PR DESCRIPTION
## Problem

After a hard reload on a docs page (for example `/guides/streamed-payments`), clicking a sidebar link causes a visible bounce/flicker in the main content area.

## Root cause

Two competing `scrollTo(0,0)` calls fire during sidebar navigation:

1. **Waku router** (`scrollToRoute`) — scrolls to top instantly during the route transition
2. **Vocs `ScrollRestoration`** — fires a redundant `scrollTo(0,0)` ~800ms later (dev) / ~46ms later (prod) in a `useEffect` when `path` changes

The second call triggers a layout recalculation while new content is mounting, creating the bounce. The `pageContentFadeIn` CSS animation (250ms) amplifies the visual gap.

## Fix

Extends the existing inline `scrollTo` patch in `_layout.tsx` to skip redundant `window.scrollTo` calls when the page is already at `scrollY=0`. This eliminates the second scroll call from `ScrollRestoration` without touching Vocs internals.