### PR TITLE
fix: Google Analytics not tracking — gtag used Array instead of Arguments

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -42,9 +42,10 @@ function useGoogleAnalytics() {
     document.head.appendChild(script);
 
     window.dataLayer = window.dataLayer || [];
-    function gtag(...args: unknown[]) {
-      window.dataLayer.push(args);
-    }
+    const gtag: (...args: unknown[]) => void = function () {
+      // biome-ignore lint/complexity/noArguments: gtag.js bootstrap requires the native arguments object
+      window.dataLayer.push(arguments);
+    };
     gtag("js", new Date());
     gtag("config", id);
   }, []);


### PR DESCRIPTION
## Problem

Google Analytics was not receiving any data from mpp.dev despite `VITE_GA_MEASUREMENT_ID` being correctly set.

## Root Cause

The `gtag()` function in `_layout.tsx` used ES6 rest parameters:

```ts
function gtag(...args: unknown[]) {
  window.dataLayer.push(args); // pushes an Array
}
```

Google's gtag.js expects `Arguments` objects in the dataLayer, not arrays. The standard snippet uses:

```js
function gtag(){dataLayer.push(arguments);} // pushes Arguments object
```

This caused the `["js", Date]` and `["config", "G-..."]" entries to be silently ignored — no pageview was ever sent.

## Fix

Use the standard `arguments` pattern that gtag.js expects.

## Verification

Tested on live site with browser eval:
- **Before**: `window.gtag` = `undefined`, dataLayer items = arrays (`isArray: true`)
- **After**: dataLayer items = Arguments objects (`isArray: false`), matching docs.tempo.xyz behavior