### PR TITLE
feat: add Palm — Polymarket analytics + meme data

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -4328,4 +4328,50 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+  {
+    id: "palm",
+    name: "Palm",
+    url: "https://palm.guzus.xyz",
+    serviceUrl: "https://mpp.guzus.xyz",
+    description:
+      "Polymarket on-chain analytics API. Real-time trade data, market stats, trader profiles, and meme content — powered by ClickHouse over indexed blockchain data.",
+    categories: ["data", "blockchain"],
+    integration: "first-party",
+    tags: [
+      "polymarket",
+      "prediction-markets",
+      "analytics",
+      "on-chain",
+      "memes",
+    ],
+    docs: {
+      homepage: "https://palm.guzus.xyz",
+    },
+    provider: { name: "Guzus", url: "https://guzus.xyz" },
+    realm: "mpp.guzus.xyz",
+    intent: "charge",
+    payment: TEMPO_PAYMENT,
+    endpoints: [
+      {
+        route: "GET /meme/random",
+        desc: "Random crypto meme from memtherscan",
+        amount: "1000",
+      },
+      {
+        route: "GET /polymarket/overview",
+        desc: "Polymarket aggregate stats: total trades, volume, top markets, top traders, recent trades",
+        amount: "50000",
+      },
+      {
+        route: "GET /polymarket/market",
+        desc: "Specific market data by token ID",
+        amount: "20000",
+      },
+      {
+        route: "GET /polymarket/trader",
+        desc: "Trader profile: trade count, volume, PnL, trade history",
+        amount: "20000",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## New Service: Palm

**Service URL:** https://mpp.guzus.xyz
**llms.txt:** https://mpp.guzus.xyz/llms.txt

### Description
Polymarket on-chain analytics API powered by ClickHouse over indexed blockchain data. Also serves crypto meme content from memtherscan.

### Endpoints
| Route | Price | Description |
|---|---|---|
| `GET /meme/random` | $0.001 | Random crypto meme |
| `GET /polymarket/overview` | $0.05 | Aggregate stats, top markets/traders |
| `GET /polymarket/market` | $0.02 | Market data by token ID |
| `GET /polymarket/trader` | $0.02 | Trader profile + history |

### Integration
- First-party MPP integration (Rust, mpp-rs SDK)
- Tempo Mainnet (chain 4217), USDC payments
- Recipient: `0x2Fd502ea6B2Fd05e6F4B2b1d8f3Bc5cBBAe57470`

### Stack
- Backend: Rust + Axum + mpp-rs
- Data: ClickHouse + Parquet (palm-api.guzus.xyz)
- Hosting: Mac Mini M4 + Cloudflare Tunnel