### PR TITLE
fix: make theme toggle work with LightningCSS light-dark() polyfill

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -256,7 +256,7 @@ function LogoMenu({
 
   const isDark =
     typeof window !== "undefined" &&
-    window.matchMedia("(prefers-color-scheme: dark)").matches;
+    getComputedStyle(document.documentElement).colorScheme.includes("dark");
 
   const maxX = typeof window !== "undefined" ? window.innerWidth - 240 : pos.x;
   const left = Math.min(pos.x, maxX);

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -86,6 +86,23 @@
 @source "../";
 
 /*
+ * Fix: LightningCSS (via Tailwind v4) compiles light-dark() into a polyfill
+ * that uses @media (prefers-color-scheme) — which only responds to the OS-level
+ * dark preference, not the inline `color-scheme` set by Vocs's theme toggle.
+ *
+ * Override the polyfill variables (--lightningcss-light / --lightningcss-dark)
+ * to respect the inline color-scheme attribute that Vocs sets on <html>.
+ */
+html[style*="color-scheme: light"] {
+  --lightningcss-light: initial;
+  --lightningcss-dark: ;
+}
+html[style*="color-scheme: dark"] {
+  --lightningcss-light: ;
+  --lightningcss-dark: initial;
+}
+
+/*
  * Logo visibility is handled by Vocs via vocs:dark:hidden / vocs:dark:block
  * classes which react to the inline color-scheme set by the blocking script
  * in Head.tsx. No manual overrides needed.


### PR DESCRIPTION
## Summary

Theme toggle (light/dark/system) had no effect — the site always followed the OS preference.

## Motivation

LightningCSS (via Tailwind v4) compiles `light-dark()` into a polyfill using `@media (prefers-color-scheme)`, which only responds to the OS-level dark preference. Vocs v2 toggles themes by setting `color-scheme: light` or `color-scheme: dark` on `<html>` via inline style — but the polyfill's media query ignores that.

## Changes

- `src/pages/_root.css`: Override `--lightningcss-light` / `--lightningcss-dark` polyfill variables using attribute selectors that match the inline `color-scheme` set by Vocs
- `src/pages/_layout.tsx`: Fix `LogoMenu` `isDark` check to read computed `color-scheme` instead of `matchMedia`, so the right logo variant is copied

## Testing

Verified locally with OS in dark mode:
- Click light toggle → page switches to light theme ✅
- Click dark toggle → page switches back to dark ✅
- System toggle → follows OS preference ✅

`pnpm check:types` and `pnpm check` pass.

Prompted by: tanishq