### PR TITLE
fix: point explorer links to moderato testnet

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -868,7 +868,7 @@ function AsyncSteps({
           {isRestart ? "Using" : "Create a"} wallet{" "}
           <span style={{ color: "var(--term-gray5)" }}>⋅</span>{" "}
           <a
-            href={`https://explore.tempo.xyz/address/${address}`}
+            href={`https://explore.moderato.tempo.xyz/address/${address}`}
             target="_blank"
             rel="noopener noreferrer"
             className="hover:underline"
@@ -908,7 +908,7 @@ function AsyncSteps({
               {" "}
               <span style={{ color: "var(--term-gray5)" }}>⋅</span>{" "}
               <a
-                href={`https://explore.tempo.xyz/receipt/${channelTxHash}`}
+                href={`https://explore.moderato.tempo.xyz/receipt/${channelTxHash}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="hover:underline"
@@ -935,7 +935,7 @@ function AsyncSteps({
               {" "}
               <span style={{ color: "var(--term-gray5)" }}>⋅</span>{" "}
               <a
-                href={`https://explore.tempo.xyz/receipt/${txHash}`}
+                href={`https://explore.moderato.tempo.xyz/receipt/${txHash}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="hover:underline"
@@ -1084,7 +1084,7 @@ function AsyncSteps({
                 {" "}
                 <span style={{ color: "var(--term-gray5)" }}>⋅</span>{" "}
                 <a
-                  href={`https://explore.tempo.xyz/receipt/${txHash}`}
+                  href={`https://explore.moderato.tempo.xyz/receipt/${txHash}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="hover:underline"
@@ -2210,7 +2210,7 @@ function GalleryStep({
           <StepIcon spinning={setupAt("wallet")} /> Create a wallet{" "}
           <span style={{ color: "var(--term-gray5)" }}>⋅</span>{" "}
           <a
-            href={`https://explore.tempo.xyz/address/${walletState.address}`}
+            href={`https://explore.moderato.tempo.xyz/address/${walletState.address}`}
             target="_blank"
             rel="noopener noreferrer"
             className="hover:underline"
@@ -2250,7 +2250,7 @@ function GalleryStep({
               {" "}
               <span style={{ color: "var(--term-gray5)" }}>⋅</span>{" "}
               <a
-                href={`https://explore.tempo.xyz/receipt/${channelTxHash}`}
+                href={`https://explore.moderato.tempo.xyz/receipt/${channelTxHash}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="hover:underline"
@@ -2452,7 +2452,7 @@ function GalleryStep({
                 {" "}
                 <span style={{ color: "var(--term-gray5)" }}>⋅</span>{" "}
                 <a
-                  href={`https://explore.tempo.xyz/receipt/${closeTxHash}`}
+                  href={`https://explore.moderato.tempo.xyz/receipt/${closeTxHash}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="hover:underline"

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -150,7 +150,7 @@ export async function handler(request: Request) {
 ```
 
 :::info[Currency and recipient values]
-`currency` is the TIP-20 token contract address—[`0x20c0…`](https://explore.tempo.xyz/address/0x20c0000000000000000000000000000000000000?live=false) is pathUSD on Tempo. `recipient` is the address that receives payment. See [Tempo payment method](/payment-methods/tempo) for supported tokens.
+`currency` is the TIP-20 token contract address—[`0x20c0…`](https://explore.moderato.tempo.xyz/address/0x20c0000000000000000000000000000000000000?live=false) is pathUSD on Tempo. `recipient` is the address that receives payment. See [Tempo payment method](/payment-methods/tempo) for supported tokens.
 :::
 
 The intent handler accepts a [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)-compatible request object, and returns a `Response` object.


### PR DESCRIPTION
Update all `explore.tempo.xyz` links to `explore.moderato.tempo.xyz` in the Terminal demo component and quickstart docs.

**Changed files:**
- `src/components/Terminal.tsx` — 7 explorer links (wallet address, channel tx, receipt, close tx)
- `src/pages/quickstart/server.mdx` — 1 explorer link (token contract address)