### PR TITLE
stableenrich: remove Grok endpoints

### DIFF
--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -2706,7 +2706,6 @@
         "exa",
         "firecrawl",
         "google-maps",
-        "grok",
         "linkedin",
         "reddit",
         "enrichment",
@@ -2964,45 +2963,6 @@
             "currency": "0x20c000000000000000000000b9537d11c60e8b50",
             "decimals": 6,
             "description": "Partial place details by ID",
-            "amount": "20000"
-          }
-        },
-        {
-          "method": "POST",
-          "path": "/api/grok/x-search",
-          "description": "Search X/Twitter posts",
-          "payment": {
-            "intent": "charge",
-            "method": "tempo",
-            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
-            "decimals": 6,
-            "description": "Search X/Twitter posts",
-            "amount": "20000"
-          }
-        },
-        {
-          "method": "POST",
-          "path": "/api/grok/user-search",
-          "description": "Search X/Twitter users",
-          "payment": {
-            "intent": "charge",
-            "method": "tempo",
-            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
-            "decimals": 6,
-            "description": "Search X/Twitter users",
-            "amount": "20000"
-          }
-        },
-        {
-          "method": "POST",
-          "path": "/api/grok/user-posts",
-          "description": "Get recent posts from an X user",
-          "payment": {
-            "intent": "charge",
-            "method": "tempo",
-            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
-            "decimals": 6,
-            "description": "Get recent posts from an X user",
             "amount": "20000"
           }
         },

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1322,7 +1322,6 @@ export const services: ServiceDef[] = [
       "exa",
       "firecrawl",
       "google-maps",
-      "grok",
       "linkedin",
       "reddit",
       "enrichment",
@@ -1430,22 +1429,6 @@ export const services: ServiceDef[] = [
       {
         route: "GET /api/google-maps/place-details/partial",
         desc: "Partial place details by ID",
-        amount: "20000",
-      },
-      // Grok (X/Twitter)
-      {
-        route: "POST /api/grok/x-search",
-        desc: "Search X/Twitter posts",
-        amount: "20000",
-      },
-      {
-        route: "POST /api/grok/user-search",
-        desc: "Search X/Twitter users",
-        amount: "20000",
-      },
-      {
-        route: "POST /api/grok/user-posts",
-        desc: "Get recent posts from an X user",
         amount: "20000",
       },
       // Serper


### PR DESCRIPTION
Syncs StableEnrich service endpoints with the live `llms.txt`.

### Removed (no longer in llms.txt)
- `POST /api/grok/x-search`
- `POST /api/grok/user-search`
- `POST /api/grok/user-posts`
- `grok` tag