### PR TITLE
fix: 404 ASCII art compressed vertically on mobile

### DIFF
--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -161,7 +161,7 @@ export function NotFoundPage() {
         className="overflow-hidden max-w-full mb-8"
         style={{
           fontFamily: "monospace",
-          lineHeight: 1.15,
+          lineHeight: 1.8,
           whiteSpace: "pre",
           letterSpacing: "1px",
           color: "var(--vocs-text-color-heading)",
@@ -169,7 +169,7 @@ export function NotFoundPage() {
         }}
       >
         <div
-          className="text-[2.5px] sm:text-[4px] md:text-[5px] lg:text-[6px]"
+          className="text-[3px] sm:text-[4px] md:text-[5px] lg:text-[6px]"
           style={{ minWidth: "fit-content" }}
         >
           {mppLines.map((mppLine, lineIdx) => {


### PR DESCRIPTION
## Changes

- Increased `line-height` from 1.15 to 1.8
- Bumped minimum `font-size` from 2.5px to 3px

Split from #447.