### PR TITLE
feat: add Merx to the MPP service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -4759,6 +4759,45 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Merx ────────────────────────────────────────────────────────────────
+  {
+    id: "merx",
+    name: "Merx API",
+    url: "https://api.merxprotocol.eu",
+    serviceUrl: "https://api.merxprotocol.eu",
+    description:
+      "European business data — French company verification (SIRET + BODACC risk scoring), EU VAT validation (VIES), and legal search.",
+    categories: ["data"],
+    integration: "first-party",
+    tags: ["business", "europe", "company", "vat", "legal", "france", "compliance"],
+    docs: {
+      homepage: "https://merxprotocol.eu",
+      llmsTxt: "https://api.merxprotocol.eu/llms.txt",
+      apiReference: "https://api.merxprotocol.eu/v1/endpoints",
+    },
+    provider: { name: "Merx", url: "https://merxprotocol.eu" },
+    realm: "api.merxprotocol.eu",
+    intent: "charge",
+    payment: TEMPO_PAYMENT,
+    endpoints: [
+      {
+        route: "GET /v1/company/:siret",
+        desc: "French company check — legal status, directors, BODACC risk score",
+        amount: "100000",
+      },
+      {
+        route: "GET /v1/vat/:country/:number",
+        desc: "EU VAT number validation — all 27 member states via VIES",
+        amount: "50000",
+      },
+      {
+        route: "GET /v1/legal/search",
+        desc: "French legal search — laws, decrees, case law",
+        amount: "150000",
+      },
+    ],
+  },
+
   // ── Mathpix ──────────────────────────────────────────────────────────
   {
     id: "mathpix",


### PR DESCRIPTION
## Summary

Adds **Merx API** to the service directory — the first European business data service on MPP.

**Live at:** https://api.merxprotocol.eu

### Endpoints
| Route | Description | Amount |
|-------|-------------|--------|
| `GET /v1/company/:siret` | French company check — legal status, directors, BODACC risk score | $0.10 |
| `GET /v1/vat/:country/:number` | EU VAT number validation — all 27 member states via VIES | $0.05 |
| `GET /v1/legal/search` | French legal search — laws, decrees, case law | $0.15 |

### Verification
- HTTP 402 challenge works: `curl -H "X-API-Key: test" https://api.merxprotocol.eu/v1/company/32212091600208`
- llms.txt: https://api.merxprotocol.eu/llms.txt
- Endpoint discovery: https://api.merxprotocol.eu/v1/endpoints
- Payment: Tempo charge (USDC mainnet)

### Checklist
- [x] Service is live and accepting payments via MPP
- [x] Entry added to `schemas/services.ts`