### PR TITLE
docs: add MPP secret security guidance

### DIFF
--- a/src/pages/advanced/security.mdx
+++ b/src/pages/advanced/security.mdx
@@ -32,6 +32,23 @@ Do not log:
 
 Keep them out of error messages, debugging output, analytics, traces, and support logs. If you need observability, log stable metadata such as request IDs, challenge IDs, status codes, or payment method names instead.
 
+## Handle proxies and caches safely
+
+Treat reverse proxies, CDNs, API gateways, and observability pipelines as part of your threat surface.
+
+- Send `Cache-Control: no-store` with `402` responses so intermediaries do not cache Challenges.
+- Send `Cache-Control: private` on successful responses that include `Payment-Receipt`.
+- Redact `Authorization: Payment` and `Payment-Receipt` headers in proxy logs, trace exporters, and edge analytics.
+- Do not rely on intermediary-specific `402` handling—verify that your deployment forwards `WWW-Authenticate` headers correctly.
+
+## Bind paid requests to the actual request
+
+Use Challenge binding to make sure the paid request matches what your server intended to charge for.
+
+- Include a `digest` parameter for `POST`, `PUT`, and `PATCH` requests so clients cannot change the request body after receiving a Challenge.
+- Verify the expected amount, currency, recipient, and route-level business context when checking a Credential.
+- Do not use `description` as an authorization input. It is display text, not a security control.
+
 ## Rotate with overlap
 
 When you rotate `MPP_SECRET_KEY`, use a staged rollout so in-flight Challenges keep working:
@@ -52,9 +69,23 @@ If `MPP_SECRET_KEY` is exposed:
 4. Review issuance and verification telemetry for suspicious activity.
 5. Replace the key in every environment where it was reused.
 
+## Prevent replay in production
+
+Replay protection must survive concurrency and multi-instance deployments.
+
+- Use a shared atomic store when your server runs on more than one instance.
+- Do not rely on process-local memory for replay protection in distributed deployments.
+- Check that zero-amount proof flows have explicit replay protection before you use them for production identity or access control.
+
 ## Keep local development separate
 
 A local `.env` file is fine for development if it stays local and out of git. Commit only `.env.example` with placeholders, use a separate development key, and never reuse production secrets in staging or local environments.
+
+## Related security topics
+
+- [Protocol overview](/protocol)
+- [HTTP 402](/protocol/http-402)
+- [Tempo charge replay protection](/sdk/typescript/server/Method.tempo.charge)
 
 ## Read the underlying guidance
 

--- a/src/pages/advanced/security.mdx
+++ b/src/pages/advanced/security.mdx
@@ -1,0 +1,63 @@
+---
+description: "Protect MPP server secrets and payment credentials. Keep MPP_SECRET_KEY server-side, never log it, and rotate it safely."
+imageDescription: "Protect MPP server secrets"
+---
+
+# Security [Protect server secrets and payment credentials]
+
+The core Payment HTTP Authentication Scheme already requires TLS and treats payment Credentials and Receipts as sensitive data. This page covers the operational practices around `MPP_SECRET_KEY` and server deployments.
+
+## Treat `MPP_SECRET_KEY` as root-of-trust material
+
+`MPP_SECRET_KEY` binds HMAC-backed Challenge IDs to your server configuration. If an attacker gets the key, they can mint Challenges that appear server-issued for your `realm`.
+
+- Keep it on trusted servers only.
+- Never ship it to browsers, mobile apps, MCP clients, or frontend bundles.
+- Use a different key for each environment.
+- Never commit it to git or bake it into container images.
+
+## Store it in a secrets manager
+
+Use your platform's secret store as the system of record—AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, HashiCorp Vault, or an equivalent service.
+
+Environment variables are a good delivery mechanism at runtime, but they are not a secrets management strategy by themselves. Inject `MPP_SECRET_KEY` into your process from a managed secret store instead of treating `.env` files or deployment manifests as the source of truth.
+
+## Never log secrets or payment credentials
+
+Do not log:
+
+- `MPP_SECRET_KEY`
+- `Authorization: Payment` headers
+- `Payment-Receipt` headers
+
+Keep them out of error messages, debugging output, analytics, traces, and support logs. If you need observability, log stable metadata such as request IDs, challenge IDs, status codes, or payment method names instead.
+
+## Rotate with overlap
+
+When you rotate `MPP_SECRET_KEY`, use a staged rollout so in-flight Challenges keep working:
+
+1. Start issuing new Challenges with the new key.
+2. Continue verifying the previous key during a short overlap window.
+3. Remove the old key after outstanding Challenges have expired.
+
+If your deployment does not support current-and-previous-key verification yet, do a coordinated rollout and wait for the old Challenge TTL window to pass before invalidating the previous key.
+
+## Respond to exposure immediately
+
+If `MPP_SECRET_KEY` is exposed:
+
+1. Rotate it immediately.
+2. Remove the old key after your overlap window ends.
+3. Scrub logs, traces, and crash reports if the secret landed there.
+4. Review issuance and verification telemetry for suspicious activity.
+5. Replace the key in every environment where it was reused.
+
+## Keep local development separate
+
+A local `.env` file is fine for development if it stays local and out of git. Commit only `.env.example` with placeholders, use a separate development key, and never reuse production secrets in staging or local environments.
+
+## Read the underlying guidance
+
+- [Payment HTTP Authentication Scheme](/protocol/http-402)
+- [Frequently asked questions](/faq)
+- [OWASP Secrets Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -62,6 +62,12 @@ MPP requires TLS 1.2+ for all connections. Challenge IDs are cryptographically b
 
 Payments use the same security model as the underlying payment method. For Tempo, that means cryptographic signatures over every transaction. For Stripe, it means Stripe's existing fraud and dispute infrastructure.
 
+For operational guidance on `MPP_SECRET_KEY`, logging, and rotation, see [Security](/advanced/security).
+
+## How do I handle `MPP_SECRET_KEY`?
+
+Treat `MPP_SECRET_KEY` as root-of-trust material for server-side Challenge binding. Store it in a secrets manager, keep it server-side, never log it, rotate it immediately if it is exposed, and use overlapping current-and-previous key verification during rollovers so in-flight Challenges keep working. See [Security](/advanced/security) for the full guidance.
+
 ## What happens if a payment fails?
 
 The service returns an error with details following [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) (Problem Details for HTTP APIs). Your client can retry with a different payment method or surface the error. No money is deducted for failed requests.

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -23,6 +23,10 @@ Paste this into your coding agent to set up a server with `mppx` in one prompt:
 
 <ServerPrompt />
 
+:::warning[Set `MPP_SECRET_KEY` before you start]
+`Mppx.create()` reads `MPP_SECRET_KEY` by default. Store it in your platform secret manager, keep it server-side, and never log it. See [Security](/advanced/security).
+:::
+
 ## Framework mode
 
 Use the framework-specific middleware from `mppx` to integrate payment into your server. Each middleware handles the `402` Challenge/Credential flow and attaches receipts automatically.

--- a/src/pages/sdk/rust/server.mdx
+++ b/src/pages/sdk/rust/server.mdx
@@ -19,7 +19,7 @@ let challenge = mpp.charge("0.10")?;
 let receipt = mpp.verify_credential(&credential).await?;
 ```
 
-`Mpp::create()` auto-detects `realm` from environment variables (`VERCEL_URL`, `FLY_APP_NAME`, `HOSTNAME`, and others) and reads `MPP_SECRET_KEY` for stateless HMAC verification. Pass explicit values with the builder to override:
+`Mpp::create()` auto-detects `realm` from environment variables (`VERCEL_URL`, `FLY_APP_NAME`, `HOSTNAME`, and others) and reads `MPP_SECRET_KEY` for stateless HMAC verification. Treat `MPP_SECRET_KEY` as root-of-trust material: store it in your secret manager, keep it server-side, and rotate it immediately if it is exposed. See [Security](/advanced/security). Pass explicit values with the builder to override:
 
 ```rust
 let mpp = Mpp::create(
@@ -128,7 +128,7 @@ Tempo RPC endpoint URL. Also auto-detects chain ID from the URL.
 
 - **Type:** `&str`
 
-HMAC secret for stateless Challenge ID verification. Reads `MPP_SECRET_KEY` environment variable if omitted.
+HMAC secret for stateless Challenge ID verification. Reads `MPP_SECRET_KEY` if omitted. Keep it server-side, never log it, and rotate it with an overlap window during rollovers. See [Security](/advanced/security).
 
 ## `charge()` parameters
 

--- a/src/pages/sdk/typescript/core/Challenge.from.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.from.mdx
@@ -4,10 +4,14 @@ Creates a challenge from the given parameters.
 
 If `secretKey` option is provided, the challenge ID is computed as HMAC-SHA256 over the challenge parameters (realm|method|intent|request|expires|digest|opaque), cryptographically binding the ID to its contents.
 
+Load `secretKey` from your server environment or secret manager. Do not ship it to clients.
+
 ## Usage
 
 ```ts twoslash
 import { Challenge } from 'mppx'
+
+const secretKey = process.env.MPP_SECRET_KEY!
 
 // With HMAC-bound ID (recommended for servers)
 const challenge = Challenge.from(
@@ -16,7 +20,7 @@ const challenge = Challenge.from(
     method: 'tempo',
     realm: 'mpp.dev',
     request: { amount: '1000000', currency: '0x...', recipient: '0x...' },
-    secretKey: 'my-secret',
+    secretKey,
   },
 )
 ```
@@ -109,4 +113,4 @@ Method-specific request data.
 
 - **Type:** `string`
 
-Secret key for HMAC-bound challenge ID.
+Server secret for HMAC-bound challenge ID. Keep it server-side and load it from your environment or secret manager.

--- a/src/pages/sdk/typescript/core/Challenge.fromMethod.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.fromMethod.mdx
@@ -2,11 +2,15 @@
 
 Creates a validated Challenge from a method definition.
 
+Load `secretKey` from your server environment or secret manager. Do not ship it to clients.
+
 ## Usage
 
 ```ts twoslash
 import { Challenge } from 'mppx'
 import { Methods } from 'mppx/tempo'
+
+const secretKey = process.env.MPP_SECRET_KEY!
 
 const challenge = Challenge.fromMethod(
   Methods.charge,
@@ -18,7 +22,7 @@ const challenge = Challenge.fromMethod(
       decimals: 6,
       recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
     },
-    secretKey: 'my-secret',
+    secretKey,
   },
 )
 ```
@@ -89,4 +93,4 @@ Method-specific request data, validated against the method's schema.
 
 - **Type:** `string`
 
-Secret key for HMAC-bound challenge ID.
+Server secret for HMAC-bound challenge ID. Keep it server-side and load it from your environment or secret manager.

--- a/src/pages/sdk/typescript/core/Challenge.verify.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.verify.mdx
@@ -2,20 +2,24 @@
 
 Verifies that a challenge ID matches the expected HMAC for the given parameters.
 
+Use the same server-managed secret that produced the Challenge ID.
+
 ## Usage
 
 ```ts twoslash
 import { Challenge } from 'mppx'
+
+const secretKey = process.env.MPP_SECRET_KEY!
 
 const challenge = Challenge.from({
   intent: 'charge',
   method: 'tempo',
   realm: 'mpp.dev',
   request: { amount: '1000000', currency: '0x...', recipient: '0x...' },
-  secretKey: 'my-secret',
+  secretKey,
 })
 
-const isValid = Challenge.verify(challenge, { secretKey: 'my-secret' })
+const isValid = Challenge.verify(challenge, { secretKey })
 // => true
 ```
 
@@ -41,4 +45,4 @@ The challenge to verify.
 
 - **Type:** `string`
 
-Secret key for HMAC-bound challenge ID verification.
+Server secret for HMAC-bound challenge ID verification. Keep it server-side and load it from your environment or secret manager.

--- a/src/pages/sdk/typescript/server/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.create.mdx
@@ -75,7 +75,7 @@ const payment = Mppx.create({
 - **Type:** `string`
 - **Default:** Auto-detected from `MPP_SECRET_KEY` environment variable. Throws if neither provided nor set.
 
-Secret key for HMAC-bound challenge IDs. Enables stateless verification—the server verifies that a Challenge was issued by itself without storing state.
+Secret key for HMAC-bound challenge IDs. Enables stateless verification—the server verifies that a Challenge was issued by itself without storing state. Treat it as root-of-trust material: store it in your secret manager, keep it server-side, never log it, and rotate it immediately if it is exposed. See [Security](/advanced/security).
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -351,7 +351,12 @@ export default defineConfig({
           { text: "Discovery", link: "/advanced/discovery" },
           { text: "Identity", link: "/advanced/identity" },
           { text: "Refunds", link: "/advanced/refunds" },
-          { text: "Security", link: "/advanced/security" },
+        ],
+      },
+      {
+        text: "Security",
+        items: [
+          { text: "Security Best Practices", link: "/advanced/security" },
         ],
       },
       {

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -348,9 +348,10 @@ export default defineConfig({
       {
         text: "Advanced Features",
         items: [
-          { text: "Identity", link: "/advanced/identity" },
           { text: "Discovery", link: "/advanced/discovery" },
+          { text: "Identity", link: "/advanced/identity" },
           { text: "Refunds", link: "/advanced/refunds" },
+          { text: "Security", link: "/advanced/security" },
         ],
       },
       {


### PR DESCRIPTION
## Summary
- add a dedicated security page for `MPP_SECRET_KEY` handling and rotation
- link the new guidance from the FAQ, server quickstart, and server-side SDK references
- replace hardcoded secret literals in TypeScript core examples and add the new page to the docs navigation

## Testing
- `pnpm check:types`
- `pnpm build`