### PR TITLE
fix: add http language tag to code block on multiple-payment-methods guide

### DIFF
--- a/src/pages/guides/multiple-payment-methods.mdx
+++ b/src/pages/guides/multiple-payment-methods.mdx
@@ -30,7 +30,7 @@ When payment is verified via any method, return a JSON response.`}
 
 When multiple methods are registered, the `402` response includes a `WWW-Authenticate` header for each one. The client picks the method it supports and sends the appropriate Credential.
 
-```
+```http
 HTTP/1.1 402 Payment Required
 WWW-Authenticate: Payment method="tempo", intent="charge", ...
 WWW-Authenticate: Payment method="stripe", intent="charge", ...


### PR DESCRIPTION
The HTTP response code block in the 'How it works' section used a bare fenced block (```) with no language identifier, so Shiki rendered it as plain monochrome text. Added `http` language tag to match the rest of the site.

Prompted by: Brendan