### PR TITLE
docs: mark Python MCP Client transport as supported

### DIFF
--- a/src/pages/sdk/features.mdx
+++ b/src/pages/sdk/features.mdx
@@ -49,7 +49,7 @@ Additional payment methods implement their own SDKs. Refer to the maintaining or
 
 | Role | TypeScript | Rust | Python |
 |---|---|---|---|
-| **Client** | MCP SDK transport | — | — |
+| **Client** | MCP SDK transport | — | MCP SDK transport |
 | **Server** | MCP SDK transport | — | FastMCP (`@pay` decorator) |
 
 ## Tempo features


### PR DESCRIPTION
Updates the SDK feature table — Python MCP Client changes from `—` to `MCP SDK transport`.

Follows [tempoxyz/pympp#96](https://github.com/tempoxyz/pympp/pull/96) which adds the `McpClient` wrapper.