### PR TITLE
fix: remove deleted gen-icons.cjs from dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check:ci": "biome check",
     "check:sdk-drift": "npx tsx .github/actions/sdk-drift-check/check-sdk-drift.ts",
     "check:types": "tsc --noEmit",
-    "dev": "node scripts/generate-discovery.ts && node scripts/gen-icons.cjs && vite dev",
+    "dev": "node scripts/generate-discovery.ts && vite dev",
     "generate:discovery": "node scripts/generate-discovery.ts",
     "preinstall": "pnpx only-allow pnpm",
     "prepare": "pnpm simple-git-hooks",


### PR DESCRIPTION
The `dev` script references `scripts/gen-icons.cjs` which was removed in #433. This breaks `pnpm dev` on main.