### PR TITLE
docs: bump mppx to 0.5.12 and document new features

### DIFF
--- a/.mppx-docs-sync
+++ b/.mppx-docs-sync
@@ -1,0 +1,8 @@
+# mppx documentation sync bookmark
+#
+# Tracks the last mppx commit SHA (on main) that was reviewed for documentation.
+# When updating docs from mppx changes, bump this SHA to HEAD of mppx main
+# after incorporating the new features/changes into the docs site.
+
+mppx_version=0.5.12
+mppx_sha=d670f4b81ef21edb7b0917f6a7a1802476015ced

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@stripe/stripe-js": "^8.9.0",
     "@vercel/blob": "^2.3.1",
     "mermaid": "^11.12.2",
-    "mppx": "0.5.7",
+    "mppx": "0.5.12",
     "react": "^19",
     "react-dom": "^19",
     "stripe": "^20.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^11.12.2
         version: 11.12.2
       mppx:
-        specifier: 0.5.7
-        version: 0.5.7(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.11.9)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
+        specifier: 0.5.12
+        version: 0.5.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.11.9)(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
       react:
         specifier: ^19
         version: 19.2.4
@@ -43,10 +43,10 @@ importers:
         version: 2.47.6(typescript@5.9.3)(zod@4.3.6)
       vocs:
         specifier: https://pkg.pr.new/wevm/vocs@2fb25c2
-        version: https://pkg.pr.new/wevm/vocs@2fb25c2(@types/react@19.2.14)(mermaid@11.12.2)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3)))(react@19.2.4)(rollup@4.57.1)(typescript@5.9.3)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: https://pkg.pr.new/wevm/vocs@2fb25c2(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.12.2)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3)))(react@19.2.4)(rollup@4.57.1)(typescript@5.9.3)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       wagmi:
         specifier: ^3.4.2
-        version: 3.5.0(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(@types/react@19.2.14)(ox@0.14.7(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
+        version: 3.5.0(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(@types/react@19.2.14)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
       waku:
         specifier: ^1.0.0-alpha.4
         version: 1.0.0-alpha.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -122,12 +122,6 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
-
-  '@apidevtools/json-schema-ref-parser@14.2.1':
-    resolution: {integrity: sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      '@types/json-schema': ^7.0.15
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -296,6 +290,9 @@ packages:
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@chevrotain/cst-dts-gen@11.0.3':
     resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
@@ -545,10 +542,6 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@humanwhocodes/momoa@2.0.4':
-    resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
-    engines: {node: '>=10.10.0'}
-
   '@iconify-json/lucide@1.2.90':
     resolution: {integrity: sha512-dPn1pRhfBa9KR+EVpdyM1Rvw3T36hCKYxd6TxK1ifffiNt0f5yXx8ZVhqnzPH4Vkz87yLMj5xFCXomNrnzd2kQ==}
 
@@ -634,6 +627,15 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@modelcontextprotocol/server@2.0.0-alpha.2':
+    resolution: {integrity: sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
     peerDependencies:
@@ -672,28 +674,6 @@ packages:
     resolution: {integrity: sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==}
     peerDependencies:
       react: '>=16.8'
-
-  '@readme/better-ajv-errors@2.4.0':
-    resolution: {integrity: sha512-9WODaOAKSl/mU+MYNZ2aHCrkoRSvmQ+1YkLj589OEqqjOAhbn8j7Z+ilYoiTu/he6X63/clsxxAB4qny9/dDzg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      ajv: 4.11.8 - 8
-
-  '@readme/openapi-parser@6.0.0':
-    resolution: {integrity: sha512-PaTnrKlKgEJZzjJ77AAhGe28NiyLBdiKMx95rJ9xlLZ8QLqYitMpPBQAKhsuEGOWQQbsIMfBZEPavbXghACQHA==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      openapi-types: '>=7'
-
-  '@readme/openapi-schemas@3.1.0':
-    resolution: {integrity: sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw==}
-    engines: {node: '>=18'}
-
-  '@remix-run/fetch-proxy@0.7.1':
-    resolution: {integrity: sha512-rPLfOpAaCXtm1dLI45uIPKERNbXbrh0P9AJc1sliz8pWd/McaFYjdr5KzB4QrFSfPvEt/Wmy6F2521qB1kK0ug==}
-
-  '@remix-run/headers@0.19.0':
-    resolution: {integrity: sha512-+62NbkXuXm9r/NdG6KfH9OCKofCWm8VjkrVPICiHKtRl8Gf2Vi6eFTN4mGgBlZRhd5mmEVRV4hTIn/JUSHDAOw==}
 
   '@remix-run/node-fetch-server@0.13.0':
     resolution: {integrity: sha512-1EsNo0ZpgXu/90AWoRZf/oE3RVTUS80tiTUpt+hv5pjtAkw7icN4WskDwz/KdAw5ARbJLMhZBrO1NqThmy/McA==}
@@ -1665,14 +1645,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv-draft-04@1.0.0:
-    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
-    peerDependencies:
-      ajv: ^8.5.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -2462,8 +2434,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  incur@0.3.1:
-    resolution: {integrity: sha512-Qbx+LI55wzHSTpSS8XcyzUDiHS2DinM8rSonw/Ri3t3KuPimwbbGUfoyPrIjxciBQxjAaL2Nkv0RKJIVp0b5iA==}
+  incur@0.3.25:
+    resolution: {integrity: sha512-jrSkzauM42ilbQJ6THVkAY6dTulkyVW0sZpVHdA8gfiBwrLrLnLUf8U3bAOegAKBIMSOFgk1idchgu9xm9HMng==}
+    engines: {node: '>=22'}
     hasBin: true
 
   inherits@2.0.4:
@@ -2571,10 +2544,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonpointer@5.0.1:
-    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
-    engines: {node: '>=0.10.0'}
-
   katex@0.16.28:
     resolution: {integrity: sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==}
     hasBin: true
@@ -2591,10 +2560,6 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
-
-  leven@3.1.0:
-    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
-    engines: {node: '>=6'}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -3002,14 +2967,14 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
-  mppx@0.5.7:
-    resolution: {integrity: sha512-jVqnpGt27RYmVqtquvOU/vVQ64j2w/oPqCyM9HAyVhOYOOUXM1uloG/dc7cuiq4LnpaNDyKTxtD9U2v1kjbUfg==}
+  mppx@0.5.12:
+    resolution: {integrity: sha512-pr6epOYJd8Q6D+MRMc27G48IMh0naAGMMyY1cZYrxMXVwH8PPn1ZaqUwv31svcjOV+UpSrSAe/MP2hRWJ0KQ7A==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4'
+      hono: '>=4.12.12'
       viem: '>=2.47.5'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -3093,11 +3058,16 @@ packages:
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
 
-  openapi-types@12.1.3:
-    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
-
   outvariant@1.4.0:
     resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
+
+  ox@0.14.10:
+    resolution: {integrity: sha512-PYsqEnSP7CrcxISS3uVBtw9yPy2gATAnWNptTI0pMnlrXLTiw0Xw/IIivJVHDFgGvKuRAtBSafhVjs+jis3CVA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   ox@0.14.7:
     resolution: {integrity: sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==}
@@ -4052,11 +4022,6 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
 
-  '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
-    dependencies:
-      '@types/json-schema': 7.0.15
-      js-yaml: 4.1.1
-
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -4231,6 +4196,8 @@ snapshots:
     optional: true
 
   '@braintree/sanitize-url@7.1.2': {}
+
+  '@cfworker/json-schema@4.1.1': {}
 
   '@chevrotain/cst-dts-gen@11.0.3':
     dependencies:
@@ -4480,8 +4447,6 @@ snapshots:
     dependencies:
       hono: 4.11.9
 
-  '@humanwhocodes/momoa@2.0.4': {}
-
   '@iconify-json/lucide@1.2.90':
     dependencies:
       '@iconify/types': 2.0.0
@@ -4611,7 +4576,7 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.9)
       ajv: 8.18.0
@@ -4630,8 +4595,16 @@ snapshots:
       raw-body: 3.0.2
       zod: 4.3.6
       zod-to-json-schema: 3.25.1(zod@4.3.6)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0-alpha.2(@cfworker/json-schema@4.1.1)':
+    dependencies:
+      zod: 4.3.6
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
 
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
@@ -4665,34 +4638,6 @@ snapshots:
   '@react-hook/passive-layout-effect@1.2.1(react@19.2.4)':
     dependencies:
       react: 19.2.4
-
-  '@readme/better-ajv-errors@2.4.0(ajv@8.18.0)':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.6
-      '@humanwhocodes/momoa': 2.0.4
-      ajv: 8.18.0
-      jsonpointer: 5.0.1
-      leven: 3.1.0
-      picocolors: 1.1.1
-
-  '@readme/openapi-parser@6.0.0(openapi-types@12.1.3)':
-    dependencies:
-      '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
-      '@readme/better-ajv-errors': 2.4.0(ajv@8.18.0)
-      '@readme/openapi-schemas': 3.1.0
-      '@types/json-schema': 7.0.15
-      ajv: 8.18.0
-      ajv-draft-04: 1.0.0(ajv@8.18.0)
-      openapi-types: 12.1.3
-
-  '@readme/openapi-schemas@3.1.0': {}
-
-  '@remix-run/fetch-proxy@0.7.1':
-    dependencies:
-      '@remix-run/headers': 0.19.0
-
-  '@remix-run/headers@0.19.0': {}
 
   '@remix-run/node-fetch-server@0.13.0': {}
 
@@ -5472,14 +5417,14 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@wagmi/connectors@7.2.1(@wagmi/core@3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(ox@0.14.7(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.6(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))':
+  '@wagmi/connectors@7.2.1(@wagmi/core@3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.6(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
-      '@wagmi/core': 3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(ox@0.14.7(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
+      '@wagmi/core': 3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
       viem: 2.47.6(typescript@5.9.3)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@wagmi/core@3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(ox@0.14.7(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))':
+  '@wagmi/core@3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
@@ -5487,7 +5432,7 @@ snapshots:
       zustand: 5.0.0(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.4.0(react@19.2.4))
     optionalDependencies:
       '@tanstack/query-core': 5.90.20
-      ox: 0.14.7(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.14.10(typescript@5.9.3)(zod@4.3.6)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/react'
@@ -5598,10 +5543,6 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
-
-  ajv-draft-04@1.0.0(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -6482,18 +6423,14 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  incur@0.3.1(openapi-types@12.1.3):
+  incur@0.3.25:
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
-      '@readme/openapi-parser': 6.0.0(openapi-types@12.1.3)
+      '@cfworker/json-schema': 4.1.1
+      '@modelcontextprotocol/server': 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
       '@toon-format/toon': 2.1.0
       tokenx: 1.3.0
       yaml: 2.8.2
       zod: 4.3.6
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - openapi-types
-      - supports-color
 
   inherits@2.0.4: {}
 
@@ -6568,8 +6505,6 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonpointer@5.0.1: {}
-
   katex@0.16.28:
     dependencies:
       commander: 8.3.0
@@ -6587,8 +6522,6 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
-
-  leven@3.1.0: {}
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -7249,22 +7182,17 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.5.7(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.11.9)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6)):
+  mppx@0.5.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.11.9)(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6)):
     dependencies:
-      '@remix-run/fetch-proxy': 0.7.1
-      '@remix-run/node-fetch-server': 0.13.0
-      incur: 0.3.1(openapi-types@12.1.3)
-      ox: 0.14.7(typescript@5.9.3)(zod@4.3.6)
+      incur: 0.3.25
+      ox: 0.14.10(typescript@5.9.3)(zod@4.3.6)
       viem: 2.47.6(typescript@5.9.3)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       express: 5.2.1
       hono: 4.11.9
     transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - openapi-types
-      - supports-color
       - typescript
 
   ms@2.1.3: {}
@@ -7317,9 +7245,22 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openapi-types@12.1.3: {}
-
   outvariant@1.4.0: {}
+
+  ox@0.14.10(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
 
   ox@0.14.7(typescript@5.9.3)(zod@4.3.6):
     dependencies:
@@ -8210,7 +8151,7 @@ snapshots:
       - tsx
       - yaml
 
-  vocs@https://pkg.pr.new/wevm/vocs@2fb25c2(@types/react@19.2.14)(mermaid@11.12.2)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3)))(react@19.2.4)(rollup@4.57.1)(typescript@5.9.3)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vocs@https://pkg.pr.new/wevm/vocs@2fb25c2(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.12.2)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3)))(react@19.2.4)(rollup@4.57.1)(typescript@5.9.3)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.5(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3)))(react@19.2.4)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@base-ui/react': 1.2.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -8222,7 +8163,7 @@ snapshots:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
       '@mdx-js/rollup': 3.1.1(rollup@4.57.1)
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@remix-run/node-fetch-server': 0.13.0
       '@shikijs/rehype': 3.22.0
       '@shikijs/transformers': 3.22.0
@@ -8324,11 +8265,11 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
-  wagmi@3.5.0(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(@types/react@19.2.14)(ox@0.14.7(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6)):
+  wagmi@3.5.0(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(@types/react@19.2.14)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6)):
     dependencies:
       '@tanstack/react-query': 5.90.21(react@19.2.4)
-      '@wagmi/connectors': 7.2.1(@wagmi/core@3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(ox@0.14.7(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.6(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
-      '@wagmi/core': 3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(ox@0.14.7(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
+      '@wagmi/connectors': 7.2.1(@wagmi/core@3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.6(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
+      '@wagmi/core': 3.4.0(@tanstack/query-core@5.90.20)(@types/react@19.2.14)(ox@0.14.10(typescript@5.9.3)(zod@4.3.6))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.4))(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
       react: 19.2.4
       use-sync-external-store: 1.4.0(react@19.2.4)
       viem: 2.47.6(typescript@5.9.3)(zod@4.3.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 
 
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - mppx

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -560,7 +560,8 @@ export function render(
         : undefined
       : undefined;
 
-    const lineStroke = colorOverride ?? (m.isLast ? "url(#grad-success)" : th.line);
+    const lineStroke =
+      colorOverride ?? (m.isLast ? "url(#grad-success)" : th.line);
     // Solid arrows (->>): filled triangle; dashed arrows (-->>): outline triangle
     const arrowFill = colorOverride
       ? m.dashed
@@ -956,7 +957,10 @@ export function lineLen(el: SVGElement): number {
 export function MermaidDiagram({
   chart,
   messageColors,
-}: { chart: string; messageColors?: MessageColors }) {
+}: {
+  chart: string;
+  messageColors?: MessageColors;
+}) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<HTMLDivElement>(null);
   const animRef = useRef<AnimationHandle | null>(null);

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -400,7 +400,13 @@ export function wrapText(
 // SVG renderer
 // ---------------------------------------------------------------------------
 
-export function render(lo: Layout, th: ThemeColors): string {
+export type MessageColors = Record<string, { light: string; dark: string }>;
+
+export function render(
+  lo: Layout,
+  th: ThemeColors,
+  resolvedMessageColors?: Record<string, string>,
+): string {
   const L = LAYOUT;
   const o: string[] = [];
   const sz = L.arrowSize;
@@ -540,16 +546,34 @@ export function render(lo: Layout, th: ThemeColors): string {
     const da = m.dashed ? ' stroke-dasharray="6 4"' : "";
     const goingRight = m.x2 > m.x1;
     const lineEndX = goingRight ? m.x2 - sz : m.x2 + sz;
-    const lineStroke = m.isLast ? "url(#grad-success)" : th.line;
+
+    // Per-message color override: match label against resolvedMessageColors keys
+    const colorOverride = resolvedMessageColors
+      ? Object.keys(resolvedMessageColors).find((k) =>
+          m.label.toLowerCase().includes(k.toLowerCase()),
+        )
+        ? resolvedMessageColors[
+            Object.keys(resolvedMessageColors).find((k) =>
+              m.label.toLowerCase().includes(k.toLowerCase()),
+            )!
+          ]
+        : undefined
+      : undefined;
+
+    const lineStroke = colorOverride ?? (m.isLast ? "url(#grad-success)" : th.line);
     // Solid arrows (->>): filled triangle; dashed arrows (-->>): outline triangle
-    const arrowFill = m.isLast
+    const arrowFill = colorOverride
       ? m.dashed
         ? th.actorFill
-        : th.successArrow
-      : m.dashed
-        ? th.actorFill
-        : th.line;
-    const arrowStroke = m.isLast ? th.successArrow : th.line;
+        : colorOverride
+      : m.isLast
+        ? m.dashed
+          ? th.actorFill
+          : th.successArrow
+        : m.dashed
+          ? th.actorFill
+          : th.line;
+    const arrowStroke = colorOverride ?? (m.isLast ? th.successArrow : th.line);
 
     // Line
     o.push(
@@ -929,7 +953,10 @@ export function lineLen(el: SVGElement): number {
 // React component
 // ---------------------------------------------------------------------------
 
-export function MermaidDiagram({ chart }: { chart: string }) {
+export function MermaidDiagram({
+  chart,
+  messageColors,
+}: { chart: string; messageColors?: MessageColors }) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<HTMLDivElement>(null);
   const animRef = useRef<AnimationHandle | null>(null);
@@ -959,7 +986,13 @@ export function MermaidDiagram({ chart }: { chart: string }) {
       const parsed = parse(chart);
       const lo = doLayout(parsed);
       const th = isDark ? THEMES.dark : THEMES.light;
-      el.innerHTML = render(lo, th);
+      const mode = isDark ? "dark" : "light";
+      const resolved = messageColors
+        ? Object.fromEntries(
+            Object.entries(messageColors).map(([k, v]) => [k, v[mode]]),
+          )
+        : undefined;
+      el.innerHTML = render(lo, th, resolved);
       const svg = el.querySelector("svg");
       if (!svg) return;
       svg.style.maxWidth = "100%";
@@ -974,7 +1007,7 @@ export function MermaidDiagram({ chart }: { chart: string }) {
     } catch (err) {
       console.error("MermaidDiagram:", err);
     }
-  }, [chart, isDark]);
+  }, [chart, isDark, messageColors]);
 
   useEffect(() => {
     const el = svgRef.current;

--- a/src/pages/guides/multiple-payment-methods.mdx
+++ b/src/pages/guides/multiple-payment-methods.mdx
@@ -269,6 +269,41 @@ export const GET =
 
 Each payment method has its own parameters. Refer to the individual method docs for the full configuration reference:
 
+## Client preferences
+
+Clients can declare which payment methods they prefer by passing `paymentPreferences` to `Mppx.create`. This sends an `Accept-Payment` header on every request, and the server uses it to filter Challenges down to the methods the client supports.
+
+```ts twoslash
+import { Mppx, stripe, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+Mppx.create({
+  methods: [
+    tempo({ account }),
+    stripe.charge({
+      createToken: async (opts) => {
+        const res = await fetch('/api/create-spt', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(opts),
+        })
+        const { spt } = await res.json() as { spt: string }
+        return spt
+      },
+    }),
+  ],
+  paymentPreferences: ({ tempo, stripe }) => ({ // [!code hl:start]
+    [tempo.charge]: 1,
+    [stripe.charge]: 0.5,
+    [tempo.session]: 0.2,
+  }), // [!code hl:end]
+})
+```
+
+See the [`paymentPreferences` parameter reference](/sdk/typescript/client/Mppx.create#paymentpreferences-optional) for the full configuration options.
+
 ## Next steps
 
 <Cards>

--- a/src/pages/protocol/transports/index.mdx
+++ b/src/pages/protocol/transports/index.mdx
@@ -1,9 +1,9 @@
 ---
-description: "MPP defines transport bindings for HTTP and MCP. Learn how Challenges, Credentials, and Receipts map to headers and JSON-RPC messages."
-imageDescription: "Payment flows over HTTP and MCP transports"
+description: "MPP defines transport bindings for HTTP, MCP, and WebSocket. Learn how Challenges, Credentials, and Receipts map to headers, JSON-RPC messages, and WebSocket frames."
+imageDescription: "Payment flows over HTTP, MCP, and WebSocket transports"
 ---
 
-# Transports [HTTP and MCP bindings for payment flows]
+# Transports [HTTP, MCP, and WebSocket bindings for payment flows]
 
 MPP defines how the Payment authentication scheme operates over different transport protocols. The core protocol targets HTTP, with extensions for other transports like MCP and JSON-RPC.
 
@@ -13,6 +13,7 @@ MPP defines how the Payment authentication scheme operates over different transp
 |-----------|----------|------|
 | [HTTP](/protocol/transports/http) | REST APIs, web resources | [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-11) |
 | [MCP](/protocol/transports/mcp) | AI tool calls using Model Context Protocol | [MCP Transport Spec](https://paymentauth.org) |
+| [WebSocket](/protocol/transports/websocket) | Bidirectional payment streams | [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455) |
 | JSON-RPC | Non-MCP JSON-RPC services | [JSON-RPC 2.0](https://www.jsonrpc.org/specification) |
 
 ## Transport-agnostic design
@@ -21,5 +22,6 @@ MPP's core concepts—Challenges, Credentials, and Receipts—remain the same ac
 
 - **HTTP** uses standard headers (`WWW-Authenticate`, `Authorization`, `Payment-Receipt`)
 - **MCP** uses JSON-RPC error codes and `_meta` fields
+- **WebSocket** uses JSON message framing with an `mpp` discriminator
 
-Choose the transport that matches your protocol. HTTP for REST APIs, MCP for AI agent tool calls, or JSON-RPC for non-MCP JSON-RPC services.
+Choose the transport that matches your protocol. HTTP for REST APIs, MCP for AI agent tool calls, WebSocket for bidirectional payment streams, or JSON-RPC for non-MCP JSON-RPC services.

--- a/src/pages/protocol/transports/websocket.mdx
+++ b/src/pages/protocol/transports/websocket.mdx
@@ -51,9 +51,6 @@ All messages are JSON objects with an `mpp` field as a discriminator:
     participant C as Client
     participant S as Server
     C->>S: WebSocket connect
-    rect rgba(0,0,0,0.03)
-    Note right of C: solid = payment, dashed = data
-    end
     C->>S: authorization (Credential)
     S->>C: payment-receipt
     S-->>C: message (data)
@@ -64,7 +61,14 @@ All messages are JSON objects with an `mpp` field as a discriminator:
     S-->>C: message (data)
     C->>S: payment-close-request
     S->>C: payment-close-ready (final Receipt)
-`} />
+`} messageColors={{
+  'authorization': { light: '#16a34a', dark: '#4ade80' },
+  'payment-receipt': { light: '#16a34a', dark: '#4ade80' },
+  'payment-close-ready': { light: '#16a34a', dark: '#4ade80' },
+  'payment-need-voucher': { light: '#dc2626', dark: '#f87171' },
+}} />
+
+> **Green** arrows represent payment flow (`authorization`, `payment-receipt`). **Red** arrows indicate a payment is required (`payment-need-voucher`). Black arrows are data messages.
 
 1. The client opens a WebSocket connection (`ws://` or `wss://`)
 2. The client sends an `authorization` message containing the session Credential

--- a/src/pages/protocol/transports/websocket.mdx
+++ b/src/pages/protocol/transports/websocket.mdx
@@ -1,0 +1,88 @@
+---
+description: "The WebSocket transport streams paid data over a persistent connection, with in-band voucher top-ups and JSON message framing."
+imageDescription: "Stream paid data over WebSocket connections"
+---
+
+import { MermaidDiagram } from '../../../components/MermaidDiagram'
+
+# WebSocket transport [Bidirectional payment streams over WebSocket]
+
+The WebSocket transport binds MPP payment flows to a persistent WebSocket connection using JSON message framing. Unlike the HTTP transport, the client and server exchange payment messages in-band—no separate requests needed for voucher top-ups.
+
+## Message protocol
+
+All messages are JSON objects with an `mpp` field as a discriminator:
+
+| Direction | `mpp` value | Payload | Purpose |
+|-----------|-------------|---------|---------|
+| Client → Server | `authorization` | `authorization: string` | Send Credential or top-up voucher |
+| Server → Client | `message` | `data: string` | Application data |
+| Client → Server | `payment-close-request` | — | Request session close |
+| Server → Client | `payment-close-ready` | `data: SessionReceipt` | Acknowledge close with final Receipt |
+| Server → Client | `payment-error` | `status: number, message: string` | Report error |
+| Server → Client | `payment-need-voucher` | `data: NeedVoucherEvent` | Request more funds |
+| Server → Client | `payment-receipt` | `data: SessionReceipt` | Confirm Credential |
+
+### Example messages
+
+```json
+// Client sends Credential
+{ "mpp": "authorization", "authorization": "eyJjaGFsbGVuZ2UiOi..." }
+
+// Server confirms payment
+{ "mpp": "payment-receipt", "data": { "status": "success", ... } }
+
+// Server streams data
+{ "mpp": "message", "data": "chunk of application data" }
+
+// Server requests top-up
+{ "mpp": "payment-need-voucher", "data": { "remaining": "0", ... } }
+
+// Client requests close
+{ "mpp": "payment-close-request" }
+
+// Server acknowledges close
+{ "mpp": "payment-close-ready", "data": { "status": "success", ... } }
+```
+
+## Connection flow
+
+<MermaidDiagram chart={`sequenceDiagram
+    participant C as Client
+    participant S as Server
+    C->>S: WebSocket connect
+    rect rgba(0,0,0,0.03)
+    Note right of C: solid = payment, dashed = data
+    end
+    C->>S: authorization (Credential)
+    S->>C: payment-receipt
+    S-->>C: message (data)
+    S-->>C: message (data)
+    S->>C: payment-need-voucher
+    C->>S: authorization (top-up voucher)
+    S->>C: payment-receipt
+    S-->>C: message (data)
+    C->>S: payment-close-request
+    S->>C: payment-close-ready (final Receipt)
+`} />
+
+1. The client opens a WebSocket connection (`ws://` or `wss://`)
+2. The client sends an `authorization` message containing the session Credential
+3. The server verifies the Credential and responds with a `payment-receipt`
+4. The server streams `message` events with application data
+5. When the channel balance depletes, the server sends `payment-need-voucher`
+6. The client tops up by sending a new `authorization` with a voucher
+7. When the stream ends, the server sends `payment-close-ready` with the final Receipt
+8. The client can also initiate close at any time via `payment-close-request`
+
+## When to use WebSocket vs SSE
+
+| Aspect | WebSocket | Server-Sent Events |
+|--------|-----------|---------------------|
+| Direction | Bidirectional | Server → Client only |
+| Voucher top-ups | In-band `authorization` message | Separate HTTP request |
+| Overhead | Single persistent connection | HTTP connection + side-channel |
+| High-frequency metering | Lower overhead per message | Higher overhead per top-up |
+| Environment support | Broad (browsers, agents, servers) | Limited in some runtimes |
+
+Use the WebSocket transport when you need bidirectional communication—for example, streaming sessions where the client tops up vouchers frequently. Use SSE when the server only needs to push data and top-ups are infrequent.

--- a/src/pages/sdk/typescript/client/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/client/Mppx.create.mdx
@@ -186,6 +186,74 @@ const mppx = Mppx.create({
 })
 ```
 
+### paymentPreferences (optional)
+
+- **Type:** `AcceptPayment.Config<methods>`
+
+Configures which payment methods the client prefers when a server offers multiple options via `Mppx.compose`. Emits an `Accept-Payment` header on requests so the server can filter Challenges to the client's preferred methods.
+
+Accepts a definition map or a callback that receives a typed key tree. Each key is a `method/intent` string (like `'tempo/charge'`). Values are q-values from 0 to 1—higher means more preferred. Set to 0 to explicitly opt out.
+
+```ts twoslash
+import { Mppx, stripe, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+Mppx.create({
+  methods: [
+    tempo({ account }),
+    stripe.charge({
+      createToken: async (opts) => {
+        const res = await fetch('/api/create-spt', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(opts),
+        })
+        const { spt } = await res.json() as { spt: string }
+        return spt
+      },
+    }),
+  ],
+  paymentPreferences: ({ tempo, stripe }) => ({ // [!code focus:start]
+    [tempo.charge]: 1,
+    [stripe.charge]: 0.5,
+    [tempo.session]: 0.2,
+  }), // [!code focus:end]
+})
+```
+
+With a plain definition map:
+
+```ts twoslash
+import { Mppx, stripe, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+Mppx.create({
+  methods: [
+    tempo({ account }),
+    stripe.charge({
+      createToken: async (opts) => {
+        const res = await fetch('/api/create-spt', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(opts),
+        })
+        const { spt } = await res.json() as { spt: string }
+        return spt
+      },
+    }),
+  ],
+  paymentPreferences: { // [!code focus:start]
+    'tempo/charge': 1,
+    'stripe/charge': 0.5,
+    'tempo/session': 0.2,
+  }, // [!code focus:end]
+})
+```
+
 ### transport (optional)
 
 - **Type:** `Transport`

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -150,13 +150,13 @@ On-chain memo for the transaction.
 
 ### store (optional)
 
-- **Type:** `Store.Store`
+- **Type:** `Store.AtomicStore`
 
-Pass a store when you want replay protection for charge Credentials.
+Pass a store when you want replay protection for charge Credentials. A `Store` provides async key-value operations (`get`, `put`, `delete`). An `AtomicStore` extends `Store` with an atomic `update(key, fn)` method for safe concurrent replay checks.
 
 For non-zero charges, `mppx` falls back to an in-memory store when you omit this parameter. For zero-dollar proof auth, replay prevention is disabled unless you pass a store.
 
-Use `Store.memory()` for local development, tests, or a single long-lived server process. For multi-instance deployments, use `Store.redis()`, `Store.upstash()`, or `Store.cloudflare()` so replay markers are shared across processes.
+Use `Store.memory()` for local development, tests, or a single long-lived server process. For multi-instance deployments, use `Store.redis()`, `Store.upstash()`, or `Store.cloudflare()`. All built-in factories return `AtomicStore` — for custom backends, provide an `update` function alongside `get`, `put`, and `delete`.
 
 ### testnet (optional)
 

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -119,10 +119,10 @@ Enable SSE streaming. Pass `true` to enable with defaults, or an options object 
 
 ### store (optional)
 
-- **Type:** `Store.Store`
+- **Type:** `Store.AtomicStore`
 - **Default:** `Store.memory()`
 
-Store backend for persisting channel and session state. `mppx` handles concurrency internally.
+Store backend for persisting channel and session state. A `Store` provides async key-value operations (`get`, `put`, `delete`). An `AtomicStore` extends `Store` with an atomic `update(key, fn)` method for safe concurrent read-modify-write — required for session channel state where multiple instances may process vouchers concurrently.
 
 ```ts twoslash
 import { Store, tempo } from 'mppx/server'
@@ -132,7 +132,7 @@ const method = tempo.session({
 })
 ```
 
-Use `Store.memory()` for local development and tests. For multi-instance deployments, use `Store.redis()`, `Store.upstash()`, or `Store.cloudflare()` so channel state is shared across processes.
+Use `Store.memory()` for local development and tests. For multi-instance deployments, use `Store.redis()`, `Store.upstash()`, or `Store.cloudflare()`. All built-in factories return `AtomicStore` — for custom backends, provide an `update` function alongside `get`, `put`, and `delete`.
 
 ### suggestedDeposit (optional)
 

--- a/src/pages/sdk/typescript/server/Ws.serve.mdx
+++ b/src/pages/sdk/typescript/server/Ws.serve.mdx
@@ -1,167 +1,191 @@
-# `Ws.serve` [WebSocket session transport]
+# `Session.Ws.serve` [WebSocket session payments]
 
-Bridges a WebSocket connection to a Tempo session payment flow. Handles in-band authorization, voucher top-ups, per-unit charging, and cooperative close over a single socket.
-
-The initial `402` challenge is still served over HTTP — the client probes the endpoint, receives the challenge, then upgrades to WebSocket for the rest of the session.
-
-:::info
-
-`Ws.serve` does not perform the HTTP upgrade itself. Use your framework's WebSocket upgrade mechanism (e.g. `ws`, Bun, Deno, Cloudflare) and pass the accepted socket.
-
-:::
+Bridges a WebSocket connection to a Tempo session payment flow. Credential verification is performed by routing each in-band authorization frame through `route` as a synthetic POST request that carries only the Authorization header. The synthetic request does not include cookies, bodies, query parameters, or other headers from the original WebSocket upgrade request.
 
 ## Usage
 
-```ts
+```ts twoslash
 import { Mppx, Store, tempo } from 'mppx/server'
-import { WebSocketServer } from 'ws'
+import { Session } from 'mppx/tempo'
+import { privateKeyToAccount } from 'viem/accounts'
 
-const store = Store.memory()
+const words = ['hello', 'world']
 
 const mppx = Mppx.create({
-  methods: [tempo.session({ account: '0x...', store })],
-  secretKey: 'my-secret',
+  methods: [
+    tempo.session({
+      account: privateKeyToAccount('0x...'),
+    }),
+  ],
 })
 
-const route = mppx.session({
-  amount: '0.000075',
-  unitType: 'token',
-})
+declare const socket: Session.Ws.Socket
 
-const wss = new WebSocketServer({ noServer: true })
-
-wss.on('connection', (socket, req) => {
-  const url = new URL(req.url ?? '/', `ws://${req.headers.host}`)
-
-  tempo.Ws.serve({
-    socket,
-    store,
-    url,
-    route,
-    generate: async function* (stream) {
-      for await (const token of getTokens()) {
-        await stream.charge()
-        yield token
-      }
-    },
-  })
-})
-```
-
-### With HTTP 402 probe
-
-The same `route` handler serves both the initial HTTP `402` challenge and the WebSocket credential verification:
-
-```ts
-import { Mppx, Store, tempo } from 'mppx/server'
-
-const store = Store.memory()
-
-const mppx = Mppx.create({
-  methods: [tempo.session({ account: '0x...', store })],
-  secretKey: 'my-secret',
-})
-
-const route = mppx.session({ amount: '0.001', unitType: 'request' })
-
-export async function handler(request: Request): Promise<Response> {
-  const result = await route(request)
-  if (result.status === 402) return result.challenge
-  return result.withReceipt(new Response('Use the WebSocket endpoint for streaming.'))
-}
-```
-
-### With amount validation
-
-Pin the per-tick price when the route is backed by `Mppx.compose()` with multiple offers. Without this, a client could select the cheapest composed offer for the same stream.
-
-```ts
-import { Store, tempo } from 'mppx/server'
-
-const store = Store.memory()
-
-tempo.Ws.serve({
-  amount: '0.000075',
-  socket,
-  store,
-  url: 'ws://localhost/ws/chat',
-  route,
+// In your WebSocket handler:
+Session.Ws.serve({
   generate: async function* (stream) {
-    yield 'hello'
+    for (const word of words) {
+      await stream.charge()
+      yield word
+    }
   },
+  route: (request) => mppx.session({ amount: '0.001', currency: 'pathUSD', unitType: 'word' })(request),
+  socket,
+  store: Store.memory(),
+  url: 'wss://api.example.com/stream',
 })
 ```
 
-## How it works
+## Return type
 
-1. **Client probes** the HTTP endpoint and receives a `402` challenge
-2. **Client opens** a WebSocket and sends the signed credential as the first frame
-3. **Server verifies** the credential by routing it through the same `route` handler as a synthetic `POST` with only the `Authorization` header
-4. **Server streams** application data, calling `stream.charge()` before each unit
-5. When the voucher is exhausted, the server sends a **`payment-need-voucher`** control frame and pauses until the client sends a higher cumulative voucher
-6. When the stream ends or the client sends a **`payment-close-request`**, the server sends a `payment-close-ready` frame with the final receipt
-7. The client signs a **close credential** and the server settles the channel
+```ts
+type ReturnType = Promise<void>
+```
+
+Resolves when the WebSocket session completes or the connection closes.
 
 ## Parameters
-
-### socket
-
-- **Type:** `Socket`
-
-The WebSocket connection. Accepts any implementation with `send`, `close`, and either `addEventListener`/`removeEventListener` (browser-style) or `on`/`off` (Node-style) methods.
-
-### store
-
-- **Type:** `Store.Store | ChannelStore`
-
-Channel store for persisting session state. Must be the same store instance used by `tempo.session()`.
-
-### url
-
-- **Type:** `string | URL`
-
-The WebSocket URL. Used to construct synthetic requests for credential verification. `ws:` and `wss:` protocols are normalized to `http:` and `https:`.
-
-### route
-
-- **Type:** `(request: Request) => Promise<SessionRouteResult>`
-
-The session route handler from `mppx.session()`. Receives synthetic `POST` requests carrying only the `Authorization` header — no cookies, bodies, or upgrade headers.
-
-### generate
-
-- **Type:** `AsyncIterable<string> | ((stream: SessionController) => AsyncIterable<string>)`
-
-The content generator. When passed a function, it receives a `SessionController` with a `charge()` method that must be called before yielding each billable unit. When passed a bare `AsyncIterable`, charging happens automatically before each yielded value.
 
 ### amount (optional)
 
 - **Type:** `string`
 
-Expected per-tick amount in raw units. When set, credentials whose challenge amount does not match are rejected with a `402` error.
+Expected per-tick amount. When set, Credentials with mismatched amounts are rejected.
+
+### generate
+
+- **Type:** `AsyncIterable<string> | ((stream: SessionController) => AsyncIterable<string>)`
+
+Async iterable that produces application messages. When passed as a function, receives a `SessionController` with a `charge()` method for requesting payment before yielding each value. Each yielded string is sent to the client as an application message frame.
 
 ### pollIntervalMs (optional)
 
 - **Type:** `number`
 - **Default:** `100`
 
-Interval in milliseconds for polling the channel store when waiting for a voucher top-up. Only used when the store does not support `waitForUpdate`.
+Polling interval in milliseconds for voucher balance checks.
 
-## Control frame protocol
+### route
 
-All WebSocket frames are JSON objects with an `mpp` discriminator field. Application data and payment control frames share the same socket but are fully isolated — the managed socket returned by `session.ws()` on the client only surfaces application messages.
+- **Type:** `SessionRoute`
 
-| Frame | Direction | Purpose |
-|---|---|---|
-| `authorization` | Client → Server | Signed credential (open, top-up, or close) |
-| `payment-receipt` | Server → Client | Voucher receipt after successful verification |
-| `payment-need-voucher` | Server → Client | Request a higher cumulative voucher |
-| `payment-close-request` | Client → Server | Request graceful close |
-| `payment-close-ready` | Server → Client | Final receipt before close credential |
-| `payment-error` | Server → Client | Error with status code and message |
-| `message` | Server → Client | Application data (content) |
+Session route handler. Receives synthetic POST requests constructed from in-band authorization frames. The synthetic request carries only the `Authorization` header—no cookies, bodies, query parameters, or other headers from the original WebSocket upgrade request.
 
-## Related
+```ts twoslash
+import { Mppx, tempo } from 'mppx/server'
+import { Session } from 'mppx/tempo'
+import { privateKeyToAccount } from 'viem/accounts'
 
-- [tempo.session (client manager)](/sdk/typescript/client/Method.tempo.session-manager) — client-side `session.ws()` method
-- [tempo.session (server)](/sdk/typescript/server/Method.tempo.session) — server-side session method configuration
+const mppx = Mppx.create({
+  methods: [tempo.session({ account: privateKeyToAccount('0x...') })],
+})
+
+const route: Session.Ws.SessionRoute = (request) =>
+  mppx.session({ amount: '0.001', currency: 'pathUSD', unitType: 'word' })(request)
+```
+
+### socket
+
+- **Type:** `Session.Ws.Socket`
+
+WebSocket instance. Accepts a browser `WebSocket`, a `ws` library socket, or any object implementing `send`/`close` with either `addEventListener`/`removeEventListener` or `on`/`off`.
+
+### store
+
+- **Type:** `Store.Store | ChannelStore`
+
+Channel store for persisting session and channel state.
+
+### url
+
+- **Type:** `string`
+
+URL used for constructing synthetic route requests. `ws://` and `wss://` schemes are normalized to `http://` and `https://`.
+
+## Helper functions
+
+### `Session.Ws.parseMessage`
+
+Parses a raw WebSocket message string into a typed `Message`.
+
+```ts
+const message = Session.Ws.parseMessage(raw)
+```
+
+### `Session.Ws.formatAuthorizationMessage`
+
+Formats an authorization string into a message frame.
+
+```ts
+const frame = Session.Ws.formatAuthorizationMessage(authorization)
+```
+
+### `Session.Ws.formatApplicationMessage`
+
+Formats application data into a message frame.
+
+```ts
+const frame = Session.Ws.formatApplicationMessage(data)
+```
+
+### `Session.Ws.formatCloseRequestMessage`
+
+Formats a close request message frame.
+
+```ts
+const frame = Session.Ws.formatCloseRequestMessage()
+```
+
+### `Session.Ws.formatReceiptMessage`
+
+Formats a Receipt into a message frame.
+
+```ts
+const frame = Session.Ws.formatReceiptMessage(receipt)
+```
+
+### `Session.Ws.formatErrorMessage`
+
+Formats an error into a message frame.
+
+```ts
+const frame = Session.Ws.formatErrorMessage({ message, status })
+```
+
+## Types
+
+### Message
+
+```ts
+type Message =
+  | { mpp: 'authorization'; authorization: string }
+  | { mpp: 'message'; data: string }
+  | { mpp: 'payment-close-request' }
+  | { mpp: 'payment-close-ready'; data: SessionReceipt }
+  | { mpp: 'payment-error'; status: number; message: string }
+  | { mpp: 'payment-need-voucher'; data: NeedVoucherEvent }
+  | { mpp: 'payment-receipt'; data: SessionReceipt }
+```
+
+### Socket
+
+```ts
+type Socket = {
+  close(code?: number, reason?: string): unknown
+  send(data: string): unknown
+  addEventListener?: (type: string, listener: (event: any) => void) => unknown
+  removeEventListener?: (type: string, listener: (event: any) => void) => unknown
+  on?: (type: string, listener: (...args: any[]) => void) => unknown
+  off?: (type: string, listener: (...args: any[]) => void) => unknown
+}
+```
+
+### SessionRoute
+
+```ts
+type SessionRouteResult =
+  | { status: 402; challenge: Response }
+  | { status: 200; withReceipt(response?: Response): Response }
+
+type SessionRoute = (request: Request) => Promise<SessionRouteResult>
+```

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -339,6 +339,7 @@ export default defineConfig({
             items: [
               { text: "HTTP", link: "/protocol/transports/http" },
               { text: "MCP and JSON-RPC", link: "/protocol/transports/mcp" },
+              { text: "WebSocket", link: "/protocol/transports/websocket" },
             ],
           },
         ],


### PR DESCRIPTION
Bumps mppx from 0.5.5 to 0.5.12 and documents all new public API surface.

### New pages

- **WebSocket transport** — Protocol page at `/protocol/transports/websocket` covering the JSON message framing protocol, connection flow diagram, and SSE comparison
- **`Session.Ws.serve`** — SDK reference at `/sdk/typescript/server/Ws.serve` for the server-side WebSocket session handler

### Updated pages

- **`Mppx.create` (client)** — Added `paymentPreferences` parameter for Accept-Payment negotiation with typed callback and definition map examples
- **`Method.tempo.session-manager`** — Added `.ws()` method and usage examples for WebSocket streaming
- **`Method.tempo.session` (server)** — Updated `store` type to `Store.AtomicStore`
- **`Method.tempo.charge` (server)** — Updated `store` type to `Store.AtomicStore`
- **Multiple payment methods guide** — Added "Client preferences" section for Accept-Payment
- **Transports index** — Added WebSocket transport row and description
- **Sidebar** — Added WebSocket transport and Ws.serve entries

### Housekeeping

- Added `.mppx-docs-sync` bookmark file tracking documented SHA
- Added `minimumReleaseAgeExclude: [mppx]` to `pnpm-workspace.yaml`