### PR TITLE
ci: auto-comment contributor guidance on service directory PRs

### DIFF
--- a/.github/workflows/service-pr-guide.yml
+++ b/.github/workflows/service-pr-guide.yml
@@ -1,0 +1,48 @@
+name: Service PR Guide
+
+on:
+  pull_request_target:
+    types: [opened]
+    paths:
+      - "schemas/services.ts"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post contributor guidance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '👋 Thanks for submitting a service to the MPP directory!',
+              '',
+              'Before we review, please make sure you\'ve completed these steps:',
+              '',
+              '### Required',
+              '- [ ] Your service is **live and accepting payments** via MPP (not a placeholder or coming-soon)',
+              '- [ ] You\'ve added your entry to `schemas/services.ts` following the [contributing guide](https://github.com/tempoxyz/mpp?tab=readme-ov-file#contributing-to-the-service-directory)',
+              '- [ ] You\'ve run `node scripts/generate-discovery.ts` and committed the updated `schemas/discovery.json`',
+              '- [ ] You\'ve run `node scripts/gen-icons.cjs` and committed any new icons',
+              '- [ ] Types pass: `pnpm check:types`',
+              '- [ ] Build succeeds: `pnpm build`',
+              '',
+              '### Recommended',
+              '- [ ] Register your service on [MPPScan](https://www.mppscan.com/register) — it follows the standard MPP discovery format and makes your service discoverable by agents immediately, no PR required',
+              '',
+              '### Review criteria',
+              'We prioritize services that are **high quality and novel**. We may not approve services that duplicate existing functionality or aren\'t yet production-ready.',
+              '',
+              '---',
+              '📖 [Contributing guide](https://github.com/tempoxyz/mpp?tab=readme-ov-file#contributing-to-the-service-directory) · 🔍 [MPPScan](https://www.mppscan.com/register) · 📄 [Protocol docs](https://mpp.dev/protocol/)',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });


### PR DESCRIPTION
Adds a GitHub Action that automatically comments on new PRs that touch `schemas/services.ts` with:

- A checklist of required steps (generate discovery, gen icons, typecheck, build)
- Links to the [contributing guide](https://github.com/tempoxyz/mpp?tab=readme-ov-file#contributing-to-the-service-directory)
- Link to [MPPScan registration](https://www.mppscan.com/register)
- Review criteria note (high quality and novel)

Uses `pull_request_target` so it works on PRs from forks.