### PR TITLE
chore: add grouped dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      npm-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Add dependabot configuration with grouped weekly updates for npm and github-actions ecosystems.

Prompted by: brendan

Co-Authored-By: Brendan Ryan <1572504+brendanjryan@users.noreply.github.com>