### PR TITLE
Add @leigents/mcp - MCP server paid tools SDK for MPP

### DIFF
--- a/src/pages/extensions.mdx
+++ b/src/pages/extensions.mdx
@@ -6,5 +6,6 @@ Third-party packages that extend MPP with new payment methods, middleware, and u
 |---|---|---|
 | `@insumermodel/mppx-token-gate` | Token-gate mppx routes—free access for NFT/token holders across 32 chains | [npm](https://www.npmjs.com/package/@insumermodel/mppx-token-gate) |
 | `@leigents/mppx-rate-limit` | Session-aware rate limiting middleware for MPP servers. Block, queue, or degrade requests per session with configurable limits and analytics. | [npm](https://www.npmjs.com/package/mppx-rate-limit) |
+| `@leigents/mcp` | Turn your MCP server tools into paid endpoints using the Machine Payments Protocol. Add price configs to tools and get paid automatically in stablecoins or fiat. | [npm](https://www.npmjs.com/package/@leigents/mcp) |
 
 Want to build your own? See [Custom payment methods](/payment-methods/custom).

--- a/src/pages/extensions.mdx
+++ b/src/pages/extensions.mdx
@@ -5,5 +5,6 @@ Third-party packages that extend MPP with new payment methods, middleware, and u
 | Name | Description | Link |
 |---|---|---|
 | `@insumermodel/mppx-token-gate` | Token-gate mppx routes—free access for NFT/token holders across 32 chains | [npm](https://www.npmjs.com/package/@insumermodel/mppx-token-gate) |
+| `@leigents/mppx-rate-limit` | Session-aware rate limiting middleware for MPP servers. Block, queue, or degrade requests per session with configurable limits and analytics. | [npm](https://www.npmjs.com/package/mppx-rate-limit) |
 
 Want to build your own? See [Custom payment methods](/payment-methods/custom).


### PR DESCRIPTION
## @leigents/mcp

Turn your MCP server tools into paid endpoints — in minutes, not days.

### What it does
`@leigents/mcp` makes it trivial to add the Machine Payments Protocol (MPP) to any MCP server. Define your tools, set a price, and get paid — in stablecoins or fiat — without touching blockchain code.

### Key features
- **Per-call payments (`charge`)** — agents pay per tool invocation
- **Session payments (`session`)** — streaming-compatible billing
- **Multi-method support** — Tempo stablecoins, Stripe cards
- **Zero blockchain code** — just add a `price` config to your tools
- **Works with Claude Desktop, Cursor, and any MCP client**

### Links
- **GitHub**: https://github.com/leigents/mpp-mcp
- **npm**: https://www.npmjs.com/package/@leigents/mcp

Built by [clei](https://github.com/leigents) | MIT License