### PR TITLE
chore: update alchemy details on mpp.dev

### DIFF
--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -2175,7 +2175,7 @@
     {
       "id": "alchemy",
       "name": "Alchemy",
-      "url": "https://eth-mainnet.g.alchemy.com",
+      "url": "https://agents.alchemy.com/",
       "serviceUrl": "https://mpp.alchemy.com",
       "description": "Blockchain data APIs including Core RPC APIs, Prices API, Portfolio API, and NFT API across 100+ chains.",
       "categories": [
@@ -2192,8 +2192,8 @@
       ],
       "status": "active",
       "docs": {
-        "homepage": "https://www.alchemy.com/docs",
-        "llmsTxt": "https://www.alchemy.com/docs/llms.txt"
+        "homepage": "https://agents.alchemy.com/s",
+        "llmsTxt": "https://www.alchemy.com/llms.txt"
       },
       "methods": {
         "tempo": {
@@ -2208,7 +2208,7 @@
       "realm": "alchemy.com",
       "provider": {
         "name": "Alchemy",
-        "url": "https://alchemy.com"
+        "url": "https://agents.alchemy.com/"
       },
       "endpoints": [
         {
@@ -2223,7 +2223,7 @@
             "description": "JSON-RPC call (eth_*, alchemy_*)",
             "amount": "100"
           },
-          "docs": "https://context7.com/websites/alchemy/llms.txt?topic=POST%20%2F%3Anetwork%2Fv2"
+          "docs": "https://www.alchemy.com/llms.txt?topic=POST%20%2F%3Anetwork%2Fv2"
         },
         {
           "method": "GET",
@@ -2237,7 +2237,7 @@
             "description": "NFT API v3",
             "amount": "500"
           },
-          "docs": "https://context7.com/websites/alchemy/llms.txt?topic=GET%20%2F%3Anetwork%2Fnft%2Fv3%2F%3Aendpoint"
+          "docs": "https://www.alchemy.com/llms.txt?topic=GET%20%2F%3Anetwork%2Fnft%2Fv3%2F%3Aendpoint"
         },
         {
           "method": "POST",
@@ -2251,7 +2251,7 @@
             "description": "NFT API v3",
             "amount": "500"
           },
-          "docs": "https://context7.com/websites/alchemy/llms.txt?topic=POST%20%2F%3Anetwork%2Fnft%2Fv3%2F%3Aendpoint"
+          "docs": "https://www.alchemy.com/llms.txt?topic=POST%20%2F%3Anetwork%2Fnft%2Fv3%2F%3Aendpoint"
         }
       ]
     },

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1079,7 +1079,7 @@ export const services: ServiceDef[] = [
   {
     id: "alchemy",
     name: "Alchemy",
-    url: "https://eth-mainnet.g.alchemy.com",
+    url: "https://agents.alchemy.com/",
     serviceUrl: "https://mpp.alchemy.com",
     description:
       "Blockchain data APIs including Core RPC APIs, Prices API, Portfolio API, and NFT API across 100+ chains.",
@@ -1087,14 +1087,14 @@ export const services: ServiceDef[] = [
     integration: "first-party",
     tags: ["rpc", "json-rpc", "nft", "evm", "multichain"],
     docs: {
-      homepage: "https://www.alchemy.com/docs",
-      llmsTxt: "https://www.alchemy.com/docs/llms.txt",
+      homepage: "https://agents.alchemy.com/s",
+      llmsTxt: "https://www.alchemy.com/llms.txt",
     },
-    provider: { name: "Alchemy", url: "https://alchemy.com" },
+    provider: { name: "Alchemy", url: "https://agents.alchemy.com/" },
     realm: "alchemy.com",
     intent: "session",
     payment: TEMPO_PAYMENT,
-    docsBase: "https://context7.com/websites/alchemy/llms.txt",
+    docsBase: "https://www.alchemy.com/llms.txt",
     endpoints: [
       {
         route: "POST /:network/v2",


### PR DESCRIPTION
Updates Alchemy service URLs and docs links:

- URL → `https://agents.alchemy.com/`
- Docs homepage → `https://agents.alchemy.com/s`
- llms.txt → `https://www.alchemy.com/llms.txt`
- Provider URL → `https://agents.alchemy.com/`
- Endpoint docs → `https://www.alchemy.com/llms.txt` (from context7.com)

Supersedes #380 (fork PR skipping ci).

Co-authored-by: Samuel Raghunath <samuel@onewaysidewalks.com>