### PR TITLE
docs: tune one-time payments page metadata for SEO

### DIFF
--- a/src/pages/guides/one-time-payments.mdx
+++ b/src/pages/guides/one-time-payments.mdx
@@ -1,5 +1,6 @@
 ---
-imageDescription: "Accept one-time payments for API calls"
+description: "Charge per API call with MPP. Accept pay-per-request payments from agents, apps, and users—no API keys or subscriptions required."
+imageDescription: "Charge per API call with one-time payments"
 ---
 
 import { Cards, Tabs, Tab } from 'vocs'


### PR DESCRIPTION
Target keyword: **pay per API call** (~300–500 monthly searches US)

### Changes
- **description**: added (was completely missing). "Charge per API call with MPP. Accept pay-per-request payments..." — targets "pay per API call" and "charge per API call" variants
- **imageDescription**: "Charge per API call with one-time payments" — includes keyword, clearer than old "Accept one-time payments for API calls"

### Rationale
This page had no `description` at all, meaning search engines were auto-generating one from page content. The new description puts "charge per API call" and "pay-per-request" front and center—matching what developers search when looking to implement per-request billing.

Prompted by: Tony