### PR TITLE
feat: add ZK Proof Service Real cryptographic compute via MPP

### DIFF
--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -9529,6 +9529,92 @@
           }
         }
       ]
+    },
+    {
+      "id": "zk-proof",
+      "name": "ZK Proof Service",
+      "url": "https://himess-zk-proof-service.hf.space",
+      "serviceUrl": "https://himess-zk-proof-service.hf.space",
+      "description": "Groth16 ZK proof generation for private UTXO transactions — JoinSplit circuits on BN254 curve.",
+      "categories": [
+        "compute",
+        "blockchain"
+      ],
+      "integration": "third-party",
+      "tags": [
+        "zk",
+        "zero-knowledge",
+        "groth16",
+        "proof",
+        "privacy",
+        "snarkjs"
+      ],
+      "status": "active",
+      "docs": {
+        "homepage": "https://github.com/Himess/zk-proof-service",
+        "llmsTxt": "https://himess-zk-proof-service.hf.space/llms.txt"
+      },
+      "methods": {
+        "tempo": {
+          "intents": [
+            "charge"
+          ],
+          "assets": [
+            "0x20c000000000000000000000b9537d11c60e8b50"
+          ]
+        }
+      },
+      "realm": "himess-zk-proof-service.hf.space",
+      "provider": {
+        "name": "Himess",
+        "url": "https://github.com/Himess"
+      },
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/circuits",
+          "description": "List available circuits and pricing",
+          "payment": null
+        },
+        {
+          "method": "POST",
+          "path": "/prove/1x2",
+          "description": "Generate Groth16 proof for 1-input 2-output JoinSplit (13,726 constraints)",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "Generate 1x2 JoinSplit proof",
+            "amount": "10000"
+          }
+        },
+        {
+          "method": "POST",
+          "path": "/prove/2x2",
+          "description": "Generate Groth16 proof for 2-input 2-output JoinSplit (25,877 constraints)",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "Generate 2x2 JoinSplit proof",
+            "amount": "20000"
+          }
+        },
+        {
+          "method": "POST",
+          "path": "/verify/1x2",
+          "description": "Verify a 1x2 JoinSplit proof",
+          "payment": null
+        },
+        {
+          "method": "POST",
+          "path": "/verify/2x2",
+          "description": "Verify a 2x2 JoinSplit proof",
+          "payment": null
+        }
+      ]
     }
   ]
 }

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -4328,4 +4328,51 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── ZK Proof Service ───────────────────────────────────────────────────
+  {
+    id: "zk-proof",
+    name: "ZK Proof Service",
+    url: "https://himess-zk-proof-service.hf.space",
+    serviceUrl: "https://himess-zk-proof-service.hf.space",
+    description:
+      "Groth16 ZK proof generation for private UTXO transactions — JoinSplit circuits on BN254 curve.",
+    categories: ["compute", "blockchain"],
+    integration: "third-party",
+    tags: ["zk", "zero-knowledge", "groth16", "proof", "privacy", "snarkjs"],
+    docs: {
+      homepage: "https://github.com/Himess/zk-proof-service",
+      llmsTxt: "https://himess-zk-proof-service.hf.space/llms.txt",
+    },
+    provider: { name: "Himess", url: "https://github.com/Himess" },
+    realm: "himess-zk-proof-service.hf.space",
+    intent: "charge",
+    payment: TEMPO_PAYMENT,
+    endpoints: [
+      {
+        route: "GET /circuits",
+        desc: "List available circuits and pricing",
+      },
+      {
+        route: "POST /prove/1x2",
+        desc: "Generate Groth16 proof for 1-input 2-output JoinSplit (13,726 constraints)",
+        amount: "10000",
+        unitType: "proof",
+      },
+      {
+        route: "POST /prove/2x2",
+        desc: "Generate Groth16 proof for 2-input 2-output JoinSplit (25,877 constraints)",
+        amount: "20000",
+        unitType: "proof",
+      },
+      {
+        route: "POST /verify/1x2",
+        desc: "Verify a 1x2 JoinSplit proof",
+      },
+      {
+        route: "POST /verify/2x2",
+        desc: "Verify a 2x2 JoinSplit proof",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## New Service: ZK Proof Service

**Live:** https://himess-zk-proof-service.hf.space
**Source:** https://github.com/Himess/zk-proof-service
**llms.txt:** https://himess-zk-proof-service.hf.space/llms.txt

### What it does

Generates Groth16 zero-knowledge proofs for private UTXO transactions. This is real cryptographic computation — 13,726 constraints, elliptic curve pairings on BN254 — not an API proxy. Agents send circuit inputs, pay via MPP, and get back a proof ready for on-chain Solidity verifiers.

### Endpoints

| Route | Price | Description |
|---|---|---|
| `GET /circuits` | Free | List circuits and pricing |
| `POST /prove/1x2` | $0.01 | 1-input 2-output JoinSplit proof (13,726 constraints) |
| `POST /prove/2x2` | $0.02 | 2-input 2-output JoinSplit proof (25,877 constraints) |
| `POST /verify/1x2` | Free | Verify a proof |
| `POST /verify/2x2` | Free | Verify a proof |

### Stack

- **Engine:** snarkjs Groth16 + BN254 curve
- **Server:** Hono + mppx (first-party MPP integration)
- **Payment:** MPP (USDC on Tempo), per-proof charging via 402 flow
- **Hosting:** Hugging Face Spaces (16GB RAM)
- **Extras:** MCP server for Claude/Cursor, llms.txt for agent discovery

### Performance

- Proof generation: ~2-5s (warm)
- Verification: ~50ms
- Output includes `contractProof` (uint256[8]) for direct Solidity `verifyProof()` calls

### Verified

```
$ tempo request -t https://himess-zk-proof-service.hf.space/circuits
  1x2: $0.01, 2x2: $0.02

$ tempo request -v -X POST -H "Content-Type: application/json" \
    -d @input.json https://himess-zk-proof-service.hf.space/prove/1x2
  Paid 0.01 USDC · 0x68ec5052...
  { proof: { pi_a, pi_b, pi_c }, generationTimeMs: 2031 }
```