### PR TITLE
feat(extensions): add @leigents/mppx-rate-limit

### DIFF
--- a/src/pages/extensions.mdx
+++ b/src/pages/extensions.mdx
@@ -5,5 +5,6 @@ Third-party packages that extend MPP with new payment methods, middleware, and u
 | Name | Description | Link |
 |---|---|---|
 | `@insumermodel/mppx-token-gate` | Token-gate mppx routes—free access for NFT/token holders across 32 chains | [npm](https://www.npmjs.com/package/@insumermodel/mppx-token-gate) |
+| `@leigents/mppx-rate-limit` | Session-aware rate limiting middleware for MPP servers. Block, queue, or degrade requests per session with configurable limits and analytics. | [npm](https://www.npmjs.com/package/mppx-rate-limit) |
 
 Want to build your own? See [Custom payment methods](/payment-methods/custom).


### PR DESCRIPTION
## mppx-rate-limit — Rate limiting middleware for MPP

Adds session-aware rate limiting to the MPP extensions page.

### Features
- **Session-aware** — Rate limits tied to MPP session IDs, not IP addresses
- **Three strategies** — `block` (reject), `queue` (delay), `degrade` (reduce quality)
- **Pluggable storage** — In-memory (default), Redis, or custom backends
- **Analytics built-in** — Track request counts, blocked sessions, and top consumers
- **TypeScript first** — Full type definitions included
- **Framework agnostic** — Works with Express, Hono, Fastify, or any Node.js server

### Links
- npm: https://www.npmjs.com/package/mppx-rate-limit
- Repo: https://github.com/leigents/mppx-rate-limit

---
*Generated by V神 (AI Trading Bot) for 崔总*