### PR TITLE
feat: add Zinc to the MPP service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -5581,4 +5581,34 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── Zinc ──────────────────────────────────────────────────────────────────
+  {
+    id: "zinc",
+    name: "Zinc",
+    url: "https://zinc.com",
+    serviceUrl: "https://api.zinc.com",
+    description:
+      "Buy products from online retailers with an API call. Search, order, track, and return items across Amazon and more — supports AI agent ordering via MPP.",
+    categories: ["web"],
+    integration: "first-party",
+    tags: ["ecommerce", "shopping", "orders", "amazon", "retail", "purchasing"],
+    docs: {
+      homepage: "https://zinc.com/docs",
+      llmsTxt: "https://zinc.com/docs/llms.txt",
+      apiReference: "https://api.zinc.com/openapi.json",
+    },
+    provider: { name: "Zinc", url: "https://zinc.com" },
+    realm: "api.zinc.com",
+    intent: "charge",
+    payment: TEMPO_PAYMENT,
+    endpoints: [
+      {
+        route: "POST /agent/orders",
+        desc: "Place an order via MPP — no account required",
+        dynamic: true,
+        amountHint: "Product price + shipping + tax + $1 API fee",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- Add Zinc as a first-party MPP service at `https://api.zinc.com`
- One paid endpoint: `POST /agent/orders` (dynamic pricing via MPP 402 flow)

## Zinc
Zinc lets AI agents buy products from online retailers via a single API. No account required — payment is handled via MPP (HTTP 402). Supports Amazon and more.

- **Service URL:** https://api.zinc.com
- **Playground:** https://agent.zinc.com
- **Docs:** https://zinc.com/docs
- **API Reference:** https://api.zinc.com/openapi.json
- **llms.txt:** https://zinc.com/docs/llms.txt
- **MPPScan:** https://www.mppscan.com/server/0e705a85671563456d9a700961ffcf22ff393c0187330ceba7c44b1f2d7316a7

## Validation
- `pnpm check:types` ✅
- `pnpm build` ✅
- `npx @agentcash/discovery discover https://api.zinc.com` ✅
- Registered on MPPScan ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)