### PR TITLE
feat: add Vercel Skew Protection middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,15 @@
+export default function middleware(request: Request) {
+  const deploymentId = process.env.VERCEL_DEPLOYMENT_ID;
+  if (!deploymentId) return;
+
+  const cookie = request.headers.get("cookie") ?? "";
+  if (cookie.includes("__vdpl=")) return;
+
+  return new Response(null, {
+    status: 200,
+    headers: {
+      "x-middleware-next": "1",
+      "set-cookie": `__vdpl=${deploymentId}; Path=/; HttpOnly; SameSite=Strict`,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Fixes stale JS chunk 404s after deploys by adding Vercel [Skew Protection](https://vercel.com/docs/skew-protection).

## Problem

When a new deploy goes live, users with the old page loaded try to fetch old lazily-loaded JS bundles that no longer exist, causing a broken page until hard refresh.

## Changes

- Added `middleware.ts` — sets the `__vdpl` cookie on first request, pinning the client to the deployment that served the initial page. Subsequent asset requests resolve against that deployment.

## Action required

Skew Protection must also be enabled in the Vercel dashboard:
1. Go to the mpp project → **Settings** → **Advanced**
2. Toggle **Skew Protection** on
3. Redeploy

Co-Authored-By: zhygis <5236121+Zygimantass@users.noreply.github.com>

Prompted by: zygis