### PR TITLE
docs: add Solana as payment method

### DIFF
--- a/src/components/cards.tsx
+++ b/src/components/cards.tsx
@@ -231,6 +231,39 @@ export function LightningSessionCard() {
   );
 }
 
+export function SolanaMethodCard() {
+  return (
+    <Card
+      description="Native SOL and SPL token payments on Solana"
+      icon="simple-icons:solana"
+      title="Solana"
+      to="/payment-methods/solana"
+    />
+  );
+}
+
+export function SolanaChargeCard() {
+  return (
+    <Card
+      description="One-time payments with signed transactions or confirmed signatures"
+      icon="simple-icons:solana"
+      title="Solana charge"
+      to="/payment-methods/solana/charge"
+    />
+  );
+}
+
+export function SolanaSessionCard() {
+  return (
+    <Card
+      description="Coming soon: Solana sessions with off-chain vouchers and on-chain settlement"
+      icon="simple-icons:solana"
+      title="Solana session"
+      to="https://github.com/tempoxyz/mpp-specs/pull/201"
+    />
+  );
+}
+
 export function StripeMethodCard() {
   return (
     <Card

--- a/src/pages/_api/api/og.tsx
+++ b/src/pages/_api/api/og.tsx
@@ -24,6 +24,7 @@ const sidebarSubcategories: Record<string, string> = {
   "/payment-methods/stripe": "Stripe",
   "/payment-methods/card": "Card",
   "/payment-methods/lightning": "Lightning",
+  "/payment-methods/solana": "Solana",
   "/payment-methods/custom": "Custom",
   "/intents": "Intents",
   "/protocol/transports": "Transports",

--- a/src/pages/intents/charge.mdx
+++ b/src/pages/intents/charge.mdx
@@ -5,7 +5,7 @@ imageDescription: "Immediate one-time payments where the full amount is collecte
 
 import { Cards } from 'vocs'
 import { MermaidDiagram } from '../../components/MermaidDiagram'
-import { TempoChargeCard, StripeMethodCard, LightningMethodCard, CardMethodCard } from '../../components/cards'
+import { TempoChargeCard, StripeMethodCard, LightningMethodCard, SolanaChargeCard, CardMethodCard } from '../../components/cards'
 import { SpecCard } from '../../components/SpecCard'
 
 # Charge [Immediate one-time payments]
@@ -69,6 +69,7 @@ Each payment method defines how charge is fulfilled, verified, and settled on it
   <TempoChargeCard />
   <StripeMethodCard />
   <LightningMethodCard />
+  <SolanaChargeCard />
   <CardMethodCard />
 </Cards>
 

--- a/src/pages/payment-methods/index.mdx
+++ b/src/pages/payment-methods/index.mdx
@@ -3,7 +3,7 @@ imageDescription: "Available payment methods in MPP and how to choose the right 
 ---
 
 import { Cards, Tab, Tabs } from 'vocs'
-import { TempoMethodCard, CardMethodCard, LightningMethodCard, StripeMethodCard, CustomMethodCard } from '../../components/cards'
+import { TempoMethodCard, CardMethodCard, LightningMethodCard, SolanaMethodCard, StripeMethodCard, CustomMethodCard } from '../../components/cards'
 
 # Payment methods [Available methods and how to choose one]
 
@@ -38,6 +38,12 @@ HTTP/1.1 402 Payment Required
 WWW-Authenticate: Payment method="lightning", intent="charge", ...
 ```
   </Tab>
+  <Tab title="Solana">
+```http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: Payment method="solana", intent="charge", ...
+```
+  </Tab>
 </Tabs>
 
 ## Available methods
@@ -47,5 +53,6 @@ WWW-Authenticate: Payment method="lightning", intent="charge", ...
   <StripeMethodCard />
   <CardMethodCard />
   <LightningMethodCard />
+  <SolanaMethodCard />
   <CustomMethodCard />
 </Cards>

--- a/src/pages/payment-methods/solana/charge.mdx
+++ b/src/pages/payment-methods/solana/charge.mdx
@@ -1,0 +1,63 @@
+---
+imageDescription: "One-time Solana payments using signed transactions or confirmed transaction signatures"
+---
+
+import { Cards } from 'vocs'
+import { SpecCard } from '../../../components/SpecCard'
+
+# Solana charge [One-time payments on Solana]
+
+The Solana implementation of the [charge](/intents/charge) intent.
+
+The server issues a charge challenge describing the expected amount, currency, recipient, and Solana-specific `methodDetails`. The client either presents a signed transaction for server broadcast or presents a confirmed transaction signature. The server verifies the transfer on-chain and returns the resource with a receipt.
+
+This method is best for fixed-price API calls, digital goods, and payments that should settle directly on Solana.
+
+## Server
+
+Use `solana.charge` to gate endpoints behind native SOL or SPL token payments.
+
+```ts
+import { Mppx } from 'mppx/server'
+import { solana } from '@solana/mpp/server'
+
+const mppx = Mppx.create({
+  methods: [solana.charge({
+    recipient: '9xAXssX9j7vuK99c7cFwqbixzL3bFrzPy9PUhCtDPAYJ',
+    network: 'devnet',
+  })],
+  secretKey: process.env.MPP_SECRET_KEY!,
+})
+```
+
+## Client
+
+Use `solana.charge` with `Mppx.create` to automatically handle Solana charge challenges.
+
+```ts
+import { Mppx } from 'mppx/client'
+import { solana } from '@solana/mpp/client'
+
+const mppx = Mppx.create({
+  methods: [solana.charge()],
+})
+```
+
+## Solana-specific request fields
+
+The Solana charge request extends the base charge schema with `methodDetails` fields such as:
+
+- `network`
+- `decimals`
+- `tokenProgram`
+- `feePayer`
+- `feePayerKey`
+- `splits`
+
+These fields let the server describe whether payment is in SOL or an SPL asset, whether fee sponsorship is available, and whether the payment should be split across multiple recipients.
+
+## Specification
+
+<Cards>
+  <SpecCard to="https://paymentauth.org/draft-solana-charge-00" />
+</Cards>

--- a/src/pages/payment-methods/solana/index.mdx
+++ b/src/pages/payment-methods/solana/index.mdx
@@ -1,0 +1,60 @@
+---
+imageDescription: "Native SOL and SPL token payments on Solana for one-time and session-based billing"
+---
+
+# Solana [Native SOL and SPL token payments]
+
+The Solana payment method enables MPP payments on Solana using native SOL, SPL tokens, and Token-2022 assets. Solana supports two intents: **charge** for one-time payments and **session** for escrowed, pay-as-you-go billing.
+
+The reference implementation is provided by [`@solana/mpp`](https://github.com/solana-foundation/mpp-sdk), which extends [`mppx`](https://github.com/tempoxyz/mpp) with Solana-native client and server handlers.
+
+## Installation
+
+:::code-group
+```bash [npm]
+npm install @solana/mpp mppx @solana/kit
+```
+```bash [pnpm]
+pnpm add @solana/mpp mppx @solana/kit
+```
+:::
+
+## Why Solana
+
+Solana enables several useful capabilities for MPP:
+
+- **Split payouts and richer settlement flows** through multiple instructions per transaction
+- **Fast finality** for low-latency charge flows
+- **Cheap transactions** for micropayments and fee-sponsored UX
+- **Native fee payer support** so servers can sponsor network fees
+- **Token flexibility** across SOL, SPL, and Token-2022 assets
+- **Delegated signer options** including Ed25519 and passkey-friendly secp256r1 flows
+
+## Choosing an intent
+
+| | **Charge** | **Session** |
+|---|---|---|
+| **Pattern** | One-time payment per request | Escrow once, pay incrementally with vouchers |
+| **Latency overhead** | One transaction or confirmed signature per request | Low after open; vouchers are off-chain |
+| **Throughput** | Best for discrete purchases | Best for high-frequency metered usage |
+| **Best for** | Paid API calls, downloads, fixed-price purchases | LLM APIs, streaming, repeated calls |
+| **Settlement** | Immediate on-chain transfer | Escrow on-chain, settle accepted usage later |
+
+## Intents
+
+<div className="vocs:grid vocs:grid-cols-1 vocs:md:grid-cols-2 vocs:gap-4">
+  <a href="/payment-methods/solana/charge" className="vocs:relative vocs:flex vocs:flex-col vocs:space-y-2 vocs:rounded-md vocs:bg-surfaceTint/70 vocs:border vocs:border-primary vocs:p-4 vocs:no-underline vocs:transition-colors vocs:hover:bg-surfaceTint">
+    <div className="vocs:size-8 vocs:flex vocs:items-center vocs:justify-center vocs:rounded-lg vocs:border vocs:border-primary vocs:bg-surface vocs:text-accent">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 397.7 311.7" fill="currentColor"><path d="M64.3 237.9c2.4-2.4 5.7-3.8 9.1-3.8h317.6c5.7 0 8.5 6.9 4.5 10.9l-62.7 62.7c-2.4 2.4-5.7 3.8-9.1 3.8H6.1c-5.7 0-8.5-6.9-4.5-10.9l62.7-62.7ZM64.3 3.8C66.7 1.4 70 0 73.4 0H391c5.7 0 8.5 6.9 4.5 10.9l-62.7 62.7c-2.4 2.4-5.7 3.8-9.1 3.8H6.1c-5.7 0-8.5-6.9-4.5-10.9L64.3 3.8Zm268.5 116.2c-2.4-2.4-5.7-3.8-9.1-3.8H6.1c-5.7 0-8.5 6.9-4.5 10.9l62.7 62.7c2.4 2.4 5.7 3.8 9.1 3.8h317.6c5.7 0 8.5-6.9 4.5-10.9L332.8 120Z"/></svg>
+    </div>
+    <div className="vocs:text-[15px] vocs:font-medium vocs:text-heading">Solana charge</div>
+    <div className="vocs:text-sm vocs:leading-relaxed vocs:text-secondary">One-time payments with signed transactions or confirmed signatures</div>
+  </a>
+  <a href="https://github.com/tempoxyz/mpp-specs/pull/201" className="vocs:relative vocs:flex vocs:flex-col vocs:space-y-2 vocs:rounded-md vocs:bg-surfaceTint/70 vocs:border vocs:border-primary vocs:p-4 vocs:no-underline vocs:transition-colors vocs:hover:bg-surfaceTint">
+    <div className="vocs:size-8 vocs:flex vocs:items-center vocs:justify-center vocs:rounded-lg vocs:border vocs:border-primary vocs:bg-surface vocs:text-accent">
+      <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 397.7 311.7" fill="currentColor"><path d="M64.3 237.9c2.4-2.4 5.7-3.8 9.1-3.8h317.6c5.7 0 8.5 6.9 4.5 10.9l-62.7 62.7c-2.4 2.4-5.7 3.8-9.1 3.8H6.1c-5.7 0-8.5-6.9-4.5-10.9l62.7-62.7ZM64.3 3.8C66.7 1.4 70 0 73.4 0H391c5.7 0 8.5 6.9 4.5 10.9l-62.7 62.7c-2.4 2.4-5.7 3.8-9.1 3.8H6.1c-5.7 0-8.5-6.9-4.5-10.9L64.3 3.8Zm268.5 116.2c-2.4-2.4-5.7-3.8-9.1-3.8H6.1c-5.7 0-8.5 6.9-4.5 10.9l62.7 62.7c2.4 2.4 5.7 3.8 9.1 3.8h317.6c5.7 0 8.5-6.9 4.5-10.9L332.8 120Z"/></svg>
+    </div>
+    <div className="vocs:text-[15px] vocs:font-medium vocs:text-heading">Solana session</div>
+    <div className="vocs:text-sm vocs:leading-relaxed vocs:text-secondary">Coming soon: Solana sessions with off-chain vouchers and on-chain settlement</div>
+  </a>
+</div>

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -355,6 +355,14 @@ export default defineConfig({
               { text: "Session", link: "/payment-methods/lightning/session" },
             ],
           },
+          {
+            text: "Solana",
+            collapsed: true,
+            items: [
+              { text: "Overview", link: "/payment-methods/solana" },
+              { text: "Charge", link: "/payment-methods/solana/charge" },
+            ],
+          },
           { text: "Custom", link: "/payment-methods/custom" },
         ],
       },


### PR DESCRIPTION
  ## Summary

  Add Solana to the docs navigation and payment-method docs surface.

  ## Changes

  - add Solana to the sidebar under Payment Methods, after Lightning
  - add Solana payment method overview page
  - add Solana charge page
  - wire Solana into payment-method cards, charge intent cards, and OG subcategory mapping
  - link Solana session to the in-progress spec PR instead of publishing a local session docs page
  - clarify Solana overview wording around split payouts, fee payer support, and coming-soon session support

  ## Notes

  - Solana session is intentionally not documented as a local page yet
  - the Solana session card currently points to the spec draft PR:
    - https://github.com/tempoxyz/mpp-specs/pull/201

  ## Validation

  - `pnpm check:ci`
  - `pnpm check:types`
  - `pnpm build`
  - local docs server tested successfully