### PR TITLE
feat: add AsiaPulse — Asian macro financial data + Tempo on-chain analytics

### DIFF
--- a/schemas/discovery.json
+++ b/schemas/discovery.json
@@ -9529,6 +9529,176 @@
           }
         }
       ]
+    },
+    {
+      "id": "asiapulse",
+      "name": "AsiaPulse",
+      "url": "https://asiapulse.paulc7.workers.dev",
+      "serviceUrl": "https://asiapulse.paulc7.workers.dev",
+      "description": "Asian macro financial data and Tempo on-chain analytics — kimchi premium, FX rates, central bank interest rates, Korean crypto news in English, and Tempo chain payment flow analysis.",
+      "categories": [
+        "data",
+        "blockchain"
+      ],
+      "integration": "first-party",
+      "tags": [
+        "macro",
+        "asia",
+        "korea",
+        "fx",
+        "interest-rates",
+        "tempo-analytics",
+        "kimchi-premium",
+        "stablecoin"
+      ],
+      "status": "active",
+      "docs": {
+        "homepage": "https://asiapulse.paulc7.workers.dev",
+        "llmsTxt": "https://asiapulse.paulc7.workers.dev/llms.txt"
+      },
+      "methods": {
+        "tempo": {
+          "intents": [
+            "charge"
+          ],
+          "assets": [
+            "0x20c000000000000000000000b9537d11c60e8b50"
+          ]
+        }
+      },
+      "realm": "asiapulse.paulc7.workers.dev",
+      "provider": {
+        "name": "AsiaPulse",
+        "url": "https://asiapulse.paulc7.workers.dev"
+      },
+      "endpoints": [
+        {
+          "method": "GET",
+          "path": "/asia-macro/kimchi-premium",
+          "description": "Real-time BTC/ETH kimchi premium (Upbit vs Binance price gap)",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "Real-time BTC/ETH kimchi premium (Upbit vs Binance price gap)",
+            "amount": "5000",
+            "unitType": "request"
+          }
+        },
+        {
+          "method": "GET",
+          "path": "/asia-macro/fx-rates",
+          "description": "Live KRW, JPY, CNY, EUR exchange rates against USD",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "Live KRW, JPY, CNY, EUR exchange rates against USD",
+            "amount": "3000",
+            "unitType": "request"
+          }
+        },
+        {
+          "method": "GET",
+          "path": "/asia-macro/interest-rates",
+          "description": "Central bank policy rates for US, KR, JP, EU, UK, CN, CH — auto-updated daily",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "Central bank policy rates for US, KR, JP, EU, UK, CN, CH — auto-updated daily",
+            "amount": "5000",
+            "unitType": "request"
+          }
+        },
+        {
+          "method": "GET",
+          "path": "/asia-macro/kr-news",
+          "description": "Korean crypto news headlines translated to English with sentiment analysis",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "Korean crypto news headlines translated to English with sentiment analysis",
+            "amount": "10000",
+            "unitType": "request"
+          }
+        },
+        {
+          "method": "GET",
+          "path": "/tempo/chain-stats",
+          "description": "Tempo chain block height, TPS, and transaction metrics",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "Tempo chain block height, TPS, and transaction metrics",
+            "amount": "3000",
+            "unitType": "request"
+          }
+        },
+        {
+          "method": "GET",
+          "path": "/tempo/stablecoin-flows",
+          "description": "PathUSD transfer volume, unique wallets, and flow analysis",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "PathUSD transfer volume, unique wallets, and flow analysis",
+            "amount": "5000",
+            "unitType": "request"
+          }
+        },
+        {
+          "method": "GET",
+          "path": "/tempo/top-accounts",
+          "description": "Top payment accounts by volume on Tempo",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "Top payment accounts by volume on Tempo",
+            "amount": "5000",
+            "unitType": "request"
+          }
+        },
+        {
+          "method": "GET",
+          "path": "/tempo/mpp-activity",
+          "description": "MPP payment traffic and service usage analytics",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "MPP payment traffic and service usage analytics",
+            "amount": "10000",
+            "unitType": "request"
+          }
+        },
+        {
+          "method": "GET",
+          "path": "/bundle/asia-snapshot",
+          "description": "Combined macro data + Tempo chain analytics in one call",
+          "payment": {
+            "intent": "charge",
+            "method": "tempo",
+            "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+            "decimals": 6,
+            "description": "Combined macro data + Tempo chain analytics in one call",
+            "amount": "20000",
+            "unitType": "request"
+          }
+        }
+      ]
     }
   ]
 }

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -4328,4 +4328,81 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+  
+  // ── AsiaPulse ──────────────────────────────────────────────────────────
+  {
+    id: "asiapulse",
+    name: "AsiaPulse",
+    url: "https://asiapulse.paulc7.workers.dev",
+    serviceUrl: "https://asiapulse.paulc7.workers.dev",
+    description:
+      "Asian macro financial data and Tempo on-chain analytics — kimchi premium, FX rates, central bank interest rates, Korean crypto news in English, and Tempo chain payment flow analysis.",
+    categories: ["data", "blockchain"],
+    integration: "first-party",
+    tags: ["macro", "asia", "korea", "fx", "interest-rates", "tempo-analytics", "kimchi-premium", "stablecoin"],
+    docs: {
+      homepage: "https://asiapulse.paulc7.workers.dev",
+      llmsTxt: "https://asiapulse.paulc7.workers.dev/llms.txt",
+    },
+    provider: { name: "AsiaPulse", url: "https://asiapulse.paulc7.workers.dev" },
+    realm: "asiapulse.paulc7.workers.dev",
+    intent: "charge",
+    payment: TEMPO_PAYMENT,
+    endpoints: [
+      {
+        route: "GET /asia-macro/kimchi-premium",
+        desc: "Real-time BTC/ETH kimchi premium (Upbit vs Binance price gap)",
+        amount: "5000",
+        unitType: "request",
+      },
+      {
+        route: "GET /asia-macro/fx-rates",
+        desc: "Live KRW, JPY, CNY, EUR exchange rates against USD",
+        amount: "3000",
+        unitType: "request",
+      },
+      {
+        route: "GET /asia-macro/interest-rates",
+        desc: "Central bank policy rates for US, KR, JP, EU, UK, CN, CH — auto-updated daily",
+        amount: "5000",
+        unitType: "request",
+      },
+      {
+        route: "GET /asia-macro/kr-news",
+        desc: "Korean crypto news headlines translated to English with sentiment analysis",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "GET /tempo/chain-stats",
+        desc: "Tempo chain block height, TPS, and transaction metrics",
+        amount: "3000",
+        unitType: "request",
+      },
+      {
+        route: "GET /tempo/stablecoin-flows",
+        desc: "PathUSD transfer volume, unique wallets, and flow analysis",
+        amount: "5000",
+        unitType: "request",
+      },
+      {
+        route: "GET /tempo/top-accounts",
+        desc: "Top payment accounts by volume on Tempo",
+        amount: "5000",
+        unitType: "request",
+      },
+      {
+        route: "GET /tempo/mpp-activity",
+        desc: "MPP payment traffic and service usage analytics",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "GET /bundle/asia-snapshot",
+        desc: "Combined macro data + Tempo chain analytics in one call",
+        amount: "20000",
+        unitType: "request",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## New Service: AsiaPulse

**Service URL:** `https://asiapulse.paulc7.workers.dev`  
**llms.txt:** `https://asiapulse.paulc7.workers.dev/llms.txt`  
**Categories:** data, blockchain  
**Payment:** Tempo charge (PathUSD)

### What is AsiaPulse?

AsiaPulse provides two types of data currently unavailable in the MPP ecosystem:

**1. Asian Macro Financial Data**
- Real-time kimchi premium (Upbit vs Binance price gap for BTC/ETH)
- Live FX rates for KRW, JPY, CNY, EUR
- Central bank interest rates for 7 major economies (US, KR, JP, EU, UK, CN, CH) — auto-updated daily
- Korean crypto news headlines translated to English with sentiment analysis

**2. Tempo On-Chain Analytics**
- Chain stats (block height, TPS, transaction count)
- PathUSD stablecoin transfer volume and flow analysis
- Top payment accounts by volume
- MPP payment traffic analytics

### Why this matters for the MPP ecosystem

- **First non-English market data** in the MPP directory — Korean/Asian crypto market intelligence has zero coverage today
- **First Tempo-native analytics** — helps visualize and track the growth of the Tempo payment ecosystem itself
- **Fills two empty categories**: FX/macro data (0 services) and non-English market data (0 services)

### Endpoints

| Route | Description | Price |
|-------|-------------|-------|
| `GET /asia-macro/kimchi-premium` | BTC/ETH kimchi premium | $0.005 |
| `GET /asia-macro/fx-rates` | KRW, JPY, CNY, EUR rates | $0.003 |
| `GET /asia-macro/interest-rates` | 7 central bank rates | $0.005 |
| `GET /asia-macro/kr-news` | Korean news in English | $0.01 |
| `GET /tempo/chain-stats` | Block, TPS, tx count | $0.003 |
| `GET /tempo/stablecoin-flows` | PathUSD flow analysis | $0.005 |
| `GET /tempo/top-accounts` | Top accounts by volume | $0.005 |
| `GET /tempo/mpp-activity` | MPP traffic analytics | $0.01 |
| `GET /bundle/asia-snapshot` | All data in one call | $0.02 |

### Technical details

- Built on Cloudflare Workers (serverless)
- Uses Tempo mainnet public RPC for on-chain data
- Interest rates auto-updated via Cron Trigger (daily)
- News auto-translated via Cloudflare Workers AI
- Zero external paid dependencies

### Checklist

- [x] `schemas/services.ts` updated
- [x] `schemas/discovery.json` regenerated
- [x] `pnpm check:types` passes
- [x] `pnpm build` succeeds
- [x] Service is live and responding to MPP requests
- [x] `/llms.txt` endpoint available for agent discovery