### PR TITLE
Add TensorPath GPU rental service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6017,6 +6017,70 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── TensorPath ──────────────────────────────────────────────────────
+  {
+    id: "tensorpath",
+    name: "TensorPath",
+    url: "https://tensorpath.io",
+    serviceUrl: "https://mpp.tensorpath.io",
+    description:
+      "Rent dedicated GPUs with SSH access — pay per-minute with stablecoins via MPP.",
+    categories: ["compute"],
+    integration: "first-party",
+    tags: [
+      "gpu",
+      "compute",
+      "ssh",
+      "rental",
+      "cloud",
+      "machine-learning",
+      "inference",
+    ],
+    docs: {
+      homepage: "https://mpp.tensorpath.io/v1/reference",
+      llmsTxt: "https://mpp.tensorpath.io/llms.txt",
+      apiReference: "https://mpp.tensorpath.io/v1/reference",
+    },
+    provider: { name: "TensorPath", url: "https://tensorpath.io" },
+    realm: "mpp.tensorpath.io",
+    intent: "charge",
+    payment: TEMPO_PAYMENT,
+    endpoints: [
+      // Discovery (free)
+      {
+        route: "GET /v1/catalog",
+        desc: "List available GPU types with pricing and specs",
+      },
+      {
+        route: "GET /v1/catalog/:instanceTypeId",
+        desc: "Get GPU type details and available OS images",
+      },
+      // Instance management (paid)
+      {
+        route: "POST /v1/instances",
+        desc: "Launch a GPU instance — price varies by GPU type and duration",
+        dynamic: true,
+        amountHint: "varies by GPU type and duration",
+        unitType: "request",
+      },
+      {
+        route: "GET /v1/instances",
+        desc: "List active GPU rentals",
+      },
+      {
+        route: "GET /v1/instances/:instanceId",
+        desc: "Get instance status and connection details",
+      },
+      {
+        route: "POST /v1/instances/:instanceId/extend",
+        desc: "Extend GPU rental duration",
+        dynamic: true,
+        amountHint: "varies by GPU type and duration",
+        unitType: "request",
+      },
+    ],
+  },
+
   // ── Timezone ─────────────────────────────────────────────────────────
   {
     id: "abstract-timezone",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -3996,15 +3996,7 @@ export const services: ServiceDef[] = [
       "The agent exchange. Discover, hire, and pay agents for coding, design, writing, and more. Pay per request with stablecoins on Tempo.",
     categories: ["ai"],
     integration: "first-party",
-    tags: [
-      "agents",
-      "marketplace",
-      "exchange",
-      "coding",
-      "design",
-      "writing",
-      "ai-agents",
-    ],
+    tags: ["agents", "marketplace", "exchange", "coding", "design", "writing", "ai-agents"],
     status: "active",
     docs: {
       homepage: "https://auto.exchange/docs",
@@ -6032,7 +6024,7 @@ export const services: ServiceDef[] = [
     url: "https://tensorpath.io",
     serviceUrl: "https://mpp.tensorpath.io",
     description:
-      "On-demand GPU compute with SSH access for AI and ML workloads — pay per-minute with stablecoins.",
+      "Rent on-demand dedicated GPU with SSH access for AI and ML workloads — pay per-minute with stablecoins.",
     categories: ["ai", "compute"],
     integration: "first-party",
     tags: [

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6032,7 +6032,7 @@ export const services: ServiceDef[] = [
     url: "https://tensorpath.io",
     serviceUrl: "https://mpp.tensorpath.io",
     description:
-      "Rent dedicated GPUs with SSH access — pay per-minute with stablecoins via MPP.",
+      "On-demand GPU compute with SSH access for AI and ML workloads — pay per-minute with stablecoins.",
     categories: ["ai", "compute"],
     integration: "first-party",
     tags: [

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -3996,7 +3996,15 @@ export const services: ServiceDef[] = [
       "The agent exchange. Discover, hire, and pay agents for coding, design, writing, and more. Pay per request with stablecoins on Tempo.",
     categories: ["ai"],
     integration: "first-party",
-    tags: ["agents", "marketplace", "exchange", "coding", "design", "writing", "ai-agents"],
+    tags: [
+      "agents",
+      "marketplace",
+      "exchange",
+      "coding",
+      "design",
+      "writing",
+      "ai-agents",
+    ],
     status: "active",
     docs: {
       homepage: "https://auto.exchange/docs",
@@ -6025,9 +6033,10 @@ export const services: ServiceDef[] = [
     serviceUrl: "https://mpp.tensorpath.io",
     description:
       "Rent dedicated GPUs with SSH access — pay per-minute with stablecoins via MPP.",
-    categories: ["compute"],
+    categories: ["ai", "compute"],
     integration: "first-party",
     tags: [
+      "ai",
       "gpu",
       "compute",
       "ssh",


### PR DESCRIPTION
## Summary
- Adds TensorPath to `schemas/services.ts` — a GPU rental platform with SSH access, paid per-minute via MPP
- 6 endpoints: catalog discovery (free) and instance management (paid with dynamic pricing)
- First-party integration at `https://mpp.tensorpath.io`

## Test plan
- [x] `pnpm check:types` passes
- [x] `pnpm build` succeeds (86 services, 833 endpoints)
- [x] `pnpm test` passes (5698 tests)
- [x] `pnpm check` passes (Biome lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)