### PR TITLE
fix: allow CI build to pass on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,5 +93,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
         env:
-          MPP_SECRET_KEY: ${{ secrets.MPP_SECRET_KEY }}
+          MPP_SECRET_KEY: ${{ secrets.MPP_SECRET_KEY || 'ci-placeholder-key' }}
 

--- a/src/mppx-stripe.server.ts
+++ b/src/mppx-stripe.server.ts
@@ -11,4 +11,5 @@ export const stripeMppx = Mppx.create({
       secretKey: process.env.STRIPE_SECRET_KEY!,
     }),
   ],
+  secretKey: "demo",
 });


### PR DESCRIPTION
Fork PRs (like #380) fail on the Build step because `MPP_SECRET_KEY` is unavailable — GitHub doesn't expose secrets to workflows triggered by fork PRs.

**Changes:**
- **`mppx-stripe.server.ts`** — Add `secretKey: "demo"` to `Mppx.create()`, matching the existing pattern in `mppx.server.ts`. This prevents the SDK from throwing when `MPP_SECRET_KEY` is missing.
- **`ci.yml`** — Use `${{ secrets.MPP_SECRET_KEY || 'ci-placeholder-key' }}` as a fallback so the env var is never empty on fork PR builds.