### PR TITLE
fix: VTCDuBois fonts not loading in production

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -447,14 +447,14 @@ export default function Layout(props: React.PropsWithChildren) {
       )}
       <link
         rel="preload"
-        href="/fonts/VTCDuBois-Regular.woff2"
+        href="https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-Regular.woff2"
         as="font"
         type="font/woff2"
         crossOrigin="anonymous"
       />
       <link
         rel="preload"
-        href="/fonts/VTCDuBois-Bold.woff2"
+        href="https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-Bold.woff2"
         as="font"
         type="font/woff2"
         crossOrigin="anonymous"

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -31,7 +31,8 @@
 
 @font-face {
   font-family: "VTC Du Bois";
-  src: url("/fonts/VTCDuBois-Regular.woff2") format("woff2");
+  src: url("https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-Regular.woff2")
+    format("woff2");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -39,7 +40,8 @@
 
 @font-face {
   font-family: "VTC Du Bois";
-  src: url("/fonts/VTCDuBois-Bold.woff2") format("woff2");
+  src: url("https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-Bold.woff2")
+    format("woff2");
   font-weight: 700;
   font-style: normal;
   font-display: swap;

--- a/vercel.json
+++ b/vercel.json
@@ -6,11 +6,5 @@
       "destination": "https://mpp.dev/:path",
       "permanent": true
     }
-  ],
-  "rewrites": [
-    {
-      "source": "/fonts/VTCDuBois-:path*",
-      "destination": "https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-:path*"
-    }
   ]
 }


### PR DESCRIPTION
## Changes

In SSR/dynamic rendering mode, the Node.js server handles all requests before Vercel rewrites fire. Since VTCDuBois font files are gitignored and not in the deployment, the server returns 404 before the Blob rewrite can kick in.

- Point `@font-face src` and preload links directly to Vercel Blob URL
- Remove the now-unnecessary `vercel.json` rewrite rule

Split from #447.