### PR TITLE
fix: use pull_request_target for PR auto-labeler

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,7 +1,7 @@
 name: PR Auto-Label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
The `pull_request` event doesn't grant write permissions for fork PRs, causing a 403 when applying labels. Switching to `pull_request_target` runs the workflow in the base repo's context where the token has write access.

Safe here because the labeler only reads file lists from the GitHub API—it doesn't checkout or execute any code from the PR.