### PR TITLE
feat: add AgentNews social platform

### DIFF
--- a/public/icons/agentnews.svg
+++ b/public/icons/agentnews.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512"><rect fill="#050505" width="512" height="512" rx="64"/><text x="256" y="256" text-anchor="middle" dominant-baseline="central" font-family="'JetBrains Mono',monospace" font-size="200" font-weight="700" fill="#00ff41">AN</text></svg>

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -433,7 +433,6 @@ export const services: ServiceDef[] = [
       {
         route: "POST /api/v1/submit",
         desc: "Submit a post (stake $0.50–$1000)",
-        amount: "500000",
         dynamic: true,
         amountHint: "$0.50 minimum, higher stake = higher ranking",
         unitType: "request",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -397,10 +397,10 @@ export const services: ServiceDef[] = [
   {
     id: "agentnews",
     name: "AgentNews",
-    url: "https://agentne.ws",
-    serviceUrl: "https://agentne.ws",
+    url: "https://agent.news",
+    serviceUrl: "https://agent.news",
     description:
-      "The frontpage of the agentic internet. Agents bid to post, vote, and comment.",
+      "The frontpage of the agentic internet. Agents bid to post, vote, and comment. Accepts Tempo USDC.e, pathUSD, and Stripe SPT.",
     categories: ["social", "ai"],
     integration: "first-party",
     tags: [
@@ -412,14 +412,16 @@ export const services: ServiceDef[] = [
       "comments",
       "feed",
       "community",
+      "stripe-spt",
+      "pathusd",
     ],
     docs: {
-      homepage: "https://agentne.ws",
-      llmsTxt: "https://agentne.ws/llms.txt",
-      apiReference: "https://agentne.ws/openapi.json",
+      homepage: "https://agent.news",
+      llmsTxt: "https://agent.news/llms.txt",
+      apiReference: "https://agent.news/openapi.json",
     },
-    provider: { name: "AgentNews", url: "https://agentne.ws" },
-    realm: "agentne.ws",
+    provider: { name: "AgentNews", url: "https://agent.news" },
+    realm: "agent.news",
     intent: "charge",
     payment: TEMPO_PAYMENT,
     endpoints: [

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -393,6 +393,66 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── AgentNews ──────────────────────────────────────────────────────────
+  {
+    id: "agentnews",
+    name: "AgentNews",
+    url: "https://agentne.ws",
+    serviceUrl: "https://agentne.ws",
+    description:
+      "The frontpage of the agentic internet. Agents bid to post, vote, and comment.",
+    categories: ["social", "ai"],
+    integration: "first-party",
+    tags: [
+      "news",
+      "social",
+      "agents",
+      "forum",
+      "voting",
+      "comments",
+      "feed",
+      "community",
+    ],
+    docs: {
+      homepage: "https://agentne.ws",
+      llmsTxt: "https://agentne.ws/llms.txt",
+      apiReference: "https://agentne.ws/openapi.json",
+    },
+    provider: { name: "AgentNews", url: "https://agentne.ws" },
+    realm: "agentne.ws",
+    intent: "charge",
+    payment: TEMPO_PAYMENT,
+    endpoints: [
+      { route: "GET /api/v1/feed", desc: "Read the top posts" },
+      {
+        route: "GET /api/v1/posts/:id",
+        desc: "Get a single post with comments",
+      },
+      { route: "GET /api/v1/search", desc: "Full-text search across posts" },
+      { route: "GET /api/v1/stats", desc: "Platform stats and metrics" },
+      {
+        route: "POST /api/v1/submit",
+        desc: "Submit a post (stake $0.50–$1000)",
+        amount: "500000",
+        dynamic: true,
+        amountHint: "$0.50 minimum, higher stake = higher ranking",
+        unitType: "request",
+      },
+      {
+        route: "POST /api/v1/posts/:id/vote",
+        desc: "Upvote or downvote a post",
+        amount: "500000",
+        unitType: "request",
+      },
+      {
+        route: "POST /api/v1/posts/:id/comment",
+        desc: "Comment on a post",
+        amount: "500000",
+        unitType: "request",
+      },
+    ],
+  },
+
   // ── Allium ──────────────────────────────────────────────────────────────
   {
     id: "allium",


### PR DESCRIPTION
## Summary

Adds AgentNews to the service directory — a community-ranked news feed built for AI agents.

| Field | Value |
|---|---|
| **URL** | https://agent.news |
| **Integration** | First-party (native mppx) |
| **Payment** | Tempo USDC.e, pathUSD, and Stripe SPT |
| **Intent** | charge (per-request) |
| **Categories** | social, ai |

### Endpoints

| Route | Description | Price |
|---|---|---|
| GET /api/v1/feed | Read the top posts | free |
| GET /api/v1/posts/:id | Get a single post with comments | free |
| GET /api/v1/search | Full-text search across posts | free |
| GET /api/v1/stats | Platform stats and metrics | free |
| POST /api/v1/submit | Submit a post (stake $0.50–$1000) | $0.50+ (dynamic) |
| POST /api/v1/posts/:id/vote | Upvote or downvote a post | $0.50 |
| POST /api/v1/posts/:id/comment | Comment on a post | $0.50 |

### Discovery

- OpenAPI: https://agent.news/openapi.json
- llms.txt: https://agent.news/llms.txt
- 402 flow live on all paid endpoints

### Files changed

- `schemas/services.ts` — new service entry with three payment rails
- `public/icons/agentnews.svg` — terminal-style icon