### PR TITLE
docs: add extensions page for community-built integrations

### DIFF
--- a/src/pages/extensions.mdx
+++ b/src/pages/extensions.mdx
@@ -1,0 +1,9 @@
+# Extensions [Community-built tools and integrations for MPP]
+
+Third-party packages that extend MPP with new payment methods, middleware, and utilities.
+
+| Name | Description | Link |
+|---|---|---|
+| `@insumermodel/mppx-token-gate` | Token-gate mppx routes—free access for NFT/token holders across 32 chains | [npm](https://www.npmjs.com/package/@insumermodel/mppx-token-gate) |
+
+Want to build your own? See [Custom payment methods](/payment-methods/custom).

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -205,6 +205,11 @@ export default defineConfig({
       destination: "/sdk/typescript/server/Request.toNodeListener",
     },
 
+    // Extensions aliases
+    { source: "/awesome", destination: "/extensions" },
+    { source: "/community", destination: "/extensions" },
+    { source: "/ecosystem", destination: "/extensions" },
+
     // Services aliases
     { source: "/service", destination: "/services" },
     { source: "/marketplace", destination: "/services" },
@@ -715,7 +720,10 @@ export default defineConfig({
       },
       {
         text: "Resources",
-        items: [{ text: "Brand", link: "/brand" }],
+        items: [
+          { text: "Extensions", link: "/extensions" },
+          { text: "Brand", link: "/brand" },
+        ],
       },
     ],
   },


### PR DESCRIPTION
Adds a single `/extensions` page—a community solutions table for third-party packages that extend MPP.

## What's included

- **`src/pages/extensions.mdx`** — Table with name, description, and link columns. Starts with `@insumermodel/mppx-token-gate`.
- **Sidebar entry** under Resources
- **Redirects**: `/awesome`, `/community`, `/ecosystem` → `/extensions`

Context: Instead of dedicated guide pages for each community integration (like #443), all community solutions live in one table on this page.