### PR TITLE
Add mpps.io — attestation for agent commerce

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -4328,4 +4328,33 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── mpps.io ─────────────────────────────────────────────────────
+  {
+    id: "mpps",
+    name: "mpps.io",
+    url: "https://api.mpps.io",
+    serviceUrl: "https://api.mpps.io",
+    description: "Cryptographic attestation for agent commerce. Proof of delivery for every MPP transaction.",
+    categories: ["data"],
+    integration: "third-party",
+    tags: ["attestation", "proof", "trust", "notarize", "certificate", "audit", "receipt", "delivery"],
+    status: "active",
+    docs: {
+      homepage: "https://mpps.io",
+      llmsTxt: "https://api.mpps.io/llms.txt",
+      apiReference: "https://github.com/gdlg-ai/mpps.io/blob/main/docs/api.md",
+    },
+    provider: { name: "GlideLogic Corp.", url: "https://glidelogic.ai" },
+    realm: "api.mpps.io",
+    intent: "charge",
+    payment: STRIPE_PAYMENT,
+    endpoints: [
+      { route: "POST /v1/notarize", desc: "Free HSM-signed attestation (10/hour)" },
+      { route: "POST /v1/certify", desc: "Certified attestation with metadata and certificate", amount: "1" },
+      { route: "GET /v1/verify/:uuid", desc: "Verify any attestation" },
+      { route: "GET /v1/public-key", desc: "Public key for offline verification" },
+      { route: "GET /v1/health", desc: "Service health check" },
+    ],
+  },
 ];


### PR DESCRIPTION
mpps.io provides cryptographic attestation for MPP transactions.

MPP receipts prove money moved. mpps.io proves what was delivered. It is the only service on this registry that serves the MPP ecosystem itself — every other service uses MPP to get paid, mpps.io makes every MPP transaction more trustworthy.

After any MPP payment, either party calls mpps.io to attest what was exchanged, creating a complete evidence chain.

**Details:**
- **Live API**: https://api.mpps.io
- **Free**: 10 attestations/hour, 10 certified/day (no auth required)
- **Paid**: $0.01/attestation via Stripe
- **HSM-signed**: AWS KMS, FIPS 140-2 Level 3
- **Immutable**: 10-year storage (S3 Object Lock, Compliance Mode)
- **Open source**: https://github.com/gdlg-ai/mpps.io (MIT)
- **llms.txt**: https://api.mpps.io/llms.txt
- **Website**: https://mpps.io

**Payment method**: `STRIPE_PAYMENT` (same as Stripe Climate)

Built by GlideLogic Corp. (OTCQB: GDLG).