### PR TITLE
fix: display prices up to 6 decimal places

### DIFF
--- a/src/components/ServiceDiscovery.tsx
+++ b/src/components/ServiceDiscovery.tsx
@@ -874,7 +874,7 @@ function ServiceDetailModal({
     const v = Number(p.amount) / 10 ** (p.decimals ?? 0);
     if (Number.isNaN(v)) return "—";
     if (v >= 0.01) return `$${v.toFixed(2)}`;
-    let s = v.toFixed(4);
+    let s = v.toFixed(6);
     s = s.replace(/0+$/, "");
     if (s.endsWith(".")) s += "00";
     else {

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -46,7 +46,7 @@ export function formatPrice(ep: Endpoint): string {
   if (Number.isNaN(v)) return "\u2014";
   if (v === 0) return "$0";
   if (v >= 1) return `$${v.toFixed(2)}`;
-  let s = v.toFixed(4);
+  let s = v.toFixed(6);
   s = s.replace(/0+$/, "");
   if (s.endsWith(".")) s += "00";
   else {


### PR DESCRIPTION
Updates `toFixed(4)` → `toFixed(6)` in both `ServicesPage.tsx` and `ServiceDiscovery.tsx` to match Tempo stablecoin precision (USDC.e/USDT use 6 decimals). Trailing zeros are already stripped, so cleaner values like `$0.00005` still display without extra zeros.