### PR TITLE
feat: add getpeon token safety scanner service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -854,6 +854,36 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── getpeon ────────────────────────────────────────────────────────────
+  {
+    id: "getpeon",
+    name: "getpeon",
+    url: "https://getpeon.xyz",
+    serviceUrl: "https://getpeon.xyz",
+    description:
+      "Token safety scanner for Tempo. Analyzes TIP-20 tokens for risk: honeypot detection, holder concentration, liquidity depth, admin permissions, supply caps, and proxy contracts. Returns a 0–100 risk score with detailed breakdowns.",
+    categories: ["blockchain"],
+    integration: "first-party",
+    tags: ["security", "tokens", "risk", "scanner", "defi", "tempo"],
+    status: "active",
+    docs: {
+      homepage: "https://getpeon.xyz",
+      llmsTxt: "https://getpeon.xyz/llms.txt",
+    },
+    provider: { name: "getpeon", url: "https://getpeon.xyz" },
+    realm: "getpeon.xyz",
+    intent: "charge",
+    payment: TEMPO_PAYMENT,
+    endpoints: [
+      {
+        route: "POST /api/scan",
+        desc: "Scan a TIP-20 token for risk",
+        amount: "60000",
+      },
+      { route: "GET /api/status", desc: "Service health and version info" },
+    ],
+  },
+
   // ── Google Gemini ──────────────────────────────────────────────────────
   {
     id: "gemini",


### PR DESCRIPTION
## What

Adds [getpeon](https://getpeon.xyz) to the MPP service registry — a first-party token safety scanner for Tempo.

## Service Details

- **Type:** First-party (self-hosted, not proxied)
- **Category:** Blockchain / Security
- **Payment:** 0.06 USDC per scan via MPP (Tempo)

### Endpoints

| Route | Description | Price |
|-------|-------------|-------|
| `POST /api/scan` | Scan a TIP-20 token for risk | $0.06 |
| `GET /api/status` | Service health and version info | Free |

### What the scanner returns

- **Risk score** (0-100) with verdict (LOW / MEDIUM / HIGH / CRITICAL)
- **Risk flags:** honeypot detection, uncapped supply, low liquidity, few holders
- **Token info:** name, symbol, decimals, supply, pause status
- **Price & FDV** from on-chain DEX data
- **Liquidity analysis:** pool reserves, LP burn percentage, DEX identification
- **Holder analysis:** concentration metrics, top holders with labels
- **Admin permissions:** mint, pause, RBAC detection
- **Contract type:** TIP-20 standard detection, proxy detection

### Documentation

- Homepage: https://getpeon.xyz
- LLMs.txt: https://getpeon.xyz/llms.txt
- Status: https://getpeon.xyz/api/status

### Note
`schemas/discovery.json` was not regenerated as I don't have the full build toolchain. Happy to update if needed.