### PR TITLE
feat(services): add AlgoVoi — MPP on Algorand, VOI, Hedera, and Stellar

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6540,8 +6540,11 @@ export const services: ServiceDef[] = [
     url: "https://www.algovoi.co.uk",
     serviceUrl: "https://api1.ilovechicken.co.uk",
     description:
-      "Multi-tenant MPP payment infrastructure for Algorand, VOI, Hedera, and Stellar. " +
-      "AI agents pay with on-chain USDC (no EVM required) to access payment-gated resources. " +
+      "Multi-tenant MPP payment infrastructure spanning both EVM and non-EVM chains: " +
+      "Algorand, VOI, Hedera, Stellar, Base, Solana, and Tempo. " +
+      "AI agents pay with on-chain USDC (SPL on Solana, ERC-20 on Base, TIP-20 on Tempo, " +
+      "ARC-3 on Algorand, etc.) to access payment-gated resources. Solana flow uses " +
+      "Solana Pay `reference` pubkey binding for cryptographic tx-to-order correlation. " +
       "Open-source adapters available for 17+ eCommerce platforms.",
     categories: ["blockchain", "web"],
     integration: "first-party",
@@ -6551,11 +6554,16 @@ export const services: ServiceDef[] = [
       "voi",
       "hedera",
       "stellar",
+      "base",
+      "solana",
+      "tempo",
       "usdc",
       "payments",
       "mpp",
-      "non-evm",
+      "multi-chain",
       "avm",
+      "evm",
+      "svm",
     ],
     docs: {
       homepage:

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -73,6 +73,13 @@ export const STRIPE_PAYMENT: PaymentDefaults = {
   currency: "usd",
   decimals: 2,
 };
+/** Common payment defaults for AlgoVoi (Algorand/VOI on-chain USDC) */
+export const ALGOVOI_PAYMENT: PaymentDefaults = {
+  method: "algovoi",
+  currency: "31566704", // Algorand USDC ASA ID; VOI aUSDC ARC200 ID: 302190
+  decimals: 6,
+};
+
 
 export interface EndpointDef {
   /** Route string: "METHOD /path" (without service slug prefix) */
@@ -6522,6 +6529,54 @@ export const services: ServiceDef[] = [
         desc: "Write and send an agent-penned postcard",
         dynamic: true,
         amountHint: "$1 digital, $3 physical",
+      },
+    ],
+  },
+
+  // ── AlgoVoi ─────────────────────────────────────────────────────────────
+  {
+    id: "algovoi",
+    name: "AlgoVoi",
+    url: "https://www.algovoi.co.uk",
+    serviceUrl: "https://api1.ilovechicken.co.uk",
+    description:
+      "Multi-tenant MPP payment infrastructure for Algorand, VOI, Hedera, and Stellar. " +
+      "AI agents pay with on-chain USDC (no EVM required) to access payment-gated resources. " +
+      "Open-source adapters available for 17+ eCommerce platforms.",
+    categories: ["blockchain", "web"],
+    integration: "first-party",
+    status: "beta",
+    tags: [
+      "algorand",
+      "voi",
+      "hedera",
+      "stellar",
+      "usdc",
+      "payments",
+      "mpp",
+      "non-evm",
+      "avm",
+    ],
+    docs: {
+      homepage:
+        "https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters",
+    },
+    provider: { name: "AlgoVoi", url: "https://www.algovoi.co.uk" },
+    realm: "api1.ilovechicken.co.uk",
+    intent: "charge",
+    payment: ALGOVOI_PAYMENT,
+    endpoints: [
+      {
+        route: "GET /protected/{resource_id}",
+        desc: "Access a payment-gated resource",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "POST /x402/verify",
+        desc: "Verify an on-chain payment proof",
+        dynamic: true,
+        amountHint: "0.01+ USDC",
       },
     ],
   },


### PR DESCRIPTION
## Summary

Adds AlgoVoi to the MPP service directory — the first MPP-native payment infrastructure for non-EVM chains (Algorand, VOI, Hedera, Stellar).

- New `ALGOVOI_PAYMENT` constant (Algorand USDC ASA 31566704, 6 decimals)
- AlgoVoi service entry: `blockchain` + `web` categories, `first-party`, `beta`
- Two endpoints: payment-gated resource access + on-chain payment verification

## What AlgoVoi is

AlgoVoi is a multi-tenant MPP payment infrastructure layer that enables AI agents to pay for services using on-chain USDC — without touching an EVM chain. It's the first complete MPP implementation on Algorand/VOI/Hedera/Stellar.

| Chain | Network | Asset | Ticker |
|-------|---------|-------|--------|
| Algorand | `algorand:mainnet` (CAIP-2) | ASA 31566704 | USDC |
| VOI | `voi:mainnet` | ARC200 302190 | aUSDC |
| Hedera | `hedera:mainnet` | HTS 0.0.456858 | USDC |
| Stellar | `stellar:pubnet` | Circle USDC | USDC |

## Validation

- **MPP adapter:** v2.1.0, 153/153 tests, full IETF `draft-ryan-httpauth-payment` compliance including Table 3 challenge echo
- **4-chain smoke tested:** 13 April 2026, real 0.01 USDC payments, all chains verified on-chain
- **Open-source adapters:** [chopmob-cloud/AlgoVoi-Platform-Adapters](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters) — 17+ eCommerce platform adapters + Python/Go/PHP/Rust native adapters

## CAIP-2 reference

For anyone building MPP on non-EVM chains, we've published a CAIP-2 conventions document:
[caip2-algorand.md](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters/blob/master/caip2-algorand.md)

## Test plan

- [ ] `ALGOVOI_PAYMENT` constant is valid `PaymentDefaults` shape
- [ ] AlgoVoi service entry passes TypeScript compilation
- [ ] Service appears correctly in `mpp.dev/services`
- [ ] Extension URI resolves: `https://api1.ilovechicken.co.uk/ap2/extensions/crypto-algo/v1`
