### PR TITLE
refactor: rename ogDescription to imageDescription frontmatter field

### DIFF
--- a/scripts/generate-og-descriptions.ts
+++ b/scripts/generate-og-descriptions.ts
@@ -11,7 +11,7 @@ function extractOgDescription(content: string): string | null {
   const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
   if (!match) return null;
   const fm = match[1];
-  const descMatch = fm.match(/^ogDescription:\s*"(.+)"\s*$/m);
+  const descMatch = fm.match(/^imageDescription:\s*"(.+)"\s*$/m);
   return descMatch ? descMatch[1] : null;
 }
 

--- a/src/pages/_api/api/og.tsx
+++ b/src/pages/_api/api/og.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck – server-only, uses Vite ?raw import and resvg native module
 import { initWasm, Resvg } from "@resvg/resvg-wasm";
 import resvgWasm from "@resvg/resvg-wasm/index_bg.wasm?url";
-import ogDescriptions from "../../../generated/og-descriptions.json";
+import imageDescriptions from "../../../generated/og-descriptions.json";
 import templateSvg from "./og-template.svg?raw";
 
 const BLOB = "https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com";
@@ -230,7 +230,7 @@ export async function GET(request: Request) {
   const rawDescription = url.searchParams.get("description") || "";
   const path = decodeURIComponent(url.searchParams.get("path") || "");
   const description =
-    (ogDescriptions as Record<string, string>)[path] || rawDescription;
+    (imageDescriptions as Record<string, string>)[path] || rawDescription;
   const category = getCategoryForPath(path);
   const subcategory = getSubcategoryForPath(path);
 

--- a/src/pages/brand.mdx
+++ b/src/pages/brand.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Brand assets and guidelines"
 description: "Download official MPP logos, wordmarks, and brand assets. Guidelines for using the Machine Payments Protocol brand in your project or integration."
-ogDescription: "Download MPP logos, icons, and brand assets for use in your documentation and marketing materials"
+imageDescription: "Download MPP logos, icons, and brand assets for use in your documentation and marketing materials"
 ---
 
 # Brand [MPP brand assets and guidelines]

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Answers to common questions about MPP—payment methods, settlement, pricing, security, and how the protocol compares to API keys and subscriptions."
-ogDescription: "Common questions about the Machine Payments Protocol, payment methods, wallets, and how MPP compares to other solutions"
+imageDescription: "Common questions about the Machine Payments Protocol, payment methods, wallets, and how MPP compares to other solutions"
 ---
 
 # Frequently asked questions [Common questions about the Machine Payments Protocol]

--- a/src/pages/guides/building-with-an-llm.mdx
+++ b/src/pages/guides/building-with-an-llm.mdx
@@ -1,7 +1,7 @@
 ---
 title: Build with an LLM
 description: Use llms-full.txt to give your agent complete MPP context.
-ogDescription: "Give your LLM or AI agent the context it needs to build MPP integrations from your codebase"
+imageDescription: "Give your LLM or AI agent the context it needs to build MPP integrations from your codebase"
 ---
 
 import { Card, Cards } from 'vocs'

--- a/src/pages/guides/multiple-payment-methods.mdx
+++ b/src/pages/guides/multiple-payment-methods.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Accept Tempo stablecoins, Stripe cards, and Lightning Bitcoin on a single API endpoint. Serve a multi-method 402 Challenge and let clients choose."
-ogDescription: "Offer your users a choice of payment methods including stablecoins, cards, and Lightning"
+imageDescription: "Offer your users a choice of payment methods including stablecoins, cards, and Lightning"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/guides/one-time-payments.mdx
+++ b/src/pages/guides/one-time-payments.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Accept single fixed-price payments for API calls using the charge intent with any payment method"
+imageDescription: "Accept single fixed-price payments for API calls using the charge intent with any payment method"
 ---
 
 import { Cards, Tabs, Tab } from 'vocs'

--- a/src/pages/guides/pay-as-you-go.mdx
+++ b/src/pages/guides/pay-as-you-go.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Build a payment-gated API with session-based billing using mppx payment channels. Charge per request with near-zero latency overhead."
-ogDescription: "Accept metered usage-based payments using sessions that track consumption over time"
+imageDescription: "Accept metered usage-based payments using sessions that track consumption over time"
 ---
 
 import { Cards, Tabs, Tab } from 'vocs'

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Accept streamed payments over Server-Sent Events with mppx. Bill per token in real time using Tempo payment channels for LLM inference APIs."
-ogDescription: "Accept continuous real-time payments that stream value as a service is consumed"
+imageDescription: "Accept continuous real-time payments that stream value as a service is consumed"
 ---
 
 import { Cards, Tabs, Tab } from "vocs";

--- a/src/pages/intents/charge.mdx
+++ b/src/pages/intents/charge.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Charge intent for one-time payments"
-ogDescription: "Immediate one-time payments where the full amount is collected in a single request-response cycle"
+imageDescription: "Immediate one-time payments where the full amount is collected in a single request-response cycle"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -1,6 +1,6 @@
 ---
 description: "MPP standardizes HTTP 402 for machine-to-machine payments. Learn how agents, apps, and services exchange payments in the same HTTP request."
-ogDescription: "The open protocol for machine-to-machine payments, built on an open IETF specification for HTTP 402"
+imageDescription: "The open protocol for machine-to-machine payments, built on an open IETF specification for HTTP 402"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/payment-methods/card/charge.mdx
+++ b/src/pages/payment-methods/card/charge.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "One-time payments using encrypted network tokens for secure card-based transactions"
+imageDescription: "One-time payments using encrypted network tokens for secure card-based transactions"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/payment-methods/card/index.mdx
+++ b/src/pages/payment-methods/card/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Card payment method"
-ogDescription: "Card payments via encrypted network tokens for direct card-present and card-not-present flows"
+imageDescription: "Card payments via encrypted network tokens for direct card-present and card-not-present flows"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/payment-methods/custom.mdx
+++ b/src/pages/payment-methods/custom.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Custom payment methods"
-ogDescription: "Build your own payment method by implementing the core challenge-credential-receipt control flow"
+imageDescription: "Build your own payment method by implementing the core challenge-credential-receipt control flow"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/payment-methods/index.mdx
+++ b/src/pages/payment-methods/index.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Available payment methods in MPP and how to choose the right one for your use case"
+imageDescription: "Available payment methods in MPP and how to choose the right one for your use case"
 ---
 
 import { Cards, Tab, Tabs } from 'vocs'

--- a/src/pages/payment-methods/lightning/charge.mdx
+++ b/src/pages/payment-methods/lightning/charge.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "One-time payments using BOLT11 invoices settled instantly over the Lightning Network"
+imageDescription: "One-time payments using BOLT11 invoices settled instantly over the Lightning Network"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/payment-methods/lightning/index.mdx
+++ b/src/pages/payment-methods/lightning/index.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Bitcoin payments over the Lightning Network for instant, low-fee global transactions"
+imageDescription: "Bitcoin payments over the Lightning Network for instant, low-fee global transactions"
 ---
 
 # Lightning [Bitcoin payments over the Lightning Network]

--- a/src/pages/payment-methods/lightning/session.mdx
+++ b/src/pages/payment-methods/lightning/session.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Pay-as-you-go streaming payments over Lightning using incrementally settled micropayments"
+imageDescription: "Pay-as-you-go streaming payments over Lightning using incrementally settled micropayments"
 ---
 
 import { Cards, Tab, Tabs } from 'vocs'

--- a/src/pages/payment-methods/stripe/charge.mdx
+++ b/src/pages/payment-methods/stripe/charge.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "One-time payments using Stripe Shared Payment Tokens for seamless card-based transactions"
+imageDescription: "One-time payments using Stripe Shared Payment Tokens for seamless card-based transactions"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/payment-methods/stripe/index.mdx
+++ b/src/pages/payment-methods/stripe/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Stripe payment method"
-ogDescription: "Accept card, wallet, and bank transfer payments through Stripe's global payment infrastructure"
+imageDescription: "Accept card, wallet, and bank transfer payments through Stripe's global payment infrastructure"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/payment-methods/tempo/charge.mdx
+++ b/src/pages/payment-methods/tempo/charge.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "One-time TIP-20 stablecoin token transfers settled on-chain with cryptographic receipts"
+imageDescription: "One-time TIP-20 stablecoin token transfers settled on-chain with cryptographic receipts"
 ---
 
 import { Cards } from "vocs";

--- a/src/pages/payment-methods/tempo/index.mdx
+++ b/src/pages/payment-methods/tempo/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Tempo stablecoin payments"
-ogDescription: "Stablecoin payments on the Tempo blockchain with near-instant finality and low transaction costs"
+imageDescription: "Stablecoin payments on the Tempo blockchain with near-instant finality and low transaction costs"
 ---
 
 import { Badge } from 'vocs'

--- a/src/pages/payment-methods/tempo/session.mdx
+++ b/src/pages/payment-methods/tempo/session.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Low-cost high-throughput streaming payments using off-chain state channels on Tempo"
+imageDescription: "Low-cost high-throughput streaming payments using off-chain state channels on Tempo"
 ---
 
 import { Cards, Tab, Tabs } from 'vocs'

--- a/src/pages/protocol/challenges.mdx
+++ b/src/pages/protocol/challenges.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Server-issued payment requirements that describe the amount, currency, and accepted payment methods"
+imageDescription: "Server-issued payment requirements that describe the amount, currency, and accepted payment methods"
 ---
 
 # Challenges [Server-issued payment requirements]

--- a/src/pages/protocol/credentials.mdx
+++ b/src/pages/protocol/credentials.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Client-submitted payment proofs that demonstrate a valid payment has been made for a request"
+imageDescription: "Client-submitted payment proofs that demonstrate a valid payment has been made for a request"
 ---
 
 # Credentials [Client-submitted payment proofs]

--- a/src/pages/protocol/http-402.mdx
+++ b/src/pages/protocol/http-402.mdx
@@ -1,6 +1,6 @@
 ---
 description: "HTTP 402 Payment Required signals that a resource requires payment. Learn when and how MPP servers return 402 with a WWW-Authenticate Challenge."
-ogDescription: "How MPP uses the HTTP 402 status code to signal that payment is required before accessing a resource"
+imageDescription: "How MPP uses the HTTP 402 status code to signal that payment is required before accessing a resource"
 ---
 
 # HTTP 402 payment required [The status code that signals payment is required]

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -1,6 +1,6 @@
 ---
 description: "The Machine Payments Protocol standardizes HTTP 402 with an extensible challenge–credential–receipt flow that works with any payment network."
-ogDescription: "An extensible framework for standardizing HTTP 402 Payment Required for machine-to-machine payments"
+imageDescription: "An extensible framework for standardizing HTTP 402 Payment Required for machine-to-machine payments"
 ---
 
 import { Badge } from "vocs";

--- a/src/pages/protocol/receipts.mdx
+++ b/src/pages/protocol/receipts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Payment receipts and verification"
 description: "Receipts confirm successful payment in MPP. Return them in the Payment-Receipt header so clients can verify that the server accepted their Credential."
-ogDescription: "Server-issued acknowledgments that confirm successful payment and grant access to the resource"
+imageDescription: "Server-issued acknowledgments that confirm successful payment and grant access to the resource"
 ---
 
 # Receipts [Server acknowledgment of successful payment]

--- a/src/pages/protocol/transports/http.mdx
+++ b/src/pages/protocol/transports/http.mdx
@@ -1,6 +1,6 @@
 ---
 description: "The HTTP transport maps MPP payment flows to standard HTTP headers—WWW-Authenticate for Challenges, Authorization for Credentials, and Payment-Receipt."
-ogDescription: "Payment flows using standard HTTP headers for challenges, credentials, and receipts"
+imageDescription: "Payment flows using standard HTTP headers for challenges, credentials, and receipts"
 ---
 
 import { Badge } from 'vocs'

--- a/src/pages/protocol/transports/index.mdx
+++ b/src/pages/protocol/transports/index.mdx
@@ -1,6 +1,6 @@
 ---
 description: "MPP defines transport bindings for HTTP and MCP. Learn how Challenges, Credentials, and Receipts map to headers and JSON-RPC messages."
-ogDescription: "How MPP payment flows are carried over different transport protocols like HTTP and MCP"
+imageDescription: "How MPP payment flows are carried over different transport protocols like HTTP and MCP"
 ---
 
 # Transports [HTTP and MCP bindings for payment flows]

--- a/src/pages/protocol/transports/mcp.mdx
+++ b/src/pages/protocol/transports/mcp.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Payment flows for AI tool calls using MCP and JSON-RPC as the underlying transport"
+imageDescription: "Payment flows for AI tool calls using MCP and JSON-RPC as the underlying transport"
 ---
 
 import { Badge } from 'vocs'

--- a/src/pages/quickstart/agent.mdx
+++ b/src/pages/quickstart/agent.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Connect your coding agent to MPP-enabled services. Set up Tempo Wallet or the mppx SDK to handle 402 payment flows automatically."
-ogDescription: "Connect your AI agent to MPP-enabled services and handle payments automatically"
+imageDescription: "Connect your AI agent to MPP-enabled services and handle payments automatically"
 ---
 
 import { Badge, Card, Cards, Tab, Tabs } from 'vocs'

--- a/src/pages/quickstart/client.mdx
+++ b/src/pages/quickstart/client.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Handle payment-gated resources in your app. Use the mppx client SDK to intercept 402 responses, pay, and retry—all automatically."
-ogDescription: "Handle payment-gated resources automatically in your frontend or backend application"
+imageDescription: "Handle payment-gated resources automatically in your frontend or backend application"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/quickstart/index.mdx
+++ b/src/pages/quickstart/index.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Get started with MPP in minutes. Protect your API with payments, connect your agent, or integrate your app with MPP-enabled services."
-ogDescription: "Get started with MPP in minutes using the TypeScript, Python, or Rust SDK"
+imageDescription: "Get started with MPP in minutes using the TypeScript, Python, or Rust SDK"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -1,6 +1,6 @@
 ---
 description: "Add payment-gated access to your API with mppx. Accept stablecoins, cards, and Bitcoin in a few lines of code using the MPP server SDK."
-ogDescription: "Charge for access to protected API resources using challenges, credentials, and receipts"
+imageDescription: "Charge for access to protected API resources using challenges, credentials, and receipts"
 ---
 
 import { Badge, Cards } from 'vocs'

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SDKs and client libraries"
 description: "Official MPP SDK implementations in TypeScript, Python, and Rust. Libraries for building MPP clients and servers with full protocol support."
-ogDescription: "Official MPP SDK implementations in TypeScript, Python, and Rust for clients, servers, and agents"
+imageDescription: "Official MPP SDK implementations in TypeScript, Python, and Rust for clients, servers, and agents"
 ---
 
 import { Cards } from 'vocs'

--- a/src/pages/sdk/python/client.mdx
+++ b/src/pages/sdk/python/client.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Python MPP client"
-ogDescription: "Handle HTTP 402 responses automatically and manage payment flows in Python clients"
+imageDescription: "Handle HTTP 402 responses automatically and manage payment flows in Python clients"
 ---
 
 # Client [Handle 402 responses automatically]

--- a/src/pages/sdk/python/core.mdx
+++ b/src/pages/sdk/python/core.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Challenge, Credential, and Receipt primitive types for working with the MPP protocol in Python"
+imageDescription: "Challenge, Credential, and Receipt primitive types for working with the MPP protocol in Python"
 ---
 
 # Core Types [Challenge, Credential, and Receipt primitives]

--- a/src/pages/sdk/python/index.mdx
+++ b/src/pages/sdk/python/index.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "The pympp Python library for building MPP clients and servers in Python applications"
+imageDescription: "The pympp Python library for building MPP clients and servers in Python applications"
 ---
 
 import * as SdkBadge from '../../../components/SdkBadge'

--- a/src/pages/sdk/python/server.mdx
+++ b/src/pages/sdk/python/server.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Protect API endpoints with payment requirements and verify credentials in Python servers"
+imageDescription: "Protect API endpoints with payment requirements and verify credentials in Python servers"
 ---
 
 # Server [Protect endpoints with payment requirements]

--- a/src/pages/sdk/rust/client.mdx
+++ b/src/pages/sdk/rust/client.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Handle HTTP 402 responses automatically and manage payment flows in Rust clients"
+imageDescription: "Handle HTTP 402 responses automatically and manage payment flows in Rust clients"
 ---
 
 # Client [Handle 402 responses automatically]

--- a/src/pages/sdk/rust/core.mdx
+++ b/src/pages/sdk/rust/core.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Challenge, Credential, and Receipt primitive types for working with the MPP protocol in Rust"
+imageDescription: "Challenge, Credential, and Receipt primitive types for working with the MPP protocol in Rust"
 ---
 
 # Core types [Challenge, Credential, and Receipt primitives]

--- a/src/pages/sdk/rust/index.mdx
+++ b/src/pages/sdk/rust/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Rust SDK for MPP"
-ogDescription: "The mpp Rust library for high-performance MPP clients and servers with zero-copy parsing"
+imageDescription: "The mpp Rust library for high-performance MPP clients and servers with zero-copy parsing"
 ---
 
 import * as SdkBadge from '../../../components/SdkBadge'

--- a/src/pages/sdk/rust/server.mdx
+++ b/src/pages/sdk/rust/server.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Protect API endpoints with payment requirements and verify credentials in Rust servers"
+imageDescription: "Protect API endpoints with payment requirements and verify credentials in Rust servers"
 ---
 
 # Server [Protect endpoints with payment requirements]

--- a/src/pages/sdk/typescript/cli.mdx
+++ b/src/pages/sdk/typescript/cli.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "Built-in command-line tool for making paid HTTP requests and managing wallets from the terminal"
+imageDescription: "Built-in command-line tool for making paid HTTP requests and managing wallets from the terminal"
 ---
 
 # CLI Reference [Built-in command-line tool for paid HTTP requests]

--- a/src/pages/sdk/typescript/core/Expires.mdx
+++ b/src/pages/sdk/typescript/core/Expires.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Expires utility functions"
-ogDescription: "Generate relative expiration timestamps for challenges, credentials, and payment requests"
+imageDescription: "Generate relative expiration timestamps for challenges, credentials, and payment requests"
 ---
 
 # `Expires` [Generate relative expiration timestamps]

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -1,5 +1,5 @@
 ---
-ogDescription: "The mppx TypeScript library for building MPP clients, servers, and middleware integrations"
+imageDescription: "The mppx TypeScript library for building MPP clients, servers, and middleware integrations"
 ---
 
 import * as SdkBadge from '../../../components/SdkBadge'

--- a/src/pages/services.mdx
+++ b/src/pages/services.mdx
@@ -4,7 +4,7 @@ layout: minimal
 showAskAi: false
 showOutline: false
 showSearch: false
-ogDescription: "Discover MPP-enabled services your agents and applications can pay for and use"
+imageDescription: "Discover MPP-enabled services your agents and applications can pay for and use"
 ---
 
 import { ServicesPage } from "../components/ServicesPage";


### PR DESCRIPTION
## Changes

Rename `ogDescription` → `imageDescription` in MDX frontmatter for clarity: this field controls the text rendered inside OG images, distinct from `description` which Vocs uses for HTML meta tags.

- 46 MDX pages: renamed frontmatter field
- `scripts/generate-og-descriptions.ts`: updated regex
- `src/pages/_api/api/og.tsx`: renamed import variable

Split from #447.