### PR TITLE
fix: SEO audit — meta descriptions, titles, redirects, orphan 404, homepage H1

### DIFF
--- a/src/pages/404.mdx
+++ b/src/pages/404.mdx
@@ -6,6 +6,7 @@ showLogo: false
 showOutline: false
 showSearch: false
 showSidebar: false
+robots: "noindex"
 ---
 
 import { NotFoundPage } from '../components/NotFoundPage'

--- a/src/pages/brand.mdx
+++ b/src/pages/brand.mdx
@@ -1,3 +1,8 @@
+---
+title: "Brand assets and guidelines"
+description: "Download official MPP logos, wordmarks, and brand assets. Guidelines for using the Machine Payments Protocol brand in your project or integration."
+---
+
 # Brand [MPP brand assets and guidelines]
 
 import { DownloadSvgButton } from "../components/DownloadSvgButton";

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -1,3 +1,7 @@
+---
+description: "Answers to common questions about MPP—payment methods, settlement, pricing, security, and how the protocol compares to API keys and subscriptions."
+---
+
 # Frequently asked questions [Common questions about the Machine Payments Protocol]
 
 ## Is MPP only for stablecoins?

--- a/src/pages/guides/multiple-payment-methods.mdx
+++ b/src/pages/guides/multiple-payment-methods.mdx
@@ -1,3 +1,7 @@
+---
+description: "Accept Tempo stablecoins, Stripe cards, and Lightning Bitcoin on a single API endpoint. Serve a multi-method 402 Challenge and let clients choose."
+---
+
 import { Cards } from 'vocs'
 import { OneTimePaymentsCard, PayAsYouGoCard, PaymentMethodsCard } from '../../components/cards'
 import { PromptBlock } from '../../components/PromptBlock'

--- a/src/pages/guides/pay-as-you-go.mdx
+++ b/src/pages/guides/pay-as-you-go.mdx
@@ -1,3 +1,7 @@
+---
+description: "Build a payment-gated API with session-based billing using mppx payment channels. Charge per request with near-zero latency overhead."
+---
+
 import { Cards, Tabs, Tab } from 'vocs'
 import { OneTimePaymentsCard, ServerQuickstartCard, WalletCliCard } from '../../components/cards'
 import { PromptBlock } from '../../components/PromptBlock'

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -1,3 +1,7 @@
+---
+description: "Accept streamed payments over Server-Sent Events with mppx. Bill per token in real time using Tempo payment channels for LLM inference APIs."
+---
+
 import { Cards, Tabs, Tab } from "vocs";
 import {
   OneTimePaymentsCard,

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -8,4 +8,6 @@ showSidebar: false
 
 import { LandingPage } from "../components/LandingPage";
 
+<h1 style={{ position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 }}>MPP — Machine Payments Protocol</h1>
+
 <LandingPage />

--- a/src/pages/intents/charge.mdx
+++ b/src/pages/intents/charge.mdx
@@ -1,3 +1,7 @@
+---
+title: "Charge intent for one-time payments"
+---
+
 import { Cards } from 'vocs'
 import { MermaidDiagram } from '../../components/MermaidDiagram'
 import { TempoChargeCard, StripeMethodCard, LightningMethodCard, CardMethodCard } from '../../components/cards'

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -1,3 +1,7 @@
+---
+description: "MPP standardizes HTTP 402 for machine-to-machine payments. Learn how agents, apps, and services exchange payments in the same HTTP request."
+---
+
 import { Cards } from 'vocs'
 import { SpecCard } from '../components/SpecCard'
 import { TerminalPing } from '../components/TerminalPing'

--- a/src/pages/payment-methods/card/index.mdx
+++ b/src/pages/payment-methods/card/index.mdx
@@ -1,3 +1,7 @@
+---
+title: "Card payment method"
+---
+
 import { Cards } from 'vocs'
 import { CardChargeCard } from '../../../components/cards'
 import { MermaidDiagram } from '../../../components/MermaidDiagram'

--- a/src/pages/payment-methods/custom.mdx
+++ b/src/pages/payment-methods/custom.mdx
@@ -1,3 +1,7 @@
+---
+title: "Custom payment methods"
+---
+
 # Custom [Build your own payment method]
 
 The `mppx` SDK supports dynamic extensibility for new payment methods. You can implement custom payment methods to integrate any payment rails such as other blockchains, card processors, or proprietary systems.

--- a/src/pages/payment-methods/lightning/index.mdx
+++ b/src/pages/payment-methods/lightning/index.mdx
@@ -2,7 +2,7 @@
 
 The Lightning payment method enables payments using Bitcoin over the [Lightning Network](https://lightning.network) within the MPP framework. Lightning supports two intents—**charge** for one-time payments and **session** for prepaid metered access—covering everything from single API calls to high-frequency streaming billing.
 
-The implementation is provided by [`@buildonspark/lightning-mpp-sdk`](https://github.com/buildonspark/lightning-mpp-sdk), which extends the [`mppx`](https://github.com/tempoxyz/mpp) SDK with Lightning Network support alongside built-in methods like [Stripe](/payment-methods/stripe/) and [Tempo](/payment-methods/tempo/). The reference implementation uses [Spark](https://spark.money) for wallet and node operations, but the protocol works with any Lightning node or wallet that can create BOLT11 invoices and verify preimages.
+The implementation is provided by [`@buildonspark/lightning-mpp-sdk`](https://github.com/buildonspark/lightning-mpp-sdk), which extends the [`mppx`](https://github.com/tempoxyz/mpp) SDK with Lightning Network support alongside built-in methods like [Stripe](/payment-methods/stripe) and [Tempo](/payment-methods/tempo). The reference implementation uses [Spark](https://spark.money) for wallet and node operations, but the protocol works with any Lightning node or wallet that can create BOLT11 invoices and verify preimages.
 
 ## Installation
 

--- a/src/pages/payment-methods/stripe/index.mdx
+++ b/src/pages/payment-methods/stripe/index.mdx
@@ -1,3 +1,7 @@
+---
+title: "Stripe payment method"
+---
+
 import { Cards } from 'vocs'
 import { StripeChargeCard } from '../../../components/cards'
 import { MermaidDiagram } from '../../../components/MermaidDiagram'

--- a/src/pages/payment-methods/tempo/index.mdx
+++ b/src/pages/payment-methods/tempo/index.mdx
@@ -1,3 +1,7 @@
+---
+title: "Tempo stablecoin payments"
+---
+
 import { Badge } from 'vocs'
 
 # Tempo [Stablecoin payments on the Tempo blockchain]

--- a/src/pages/protocol/http-402.mdx
+++ b/src/pages/protocol/http-402.mdx
@@ -1,3 +1,7 @@
+---
+description: "HTTP 402 Payment Required signals that a resource requires payment. Learn when and how MPP servers return 402 with a WWW-Authenticate Challenge."
+---
+
 # HTTP 402 payment required [The status code that signals payment is required]
 
 MPP services return HTTP `402` Payment Required to indicate that a resource requires payment for access.

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -1,3 +1,7 @@
+---
+description: "The Machine Payments Protocol standardizes HTTP 402 with an extensible challenge–credential–receipt flow that works with any payment network."
+---
+
 import { Badge } from "vocs";
 import { PaymentFlowDiagram } from "../../components/PaymentFlowDiagram";
 

--- a/src/pages/protocol/receipts.mdx
+++ b/src/pages/protocol/receipts.mdx
@@ -1,3 +1,8 @@
+---
+title: "Payment receipts and verification"
+description: "Receipts confirm successful payment in MPP. Return them in the Payment-Receipt header so clients can verify that the server accepted their Credential."
+---
+
 # Receipts [Server acknowledgment of successful payment]
 
 A **Receipt** is the server's acknowledgment of successful payment. Return receipts in the `Payment-Receipt` header on successful responses.

--- a/src/pages/protocol/transports/http.mdx
+++ b/src/pages/protocol/transports/http.mdx
@@ -1,3 +1,7 @@
+---
+description: "The HTTP transport maps MPP payment flows to standard HTTP headers—WWW-Authenticate for Challenges, Authorization for Credentials, and Payment-Receipt."
+---
+
 import { Badge } from 'vocs'
 
 # HTTP transport [Payment flows using standard HTTP headers]

--- a/src/pages/protocol/transports/index.mdx
+++ b/src/pages/protocol/transports/index.mdx
@@ -1,3 +1,7 @@
+---
+description: "MPP defines transport bindings for HTTP and MCP. Learn how Challenges, Credentials, and Receipts map to headers and JSON-RPC messages."
+---
+
 # Transports [HTTP and MCP bindings for payment flows]
 
 MPP defines how the Payment authentication scheme operates over different transport protocols. The core protocol targets HTTP, with extensions for other transports like MCP and JSON-RPC.

--- a/src/pages/quickstart/agent.mdx
+++ b/src/pages/quickstart/agent.mdx
@@ -1,3 +1,7 @@
+---
+description: "Connect your coding agent to MPP-enabled services. Set up Tempo Wallet or the mppx SDK to handle 402 payment flows automatically."
+---
+
 import { Badge, Card, Cards, Tab, Tabs } from 'vocs'
 
 # Use with agents [Connect your agent to MPP-enabled services]

--- a/src/pages/quickstart/client.mdx
+++ b/src/pages/quickstart/client.mdx
@@ -1,3 +1,7 @@
+---
+description: "Handle payment-gated resources in your app. Use the mppx client SDK to intercept 402 responses, pay, and retry—all automatically."
+---
+
 import { Cards } from 'vocs'
 import { ClientPrompt } from '../../components/QuickstartPrompt'
 import { ServerQuickstartCard, TempoMethodCard, MppxCreateReferenceCard } from '../../components/cards'

--- a/src/pages/quickstart/index.mdx
+++ b/src/pages/quickstart/index.mdx
@@ -1,3 +1,7 @@
+---
+description: "Get started with MPP in minutes. Protect your API with payments, connect your agent, or integrate your app with MPP-enabled services."
+---
+
 import { Cards } from 'vocs'
 import { QuickstartPrompts } from '../../components/QuickstartPrompt'
 import { ClientQuickstartCard, ServerQuickstartCard, WalletCliCard } from '../../components/cards'

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -1,3 +1,7 @@
+---
+description: "Add payment-gated access to your API with mppx. Accept stablecoins, cards, and Bitcoin in a few lines of code using the MPP server SDK."
+---
+
 import { Badge, Cards } from 'vocs'
 import { ServerPrompt } from '../../components/QuickstartPrompt'
 import { ClientQuickstartCard, TempoMethodCard, MppxCreateReferenceCard } from '../../components/cards'

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -1,3 +1,8 @@
+---
+title: "SDKs and client libraries"
+description: "Official MPP SDK implementations in TypeScript, Python, and Rust. Libraries for building MPP clients and servers with full protocol support."
+---
+
 import { Cards } from 'vocs'
 import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, WalletCliCard } from '../../components/cards'
 

--- a/src/pages/sdk/python/client.mdx
+++ b/src/pages/sdk/python/client.mdx
@@ -1,3 +1,7 @@
+---
+title: "Python MPP client"
+---
+
 # Client [Handle 402 responses automatically]
 
 The `Client` class wraps `httpx` and intercepts `402` responses—it parses the Challenge, signs a stablecoin transfer, and retries with the Credential.

--- a/src/pages/sdk/rust/index.mdx
+++ b/src/pages/sdk/rust/index.mdx
@@ -1,3 +1,7 @@
+---
+title: "Rust SDK for MPP"
+---
+
 import * as SdkBadge from '../../../components/SdkBadge'
 
 # Rust SDK [The mpp Rust library]

--- a/src/pages/sdk/typescript/client/Method.stripe.mdx
+++ b/src/pages/sdk/typescript/client/Method.stripe.mdx
@@ -1,3 +1,7 @@
+---
+title: "stripe client method"
+---
+
 # `stripe` [Register all Stripe intents]
 
 Convenience function that creates the Stripe `charge` method intent.

--- a/src/pages/sdk/typescript/client/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.mdx
@@ -1,3 +1,7 @@
+---
+title: "tempo client method"
+---
+
 # `tempo` [Register all Tempo intents]
 
 Convenience function that creates both `tempo.charge` and `tempo.session` method intents with shared configuration.

--- a/src/pages/sdk/typescript/core/Expires.mdx
+++ b/src/pages/sdk/typescript/core/Expires.mdx
@@ -1,3 +1,7 @@
+---
+title: "Expires utility functions"
+---
+
 # `Expires` [Generate relative expiration timestamps]
 
 Utility functions for generating ISO 8601 datetime strings relative to the current time.

--- a/src/pages/sdk/typescript/middlewares/elysia.mdx
+++ b/src/pages/sdk/typescript/middlewares/elysia.mdx
@@ -1,3 +1,7 @@
+---
+title: "Elysia payment middleware"
+---
+
 # Elysia [Payment middleware for Elysia]
 
 Native [Elysia](https://elysiajs.com) middleware that gates routes behind payment intents.

--- a/src/pages/sdk/typescript/middlewares/express.mdx
+++ b/src/pages/sdk/typescript/middlewares/express.mdx
@@ -1,3 +1,7 @@
+---
+title: "Express payment middleware"
+---
+
 # Express [Payment middleware for Express]
 
 Native [Express](https://expressjs.com) middleware that gates routes behind payment intents.

--- a/src/pages/sdk/typescript/middlewares/hono.mdx
+++ b/src/pages/sdk/typescript/middlewares/hono.mdx
@@ -1,3 +1,7 @@
+---
+title: "Hono payment middleware"
+---
+
 # Hono [Payment middleware for Hono]
 
 Native [Hono](https://hono.dev) middleware that gates routes behind payment intents.

--- a/src/pages/sdk/typescript/middlewares/nextjs.mdx
+++ b/src/pages/sdk/typescript/middlewares/nextjs.mdx
@@ -1,3 +1,7 @@
+---
+title: "Next.js payment middleware"
+---
+
 # Next.js [Payment middleware for Next.js]
 
 Native [Next.js](https://nextjs.org) route handler wrapper that gates routes behind payment intents.

--- a/src/pages/sdk/typescript/proxy.mdx
+++ b/src/pages/sdk/typescript/proxy.mdx
@@ -1,3 +1,7 @@
+---
+title: "Paid API proxy server"
+---
+
 # Proxy [Paid API proxy]
 
 Gates upstream API services behind MPP `402` payments. The proxy handles routing, credential injection, and payment verification—you configure which endpoints require payment and which are free passthrough.

--- a/src/pages/sdk/typescript/server/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.mdx
@@ -1,3 +1,7 @@
+---
+title: "tempo server method"
+---
+
 # `tempo` [Register all Tempo intents]
 
 Convenience function that creates both `tempo.charge` and `tempo.session` method intents with shared configuration.

--- a/src/pages/services.mdx
+++ b/src/pages/services.mdx
@@ -1,4 +1,5 @@
 ---
+description: "Browse live MPP-enabled services that accept machine-to-machine payments. Discover APIs you can pay for with stablecoins, cards, or Bitcoin."
 layout: minimal
 showAskAi: false
 showOutline: false


### PR DESCRIPTION
Fixes a number of SEO audit related issues

## Changes

### Errors fixed
- **Orphan 404 page** — Added `noindex: true` to `404.mdx` frontmatter so it's excluded from the sitemap
- **Homepage missing H1** — Added visually-hidden `<h1>` in the MDX for non-JS crawlers (the JS-rendered Lockup component already has one)

### Redirect chain fixes
- **Trailing-slash links on Lightning page** — Removed trailing slashes from `/payment-methods/stripe/` and `/payment-methods/tempo/` links, which caused HTTPS → HTTP → HTTPS 308 redirect chains

### SEO metadata improvements
- **Meta descriptions** — Added 120–160 char `description` frontmatter to 17 pages (overview, quickstart, guides, protocol, SDK, brand, FAQ, services)
- **Page titles** — Added descriptive `title` frontmatter to 19 pages that were under 30 chars (SDK reference pages, middleware pages, payment method pages)

### Not addressed
- **Page size >2 MB** (`/payment-methods/stripe/charge`) — The 2.2 MB is the rendered DOM from 8 twoslash code blocks. The MDX source is only 14 KB. Would require splitting the page or reducing twoslash blocks.
- **Slow pages** — Related to twoslash compilation; no easy fix without architectural changes.

## Verification
- `pnpm check:types` ✅
- `pnpm build` ✅