### PR TITLE
feat: add secret key generation and testnet option for Mppx instances across payment guides

### DIFF
--- a/src/pages/guides/multiple-payment-methods.mdx
+++ b/src/pages/guides/multiple-payment-methods.mdx
@@ -68,8 +68,10 @@ import { spark } from '@buildonspark/lightning-mpp-sdk/server'
 const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     }),
@@ -90,6 +92,7 @@ const mppx = Mppx.create({
 The route handler is identical to a single-method setup. `mppx.charge` advertises all registered methods in the Challenge and verifies whichever Credential the client presents.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import Stripe from 'stripe'
 import { Mppx, tempo, stripe } from 'mppx/server'
 import { spark } from '@buildonspark/lightning-mpp-sdk/server'
@@ -97,8 +100,10 @@ import { spark } from '@buildonspark/lightning-mpp-sdk/server'
 const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     }),
@@ -152,6 +157,7 @@ The `Mppx.create` configuration is the same across frameworks—only the route h
 ### Hono
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Hono } from 'hono'
 import Stripe from 'stripe'
 import { Mppx, tempo, stripe } from 'mppx/hono'
@@ -161,8 +167,10 @@ const app = new Hono()
 const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     }),
@@ -187,6 +195,7 @@ app.get(
 ### Express
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import express from 'express'
 import Stripe from 'stripe'
 import { Mppx, tempo, stripe } from 'mppx/express'
@@ -196,8 +205,10 @@ const app = express()
 const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     }),
@@ -222,6 +233,7 @@ app.get(
 ### Next.js
 
 ```ts [app/api/resource/route.ts]
+import crypto from 'crypto'
 import Stripe from 'stripe'
 import { Mppx, tempo, stripe } from 'mppx/nextjs'
 import { spark } from '@buildonspark/lightning-mpp-sdk/server'
@@ -229,8 +241,10 @@ import { spark } from '@buildonspark/lightning-mpp-sdk/server'
 const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     }),

--- a/src/pages/guides/one-time-payments.mdx
+++ b/src/pages/guides/one-time-payments.mdx
@@ -62,7 +62,9 @@ Set up an `Mppx` instance with the `tempo` method.
 import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -74,10 +76,13 @@ export const mppx = Mppx.create({
 Create the photo route. This route is **currently unpaid**.
 
 ```ts [app/api/photo/route.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -97,10 +102,13 @@ Add payment verification using `mppx.charge` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [app/api/photo/route.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -159,7 +167,9 @@ import { Mppx, tempo } from 'mppx/hono'
 const app = new Hono()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -171,13 +181,16 @@ const mppx = Mppx.create({
 Create the photo route. This route is **currently unpaid**.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
 
 const app = new Hono()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -197,13 +210,16 @@ Add payment verification using `mppx.charge` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
 
 const app = new Hono()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -261,7 +277,9 @@ Set up an `Mppx` instance with the `tempo` method.
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -273,10 +291,13 @@ const mppx = Mppx.create({
 Create the photo route. This route is **currently unpaid**.
 
 ```ts [src/index.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -297,10 +318,13 @@ export default {
 Add payment verification using `mppx.charge`. If the status is `402`, return the Challenge. Otherwise, fetch the photo and attach a Receipt to the response.
 
 ```ts [src/index.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -366,7 +390,9 @@ import { Mppx, tempo } from 'mppx/express'
 const app = express()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -378,13 +404,16 @@ const mppx = Mppx.create({
 Create the photo route. This route is **currently unpaid**.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import express from 'express'
 import { Mppx, tempo } from 'mppx/express'
 
 const app = express()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -404,13 +433,16 @@ Add payment verification using `mppx.charge` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import express from 'express'
 import { Mppx, tempo } from 'mppx/express'
 
 const app = express()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -473,7 +505,9 @@ Set up an `Mppx` instance with the `tempo` method.
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -485,10 +519,13 @@ const mppx = Mppx.create({
 Create the photo route. This route is **currently unpaid**.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -509,10 +546,13 @@ Bun.serve({
 Add payment verification using `mppx.charge`. If the status is `402`, return the Challenge. Otherwise, fetch the photo and attach a Receipt to the response.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -565,8 +605,10 @@ function async createPayToAddress(request: Request) {
 export async function handler(request: Request) {
   const recipientAddress = await createPayToAddress(request)
   const mppx = Mppx.create({
+    secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
     methods: [
       tempo.charge({
+        testnet: true,
         currency: "0x20c0000000000000000000000000000000000000",
         recipient: recipientAddress,
       }),

--- a/src/pages/guides/pay-as-you-go.mdx
+++ b/src/pages/guides/pay-as-you-go.mdx
@@ -68,10 +68,13 @@ Set up an `Mppx` instance with the `tempo` method.
 - `currency` is the token address for payments (in this case, `pathUSD`).
 
 ```ts [app/api/sessions/photo/route.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -83,10 +86,13 @@ export const mppx = Mppx.create({
 Create the gallery route. This route is **currently unpaid**.
 
 ```ts [app/api/sessions/photo/route.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -106,10 +112,13 @@ Add payment verification using `mppx.session` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [app/api/sessions/photo/route.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -162,31 +171,33 @@ Set up an `Mppx` instance with the `tempo` method.
 - `currency` is the token address for payments (in this case, `pathUSD`).
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
 
 const app = new Hono()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
 })
 ```
 
-#### Create the `/api/sessions/photo` route
-
-Create the gallery route. This route is **currently unpaid**.
-
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
 
 const app = new Hono()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -206,13 +217,16 @@ Add payment verification using `mppx.session` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
 
 const app = new Hono()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -267,10 +281,13 @@ Set up an `Mppx` instance with the `tempo` method.
 - `currency` is the token address for payments (in this case, `pathUSD`).
 
 ```ts [src/index.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -282,10 +299,13 @@ const mppx = Mppx.create({
 Create the gallery route. This route is **currently unpaid**.
 
 ```ts [src/index.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -306,10 +326,13 @@ export default {
 Add payment verification using `mppx.session`. If the status is `402`, return the Challenge. Otherwise, fetch the photo and attach a Receipt to the response.
 
 ```ts [src/index.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -369,13 +392,16 @@ Set up an `Mppx` instance with the `tempo` method.
 - `currency` is the token address for payments (in this case, `pathUSD`).
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import express from 'express'
 import { Mppx, tempo } from 'mppx/express'
 
 const app = express()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -387,13 +413,16 @@ const mppx = Mppx.create({
 Create the gallery route. This route is **currently unpaid**.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import express from 'express'
 import { Mppx, tempo } from 'mppx/express'
 
 const app = express()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -413,13 +442,16 @@ Add payment verification using `mppx.session` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import express from 'express'
 import { Mppx, tempo } from 'mppx/express'
 
 const app = express()
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -482,7 +514,9 @@ Set up an `Mppx` instance with the `tempo` method.
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -494,10 +528,13 @@ const mppx = Mppx.create({
 Create the gallery route. This route is **currently unpaid**.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -518,10 +555,13 @@ Bun.serve({
 Add payment verification using `mppx.session`. If the status is `402`, return the Challenge. Otherwise, fetch the photo and attach a Receipt to the response.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [tempo({
+    testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -69,11 +69,14 @@ bun add mppx viem
 Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
 ```ts [app/api/sessions/poem/route.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from "mppx/nextjs";
 
 export const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: "0x20c0000000000000000000000000000000000000",
       recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       sse: true,
@@ -87,11 +90,14 @@ export const mppx = Mppx.create({
 Create the poem route. The `withReceipt` method accepts an async generator—each yielded value is one SSE event and one charged word.
 
 ```ts [app/api/sessions/poem/route.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from "mppx/nextjs";
 
 export const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: "0x20c0000000000000000000000000000000000000",
       recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       sse: true,
@@ -166,14 +172,17 @@ bun add mppx hono viem
 Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Hono } from "hono";
 import { Mppx, tempo } from "mppx/hono";
 
 const app = new Hono();
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: "0x20c0000000000000000000000000000000000000",
       recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       sse: true,
@@ -187,14 +196,17 @@ const mppx = Mppx.create({
 Create the poem route with the session middleware. The handler returns an async generator—each yielded value is one SSE event and one charged word.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Hono } from "hono";
 import { Mppx, tempo } from "mppx/hono";
 
 const app = new Hono();
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: "0x20c0000000000000000000000000000000000000",
       recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       sse: true,
@@ -271,11 +283,14 @@ bun add mppx viem
 Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
 ```ts [src/index.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from "mppx/server";
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: "0x20c0000000000000000000000000000000000000",
       recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       sse: true,
@@ -289,11 +304,14 @@ const mppx = Mppx.create({
 Create the poem route. The `withReceipt` method accepts an async generator—each yielded value is one SSE event and one charged word.
 
 ```ts [src/index.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from "mppx/server";
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: "0x20c0000000000000000000000000000000000000",
       recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       sse: true,
@@ -375,14 +393,17 @@ bun add mppx express viem
 Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import express from "express";
 import { Mppx, tempo } from "mppx/express";
 
 const app = express();
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: "0x20c0000000000000000000000000000000000000",
       recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       sse: true,
@@ -396,14 +417,17 @@ const mppx = Mppx.create({
 Create the poem route with the session middleware. The handler returns an async generator—each yielded value is one SSE event and one charged word.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import express from "express";
 import { Mppx, tempo } from "mppx/express";
 
 const app = express();
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: "0x20c0000000000000000000000000000000000000",
       recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       sse: true,
@@ -485,11 +509,14 @@ bun add mppx viem
 Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from "mppx/server";
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: "0x20c0000000000000000000000000000000000000",
       recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       sse: true,
@@ -503,11 +530,14 @@ const mppx = Mppx.create({
 Create the route handler. `withReceipt` accepts an async generator—each yielded value becomes one SSE `event: message` and is charged one tick (`$0.001`). If the channel balance runs out mid-stream, the server emits `event: payment-need-voucher` and pauses until the client sends a new voucher.
 
 ```ts [server.ts]
+import crypto from 'crypto'
 import { Mppx, tempo } from "mppx/server";
 
 const mppx = Mppx.create({
+  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
     tempo({
+      testnet: true,
       currency: "0x20c0000000000000000000000000000000000000",
       recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       sse: true,


### PR DESCRIPTION
I ran into those issues while going through the tutorials. Since these are developer facing guide for local development, I think it's reasonable to default to testnet.