### PR TITLE
fix: sdk-drift-check workflow pnpm version mismatch

### DIFF
--- a/.github/workflows/sdk-drift-check.yml
+++ b/.github/workflows/sdk-drift-check.yml
@@ -24,13 +24,11 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
The `sdk-drift-check` workflow hardcoded `version: 9` for pnpm, but `package.json` declares `packageManager: pnpm@10.22.0`. This causes `pnpm/action-setup@v4` to fail with `Multiple versions of pnpm specified`.

Fix: remove the explicit version so it reads from `packageManager` in `package.json`. Also bumps node to 24 to match other CI workflows.

Fixes: https://github.com/tempoxyz/mpp/actions/runs/23430397645