### PR TITLE
Stack landing page CTA buttons vertically on narrow mobile viewports

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -306,6 +306,12 @@ function LandingStyles() {
         .hero-right .text-base { font-size: 1.0625rem !important; line-height: 1.65 !important; }
       }
 
+      /* ---- Narrow mobile: stack CTA buttons vertically ---- */
+      @media (max-width: 560px) {
+        .landing-ctas { flex-direction: column !important; align-items: stretch !important; }
+        .landing-ctas a { text-align: center; }
+      }
+
       /* ---- Tablet ---- */
       @media (min-width: 768px) and (max-width: 1079px) {
         .landing-hero-part { padding-left: clamp(2rem, 5vw, 4rem); padding-right: clamp(2rem, 5vw, 4rem); }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Changes the landing page hero CTA button stack from `flex-row` to `flex-col` on mobile viewports up to 560px wide. This prevents the two buttons ("Use with agents" and "Add payments to your API") from being cramped side-by-side on narrow screens.

## Changes

- Added a new `@media (max-width: 560px)` rule in `src/components/LandingPage.tsx` that:
  - Sets `flex-direction: column` on `.landing-ctas` so the buttons stack vertically
  - Sets `align-items: stretch` so buttons fill the available width
  - Centers the button text with `text-align: center`

## Testing

- `pnpm check:types` passes
- `pnpm build` completes successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bf0f445-5f65-49c4-a4eb-d22342d233f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bf0f445-5f65-49c4-a4eb-d22342d233f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

