### PR TITLE
feat: add CanFly.ai to services directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -138,7 +138,7 @@ export const services: ServiceDef[] = [
       "escrow",
       "base-chain",
     ],
-    docs: { homepage: "https://canfly.ai", llms: "https://canfly.ai/llms.txt" },
+    docs: { homepage: "https://canfly.ai", llmsTxt: "https://canfly.ai/llms.txt" },
     provider: { name: "CanFly.ai", url: "https://canfly.ai" },
     realm: "canfly.ai",
     intent: "charge",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -121,6 +121,37 @@ export interface ServiceDef {
 
 // prettier-ignore
 export const services: ServiceDef[] = [
+  // ── CanFly.ai ─────────────────────────────────────────────────────────
+  {
+    id: "canfly",
+    name: "CanFly.ai",
+    url: "https://canfly.ai",
+    serviceUrl: "https://canfly.ai",
+    description: "AI agent skill marketplace. Discover, order, and pay for agent skills with MPP.",
+    categories: ["ai"],
+    integration: "first-party",
+    tags: [
+      "marketplace",
+      "skills",
+      "agents",
+      "a2a",
+      "escrow",
+      "base-chain",
+    ],
+    docs: { homepage: "https://canfly.ai", llms: "https://canfly.ai/llms.txt" },
+    provider: { name: "CanFly.ai", url: "https://canfly.ai" },
+    realm: "canfly.ai",
+    intent: "charge",
+    payment: TEMPO_PAYMENT,
+    endpoints: [
+      { route: "POST /api/agents/{name}/tasks", desc: "Order a purchasable skill (dynamic pricing per skill)", amount: "10000" },
+      { route: "GET /api/community/agents", desc: "Browse all agents" },
+      { route: "GET /api/community/agents/{name}", desc: "Get agent detail" },
+      { route: "GET /api/agents/{name}/agent-card.json", desc: "A2A Agent Card" },
+      { route: "POST /api/agents/register", desc: "Register a new agent" },
+    ],
+  },
+
   // ── AgentMail ──────────────────────────────────────────────────────────
   {
     id: "agentmail",


### PR DESCRIPTION
## Summary
Add [CanFly.ai](https://canfly.ai) — AI agent skill marketplace — to the MPP services directory.

- **8 purchasable skills** from 3 agents, each independently priced ($0.001 ~ $0.10)
- Dynamic pricing via `POST /api/agents/{name}/tasks`
- USDC.e on Tempo via MPP
- Discovery: https://canfly.ai/openapi.json (dynamic, auto-updates when new skills are listed)
- MPPScan: [registered](https://mppscan.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)