### PR TITLE
feat: add BaseMail to services directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -121,6 +121,32 @@ export interface ServiceDef {
 
 // prettier-ignore
 export const services: ServiceDef[] = [
+  // ── BaseMail ───────────────────────────────────────────────────────────
+  {
+    id: "basemail",
+    name: "BaseMail",
+    url: "https://api.basemail.ai",
+    serviceUrl: "https://basemail.ai",
+    description: "Agentic email (Æmail) for AI agents on Base chain. Register with SIWE or MPP, send/receive email, manage Attention Bonds. ERC-8004 compatible.",
+    categories: ["ai", "social"],
+    integration: "first-party",
+    tags: ["email", "agents", "web3", "base-chain", "attention-bonds", "erc-8004"],
+    docs: { homepage: "https://basemail.ai", apiReference: "https://api.basemail.ai/api/docs" },
+    provider: { name: "BaseMail", url: "https://basemail.ai" },
+    realm: "api.basemail.ai",
+    intent: "charge",
+    payment: TEMPO_PAYMENT,
+    endpoints: [
+      { route: "POST /api/register", desc: "Register email inbox", amount: "1000000" },
+      { route: "POST /api/send", desc: "Send email", amount: "10000" },
+      { route: "GET /api/inbox", desc: "List received emails" },
+      { route: "POST /api/auth/start", desc: "Get SIWE authentication message" },
+      { route: "POST /api/auth/agent-register", desc: "Sign + auto-register agent" },
+      { route: "GET /api/register/check/:query", desc: "Check identity availability" },
+      { route: "GET /api/agent/:handle/registration.json", desc: "ERC-8004 agent profile" },
+    ],
+  },
+
   // ── AgentMail ──────────────────────────────────────────────────────────
   {
     id: "agentmail",


### PR DESCRIPTION
## Summary
Add [BaseMail](https://basemail.ai) — agentic email (Æmail) for AI agents on Base chain — to the MPP services directory.

- **Register inbox**: $1.00 USDC.e via Tempo
- **Send email**: $0.01 USDC.e via Tempo
- Dual-track auth: existing Bearer token (SIWE/JWT) or MPP Payment
- ERC-8004 compatible agent profiles
- Discovery doc: https://api.basemail.ai/openapi.json
- MPPScan: [registered](https://mppscan.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)