### PR TITLE
fix: change services card title to Third-party services

### DIFF
--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -2531,7 +2531,7 @@ function SidebarInfoCards() {
           }}
         />
         <div style={{ flex: 1 }}>
-          <div style={titleStyle}>First-party services</div>
+          <div style={titleStyle}>Third-party services</div>
           <div style={descStyle}>
             Services which directly integrate with MPP
           </div>


### PR DESCRIPTION
## Summary
Changes the card title on the /services page from "First-party services" to "Third-party services".

## Changes
- Updated title in `src/components/ServicesPage.tsx`

Co-Authored-By: Matthew Slater <83676602+dev-slater@users.noreply.github.com>

Prompted by: matthew