### PR TITLE
perf: replace inline Shiki color styles with CSS classes

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -3,11 +3,11 @@
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { injectShikiColors } from "../shiki-style-to-class.js";
 import lockupDarkRaw from "../assets/lockup-dark.svg?raw";
 import lockupLightRaw from "../assets/lockup-light.svg?raw";
 import logoDarkRaw from "../assets/logo-dark.svg?raw";
 import logoLightRaw from "../assets/logo-light.svg?raw";
+import { injectShikiColors } from "../shiki-style-to-class.js";
 
 if (typeof window !== "undefined") {
   window.addEventListener("vite:preloadError", (event) => {
@@ -444,6 +444,9 @@ export default function Layout(
           __html: `(function(){var o=Element.prototype.scrollTo;Element.prototype.scrollTo=function(a){if(a&&typeof a==='object'&&this.matches&&this.matches('[data-v-sidebar-container]')){a=Object.assign({},a,{behavior:'instant'})}return o.apply(this,arguments)};})();`,
         }}
       />
+      {/* Shiki style-to-class: reads data-shiki-css from <pre> elements and
+          injects the rules into a shared <style> tag. See shiki-style-to-class.ts
+          for the full architecture explanation. */}
       <script
         // biome-ignore lint/security/noDangerouslySetInnerHtml: injects Shiki color CSS from data attributes
         dangerouslySetInnerHTML={{ __html: injectShikiColors }}

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -3,6 +3,7 @@
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { injectShikiColors } from "../shiki-style-to-class.js";
 import lockupDarkRaw from "../assets/lockup-dark.svg?raw";
 import lockupLightRaw from "../assets/lockup-light.svg?raw";
 import logoDarkRaw from "../assets/logo-dark.svg?raw";
@@ -442,6 +443,10 @@ export default function Layout(
         dangerouslySetInnerHTML={{
           __html: `(function(){var o=Element.prototype.scrollTo;Element.prototype.scrollTo=function(a){if(a&&typeof a==='object'&&this.matches&&this.matches('[data-v-sidebar-container]')){a=Object.assign({},a,{behavior:'instant'})}return o.apply(this,arguments)};})();`,
         }}
+      />
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: injects Shiki color CSS from data attributes
+        dangerouslySetInnerHTML={{ __html: injectShikiColors }}
       />
       <meta
         name="viewport"

--- a/src/shiki-style-to-class.test.ts
+++ b/src/shiki-style-to-class.test.ts
@@ -49,17 +49,15 @@ describe("shikiStyleToClass", () => {
 
     transformer.root.call({} as any, root as any);
 
-    // Should have injected a <style> element before <pre>
-    expect(root.children.length).toBe(2);
-    expect(root.children[0].tagName).toBe("style");
-    expect(root.children[1].tagName).toBe("pre");
-
-    // Check CSS content
-    const css = root.children[0].children[0].value;
-    expect(css).toContain("color:light-dark(#D73A49, #F47067)");
+    // CSS rules stored on <pre> via data attribute
+    const pre = root.children[0];
+    expect(pre.tagName).toBe("pre");
+    expect(pre.properties["data-shiki-css"]).toContain(
+      "color:light-dark(#D73A49, #F47067)",
+    );
 
     // Check spans no longer have style, but have class
-    const code = root.children[1].children[0];
+    const code = pre.children[0];
     for (const span of code.children) {
       expect(span.properties.style).toBeUndefined();
       expect(span.properties.class).toMatch(/sc\d+/);
@@ -84,10 +82,7 @@ describe("shikiStyleToClass", () => {
 
     transformer.root.call({} as any, root as any);
 
-    const pre = root.children.find(
-      (n: any) => n.type === "element" && n.tagName === "pre",
-    );
-    const span = pre.children[0].children[0];
+    const span = root.children[0].children[0].children[0];
     // Should keep font-style inline
     expect(span.properties.style).toBe("font-style:italic");
     // Should also have a class for the color

--- a/src/shiki-style-to-class.test.ts
+++ b/src/shiki-style-to-class.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { shikiStyleToClass } from "./shiki-style-to-class.js";
 
 // biome-ignore lint/suspicious/noExplicitAny: test helpers
@@ -9,7 +9,9 @@ function makeRoot(spans: { style: string }[]): any {
       {
         type: "element",
         tagName: "pre",
-        properties: { class: "shiki shiki-themes github-light github-dark-dimmed" },
+        properties: {
+          class: "shiki shiki-themes github-light github-dark-dimmed",
+        },
         children: [
           {
             type: "element",
@@ -32,8 +34,10 @@ describe("shikiStyleToClass", () => {
   it("replaces inline color styles with CSS classes", () => {
     const transformer = shikiStyleToClass();
 
-    const style1 = "color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067";
-    const style2 = "color:light-dark(#24292E, #ADBAC7);--shiki-light:#24292E;--shiki-dark:#ADBAC7";
+    const style1 =
+      "color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067";
+    const style2 =
+      "color:light-dark(#24292E, #ADBAC7);--shiki-light:#24292E;--shiki-dark:#ADBAC7";
 
     const root = makeRoot([
       { style: style1 },
@@ -66,7 +70,9 @@ describe("shikiStyleToClass", () => {
     }
 
     // Check deduplication: 2 unique styles -> 2 classes
-    const uniqueClasses = new Set(code.children.map((s: any) => s.properties.class));
+    const uniqueClasses = new Set(
+      code.children.map((s: any) => s.properties.class),
+    );
     expect(uniqueClasses.size).toBe(2);
   });
 
@@ -74,7 +80,10 @@ describe("shikiStyleToClass", () => {
     const transformer = shikiStyleToClass();
 
     const root = makeRoot([
-      { style: "color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067;font-style:italic" },
+      {
+        style:
+          "color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067;font-style:italic",
+      },
     ]);
 
     transformer.root.call({} as any, root as any);
@@ -88,7 +97,12 @@ describe("shikiStyleToClass", () => {
 
   it("does nothing when no <pre> found", () => {
     const transformer = shikiStyleToClass();
-    const root = { type: "root", children: [{ type: "element", tagName: "div", properties: {}, children: [] }] };
+    const root = {
+      type: "root",
+      children: [
+        { type: "element", tagName: "div", properties: {}, children: [] },
+      ],
+    };
     transformer.root.call({} as any, root as any);
     expect(root.children.length).toBe(1);
   });

--- a/src/shiki-style-to-class.test.ts
+++ b/src/shiki-style-to-class.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { shikiStyleToClass } from "./shiki-style-to-class.js";
+
+// biome-ignore lint/suspicious/noExplicitAny: test helpers
+function makeRoot(spans: { style: string }[]): any {
+  return {
+    type: "root",
+    children: [
+      {
+        type: "element",
+        tagName: "pre",
+        properties: { class: "shiki shiki-themes github-light github-dark-dimmed" },
+        children: [
+          {
+            type: "element",
+            tagName: "code",
+            properties: {},
+            children: spans.map((s) => ({
+              type: "element",
+              tagName: "span",
+              properties: { style: s.style },
+              children: [{ type: "text", value: "token" }],
+            })),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("shikiStyleToClass", () => {
+  it("replaces inline color styles with CSS classes", () => {
+    const transformer = shikiStyleToClass();
+
+    const style1 = "color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067";
+    const style2 = "color:light-dark(#24292E, #ADBAC7);--shiki-light:#24292E;--shiki-dark:#ADBAC7";
+
+    const root = makeRoot([
+      { style: style1 },
+      { style: style2 },
+      { style: style1 }, // duplicate
+      { style: style1 }, // duplicate
+      { style: style2 }, // duplicate
+    ]);
+
+    // Call root hook
+    transformer.root.call({} as any, root as any);
+
+    // Should have injected a <style> element before <pre>
+    expect(root.children.length).toBe(2); // <style> + <pre>
+    expect(root.children[0].tagName).toBe("style");
+    expect(root.children[1].tagName).toBe("pre");
+
+    // Check CSS content
+    const css = root.children[0].children[0].value;
+    expect(css).toContain(".s0{");
+    expect(css).toContain(".s1{");
+    expect(css).toContain("color:light-dark(#D73A49, #F47067)");
+    console.log("Generated CSS:", css);
+
+    // Check spans no longer have style, but have class
+    const code = root.children[1].children[0];
+    for (const span of code.children) {
+      expect(span.properties.style).toBeUndefined();
+      expect(span.properties.class).toMatch(/s\d/);
+    }
+
+    // Check deduplication: 2 unique styles -> 2 classes
+    const uniqueClasses = new Set(code.children.map((s: any) => s.properties.class));
+    expect(uniqueClasses.size).toBe(2);
+  });
+
+  it("preserves non-color style properties", () => {
+    const transformer = shikiStyleToClass();
+
+    const root = makeRoot([
+      { style: "color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067;font-style:italic" },
+    ]);
+
+    transformer.root.call({} as any, root as any);
+
+    const span = root.children[1].children[0].children[0];
+    // Should keep font-style inline
+    expect(span.properties.style).toBe("font-style:italic");
+    // Should also have a class for the color
+    expect(span.properties.class).toMatch(/s\d/);
+  });
+
+  it("does nothing when no <pre> found", () => {
+    const transformer = shikiStyleToClass();
+    const root = { type: "root", children: [{ type: "element", tagName: "div", properties: {}, children: [] }] };
+    transformer.root.call({} as any, root as any);
+    expect(root.children.length).toBe(1);
+  });
+});

--- a/src/shiki-style-to-class.test.ts
+++ b/src/shiki-style-to-class.test.ts
@@ -47,26 +47,17 @@ describe("shikiStyleToClass", () => {
       { style: style2 }, // duplicate
     ]);
 
-    // Call root hook
     transformer.root.call({} as any, root as any);
 
-    // Should have injected a <style> element before <pre>
-    expect(root.children.length).toBe(2); // <style> + <pre>
-    expect(root.children[0].tagName).toBe("style");
-    expect(root.children[1].tagName).toBe("pre");
-
-    // Check CSS content
-    const css = root.children[0].children[0].value;
-    expect(css).toContain(".s0{");
-    expect(css).toContain(".s1{");
-    expect(css).toContain("color:light-dark(#D73A49, #F47067)");
-    console.log("Generated CSS:", css);
+    // No per-block <style> injection — CSS is collected globally
+    expect(root.children.length).toBe(1);
+    expect(root.children[0].tagName).toBe("pre");
 
     // Check spans no longer have style, but have class
-    const code = root.children[1].children[0];
+    const code = root.children[0].children[0];
     for (const span of code.children) {
       expect(span.properties.style).toBeUndefined();
-      expect(span.properties.class).toMatch(/s\d/);
+      expect(span.properties.class).toMatch(/sc\d+/);
     }
 
     // Check deduplication: 2 unique styles -> 2 classes
@@ -88,11 +79,11 @@ describe("shikiStyleToClass", () => {
 
     transformer.root.call({} as any, root as any);
 
-    const span = root.children[1].children[0].children[0];
+    const span = root.children[0].children[0].children[0];
     // Should keep font-style inline
     expect(span.properties.style).toBe("font-style:italic");
     // Should also have a class for the color
-    expect(span.properties.class).toMatch(/s\d/);
+    expect(span.properties.class).toMatch(/sc\d+/);
   });
 
   it("does nothing when no <pre> found", () => {

--- a/src/shiki-style-to-class.test.ts
+++ b/src/shiki-style-to-class.test.ts
@@ -49,12 +49,17 @@ describe("shikiStyleToClass", () => {
 
     transformer.root.call({} as any, root as any);
 
-    // No per-block <style> injection — CSS is collected globally
-    expect(root.children.length).toBe(1);
-    expect(root.children[0].tagName).toBe("pre");
+    // Should have injected a <style> element before <pre>
+    expect(root.children.length).toBe(2);
+    expect(root.children[0].tagName).toBe("style");
+    expect(root.children[1].tagName).toBe("pre");
+
+    // Check CSS content
+    const css = root.children[0].children[0].value;
+    expect(css).toContain("color:light-dark(#D73A49, #F47067)");
 
     // Check spans no longer have style, but have class
-    const code = root.children[0].children[0];
+    const code = root.children[1].children[0];
     for (const span of code.children) {
       expect(span.properties.style).toBeUndefined();
       expect(span.properties.class).toMatch(/sc\d+/);
@@ -79,7 +84,10 @@ describe("shikiStyleToClass", () => {
 
     transformer.root.call({} as any, root as any);
 
-    const span = root.children[0].children[0].children[0];
+    const pre = root.children.find(
+      (n: any) => n.type === "element" && n.tagName === "pre",
+    );
+    const span = pre.children[0].children[0];
     // Should keep font-style inline
     expect(span.properties.style).toBe("font-style:italic");
     // Should also have a class for the color

--- a/src/shiki-style-to-class.ts
+++ b/src/shiki-style-to-class.ts
@@ -1,0 +1,137 @@
+const COLOR_PROPS = new Set([
+	"color",
+	"background-color",
+	"--shiki-light",
+	"--shiki-dark",
+	"--shiki-light-bg",
+	"--shiki-dark-bg",
+]);
+
+function splitStyle(style: string): {
+	color: string;
+	rest: string;
+} {
+	const colorParts: string[] = [];
+	const restParts: string[] = [];
+
+	for (const raw of style.split(";")) {
+		const decl = raw.trim();
+		if (!decl) continue;
+		const i = decl.indexOf(":");
+		if (i < 0) continue;
+		const prop = decl.slice(0, i).trim();
+		if (COLOR_PROPS.has(prop)) {
+			colorParts.push(decl);
+		} else {
+			restParts.push(decl);
+		}
+	}
+
+	return {
+		color: colorParts.join(";"),
+		rest: restParts.join(";"),
+	};
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: HAST node types
+type HastNode = any;
+
+function walkSpans(node: HastNode, cb: (span: HastNode) => void) {
+	if (!node.children) return;
+	for (const child of node.children) {
+		if (child.type !== "element") continue;
+		if (child.tagName === "span" && child.properties?.style) {
+			cb(child);
+		}
+		walkSpans(child, cb);
+	}
+}
+
+let scopeCounter = 0;
+
+/**
+ * Shiki transformer that replaces repeated inline color styles with CSS classes.
+ *
+ * Shiki's dual-theme output puts a ~77-char `style` attribute on every token span
+ * (e.g. `color:light-dark(#D73A49,#F47067);--shiki-light:#D73A49;--shiki-dark:#F47067`).
+ * With only ~8 unique color combinations repeated 20K–40K times, this bloats
+ * uncompressed page size by 1.6–3.2 MB — especially in the RSC flight payload.
+ * This transformer deduplicates those styles into scoped CSS classes.
+ */
+export function shikiStyleToClass() {
+	return {
+		name: "mpp:style-to-class",
+		enforce: "post" as const,
+		root(root: HastNode) {
+			const pre = root.children?.find(
+				(n: HastNode) => n.type === "element" && n.tagName === "pre",
+			);
+			if (!pre) return;
+
+			const code = pre.children?.find(
+				(n: HastNode) => n.type === "element" && n.tagName === "code",
+			);
+			if (!code) return;
+
+			const colorToClass = new Map<string, string>();
+			let classIndex = 0;
+			const scopeId = `sc${scopeCounter++}`;
+
+			// Add scope class to <pre>
+			const existing = pre.properties?.class;
+			const classes = Array.isArray(existing)
+				? [...existing]
+				: typeof existing === "string"
+					? existing.split(" ")
+					: [];
+			classes.push(scopeId);
+			pre.properties.class = classes.join(" ");
+
+			// Walk all spans and replace color styles with classes
+			walkSpans(code, (span: HastNode) => {
+				const style =
+					typeof span.properties.style === "string"
+						? span.properties.style
+						: "";
+				if (!style) return;
+
+				const { color, rest } = splitStyle(style);
+				if (!color) return;
+
+				let cls = colorToClass.get(color);
+				if (!cls) {
+					cls = `s${classIndex++}`;
+					colorToClass.set(color, cls);
+				}
+
+				// Replace style with class
+				const spanClasses = span.properties.class
+					? `${span.properties.class} ${cls}`
+					: cls;
+				span.properties.class = spanClasses;
+
+				if (rest) {
+					span.properties.style = rest;
+				} else {
+					delete span.properties.style;
+				}
+			});
+
+			if (colorToClass.size === 0) return;
+
+			// Build CSS rules scoped to this code block
+			const rules = Array.from(colorToClass.entries())
+				.map(([style, cls]) => `.${scopeId} .${cls}{${style}}`)
+				.join("");
+
+			// Inject <style> as sibling before <pre> in the root
+			const preIndex = root.children.indexOf(pre);
+			root.children.splice(preIndex, 0, {
+				type: "element",
+				tagName: "style",
+				properties: { "data-shiki-colors": "" },
+				children: [{ type: "text", value: rules }],
+			});
+		},
+	};
+}

--- a/src/shiki-style-to-class.ts
+++ b/src/shiki-style-to-class.ts
@@ -1,50 +1,50 @@
 const COLOR_PROPS = new Set([
-	"color",
-	"background-color",
-	"--shiki-light",
-	"--shiki-dark",
-	"--shiki-light-bg",
-	"--shiki-dark-bg",
+  "color",
+  "background-color",
+  "--shiki-light",
+  "--shiki-dark",
+  "--shiki-light-bg",
+  "--shiki-dark-bg",
 ]);
 
 function splitStyle(style: string): {
-	color: string;
-	rest: string;
+  color: string;
+  rest: string;
 } {
-	const colorParts: string[] = [];
-	const restParts: string[] = [];
+  const colorParts: string[] = [];
+  const restParts: string[] = [];
 
-	for (const raw of style.split(";")) {
-		const decl = raw.trim();
-		if (!decl) continue;
-		const i = decl.indexOf(":");
-		if (i < 0) continue;
-		const prop = decl.slice(0, i).trim();
-		if (COLOR_PROPS.has(prop)) {
-			colorParts.push(decl);
-		} else {
-			restParts.push(decl);
-		}
-	}
+  for (const raw of style.split(";")) {
+    const decl = raw.trim();
+    if (!decl) continue;
+    const i = decl.indexOf(":");
+    if (i < 0) continue;
+    const prop = decl.slice(0, i).trim();
+    if (COLOR_PROPS.has(prop)) {
+      colorParts.push(decl);
+    } else {
+      restParts.push(decl);
+    }
+  }
 
-	return {
-		color: colorParts.join(";"),
-		rest: restParts.join(";"),
-	};
+  return {
+    color: colorParts.join(";"),
+    rest: restParts.join(";"),
+  };
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: HAST node types
 type HastNode = any;
 
 function walkSpans(node: HastNode, cb: (span: HastNode) => void) {
-	if (!node.children) return;
-	for (const child of node.children) {
-		if (child.type !== "element") continue;
-		if (child.tagName === "span" && child.properties?.style) {
-			cb(child);
-		}
-		walkSpans(child, cb);
-	}
+  if (!node.children) return;
+  for (const child of node.children) {
+    if (child.type !== "element") continue;
+    if (child.tagName === "span" && child.properties?.style) {
+      cb(child);
+    }
+    walkSpans(child, cb);
+  }
 }
 
 let scopeCounter = 0;
@@ -59,79 +59,79 @@ let scopeCounter = 0;
  * This transformer deduplicates those styles into scoped CSS classes.
  */
 export function shikiStyleToClass() {
-	return {
-		name: "mpp:style-to-class",
-		enforce: "post" as const,
-		root(root: HastNode) {
-			const pre = root.children?.find(
-				(n: HastNode) => n.type === "element" && n.tagName === "pre",
-			);
-			if (!pre) return;
+  return {
+    name: "mpp:style-to-class",
+    enforce: "post" as const,
+    root(root: HastNode) {
+      const pre = root.children?.find(
+        (n: HastNode) => n.type === "element" && n.tagName === "pre",
+      );
+      if (!pre) return;
 
-			const code = pre.children?.find(
-				(n: HastNode) => n.type === "element" && n.tagName === "code",
-			);
-			if (!code) return;
+      const code = pre.children?.find(
+        (n: HastNode) => n.type === "element" && n.tagName === "code",
+      );
+      if (!code) return;
 
-			const colorToClass = new Map<string, string>();
-			let classIndex = 0;
-			const scopeId = `sc${scopeCounter++}`;
+      const colorToClass = new Map<string, string>();
+      let classIndex = 0;
+      const scopeId = `sc${scopeCounter++}`;
 
-			// Add scope class to <pre>
-			const existing = pre.properties?.class;
-			const classes = Array.isArray(existing)
-				? [...existing]
-				: typeof existing === "string"
-					? existing.split(" ")
-					: [];
-			classes.push(scopeId);
-			pre.properties.class = classes.join(" ");
+      // Add scope class to <pre>
+      const existing = pre.properties?.class;
+      const classes = Array.isArray(existing)
+        ? [...existing]
+        : typeof existing === "string"
+          ? existing.split(" ")
+          : [];
+      classes.push(scopeId);
+      pre.properties.class = classes.join(" ");
 
-			// Walk all spans and replace color styles with classes
-			walkSpans(code, (span: HastNode) => {
-				const style =
-					typeof span.properties.style === "string"
-						? span.properties.style
-						: "";
-				if (!style) return;
+      // Walk all spans and replace color styles with classes
+      walkSpans(code, (span: HastNode) => {
+        const style =
+          typeof span.properties.style === "string"
+            ? span.properties.style
+            : "";
+        if (!style) return;
 
-				const { color, rest } = splitStyle(style);
-				if (!color) return;
+        const { color, rest } = splitStyle(style);
+        if (!color) return;
 
-				let cls = colorToClass.get(color);
-				if (!cls) {
-					cls = `s${classIndex++}`;
-					colorToClass.set(color, cls);
-				}
+        let cls = colorToClass.get(color);
+        if (!cls) {
+          cls = `s${classIndex++}`;
+          colorToClass.set(color, cls);
+        }
 
-				// Replace style with class
-				const spanClasses = span.properties.class
-					? `${span.properties.class} ${cls}`
-					: cls;
-				span.properties.class = spanClasses;
+        // Replace style with class
+        const spanClasses = span.properties.class
+          ? `${span.properties.class} ${cls}`
+          : cls;
+        span.properties.class = spanClasses;
 
-				if (rest) {
-					span.properties.style = rest;
-				} else {
-					delete span.properties.style;
-				}
-			});
+        if (rest) {
+          span.properties.style = rest;
+        } else {
+          delete span.properties.style;
+        }
+      });
 
-			if (colorToClass.size === 0) return;
+      if (colorToClass.size === 0) return;
 
-			// Build CSS rules scoped to this code block
-			const rules = Array.from(colorToClass.entries())
-				.map(([style, cls]) => `.${scopeId} .${cls}{${style}}`)
-				.join("");
+      // Build CSS rules scoped to this code block
+      const rules = Array.from(colorToClass.entries())
+        .map(([style, cls]) => `.${scopeId} .${cls}{${style}}`)
+        .join("");
 
-			// Inject <style> as sibling before <pre> in the root
-			const preIndex = root.children.indexOf(pre);
-			root.children.splice(preIndex, 0, {
-				type: "element",
-				tagName: "style",
-				properties: { "data-shiki-colors": "" },
-				children: [{ type: "text", value: rules }],
-			});
-		},
-	};
+      // Inject <style> as sibling before <pre> in the root
+      const preIndex = root.children.indexOf(pre);
+      root.children.splice(preIndex, 0, {
+        type: "element",
+        tagName: "style",
+        properties: { "data-shiki-colors": "" },
+        children: [{ type: "text", value: rules }],
+      });
+    },
+  };
 }

--- a/src/shiki-style-to-class.ts
+++ b/src/shiki-style-to-class.ts
@@ -64,9 +64,10 @@ let classIndex = 0;
  * With only ~8 unique color combinations repeated 20K–40K times, this bloats
  * uncompressed page size by 1.6–3.2 MB — especially in the RSC flight payload.
  *
- * This transformer deduplicates those styles into global CSS classes. Class names
- * are shared across all code blocks, and CSS rules are only emitted once per
- * unique color combination (in whichever block first encounters it).
+ * This transformer deduplicates those styles into global CSS classes. New CSS
+ * rules are stored on the `<pre>` element via a `data-shiki-css` attribute,
+ * then injected into a shared `<style>` tag at runtime by
+ * {@link injectShikiColors}.
  */
 export function shikiStyleToClass() {
   return {
@@ -116,17 +117,37 @@ export function shikiStyleToClass() {
 
       if (newRules.length === 0) return;
 
-      const rules = newRules
-        .map(([style, cls]) => `.${cls}{${style}}`)
-        .join("");
+      const css = newRules.map(([style, cls]) => `.${cls}{${style}}`).join("");
 
-      const preIndex = root.children.indexOf(pre);
-      root.children.splice(preIndex, 0, {
-        type: "element",
-        tagName: "style",
-        properties: { "data-shiki-colors": "" },
-        children: [{ type: "text", value: rules }],
-      });
+      // Store CSS on the <pre> element as a data attribute.
+      // A <style> HAST element would be stripped by the MDX/RSC pipeline,
+      // but data attributes survive through React rendering.
+      const existing = pre.properties["data-shiki-css"];
+      pre.properties["data-shiki-css"] = existing ? `${existing}${css}` : css;
     },
   };
 }
+
+/**
+ * Inline script that reads `data-shiki-css` attributes from `<pre>` elements
+ * and injects the rules into a shared `<style>` tag. Call this once in the
+ * page layout. It handles both initial load and client-side navigation via
+ * MutationObserver.
+ */
+export const injectShikiColors = `
+(function(){
+  var s=document.createElement('style');
+  s.dataset.shikiColors='';
+  document.head.appendChild(s);
+  var seen=new Set();
+  function flush(){
+    document.querySelectorAll('pre[data-shiki-css]').forEach(function(pre){
+      var css=pre.getAttribute('data-shiki-css');
+      if(css&&!seen.has(css)){seen.add(css);s.textContent+=css}
+      pre.removeAttribute('data-shiki-css');
+    });
+  }
+  flush();
+  new MutationObserver(flush).observe(document.body,{childList:true,subtree:true});
+})();
+`;

--- a/src/shiki-style-to-class.ts
+++ b/src/shiki-style-to-class.ts
@@ -1,3 +1,42 @@
+/**
+ * Shiki Style-to-Class Transformer
+ *
+ * Problem:
+ * Shiki's dual-theme output puts a ~77-char inline `style` attribute on every
+ * token <span>. There are only ~8 unique color combinations, but they repeat
+ * 20K–40K times per page. This bloats uncompressed page size by 1.6–3.2 MB,
+ * especially in the RSC flight payload where every span is serialized twice.
+ *
+ * Solution:
+ * A two-phase approach:
+ *
+ * 1. BUILD TIME (Shiki transformer — `shikiStyleToClass`):
+ *    Runs during MDX compilation. Walks every token <span>, extracts color
+ *    styles into a global Map, replaces `style` with `class`, and stores
+ *    the CSS rules as a `data-shiki-css` attribute on the <pre> element.
+ *    Data attributes survive RSC serialization (raw <style> HAST elements
+ *    get stripped by the MDX/RSC pipeline).
+ *
+ * 2. RUNTIME (inline script — `injectShikiColors`):
+ *    A tiny self-executing script injected via `_layout.tsx`. Creates a single
+ *    shared <style> tag, reads `data-shiki-css` from every <pre>, appends the
+ *    rules, and removes the attribute. A MutationObserver handles code blocks
+ *    that appear after client-side navigation.
+ *
+ * Why not simpler approaches?
+ * - Vite `transformIndexHtml`: Vocs uses RSC/Waku — no traditional index.html
+ *   to transform. The hook never fires for rendered pages.
+ * - HAST <style> sibling: MDX component overrides in Vocs don't map <style>
+ *   elements, so they get stripped during React rendering.
+ * - Per-block scoped styles: Works but creates N <style> tags. The global map
+ *   approach deduplicates across all blocks — only the first block to encounter
+ *   a new color combination emits its CSS rule.
+ *
+ * @see https://github.com/shikijs/shiki/issues/671#issuecomment-3605208867
+ */
+
+// CSS properties that represent token colors in Shiki's dual-theme output.
+// These get extracted into classes; everything else stays inline.
 const COLOR_PROPS = new Set([
   "color",
   "background-color",
@@ -7,6 +46,15 @@ const COLOR_PROPS = new Set([
   "--shiki-dark-bg",
 ]);
 
+/**
+ * Splits a CSS style string into color-related declarations (to be classified)
+ * and non-color declarations (to remain inline on the element).
+ *
+ * Example:
+ *   "color:#D73A49;--shiki-dark:#F47067;font-style:italic"
+ *   → color: "color:#D73A49;--shiki-dark:#F47067"
+ *   → rest:  "font-style:italic"
+ */
 function splitStyle(style: string): {
   color: string;
   rest: string;
@@ -33,9 +81,10 @@ function splitStyle(style: string): {
   };
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: HAST node types
+// biome-ignore lint/suspicious/noExplicitAny: HAST node types are untyped
 type HastNode = any;
 
+/** Recursively walk all <span> elements with a style attribute. */
 function walkSpans(node: HastNode, cb: (span: HastNode) => void) {
   if (!node.children) return;
   for (const child of node.children) {
@@ -48,26 +97,28 @@ function walkSpans(node: HastNode, cb: (span: HastNode) => void) {
 }
 
 /**
- * Global color→class registry shared across all code blocks.
- * Since the same Shiki themes produce the same color strings site-wide,
- * a single global map deduplicates them into one set of class names.
- * Only the first code block that encounters a new color emits a CSS rule.
+ * Global color→class registry, shared across ALL code blocks at build time.
+ *
+ * The same Shiki themes produce the same ~8 color strings site-wide, so a
+ * global map means each unique style only generates one CSS class and one
+ * CSS rule. Subsequent blocks that use the same color reuse the existing
+ * class without emitting duplicate rules.
  */
 const colorToClass = new Map<string, string>();
 let classIndex = 0;
 
 /**
- * Shiki transformer that replaces repeated inline color styles with CSS classes.
+ * Shiki transformer (build time).
  *
- * Shiki's dual-theme output puts a ~77-char `style` attribute on every token span
- * (e.g. `color:light-dark(#D73A49,#F47067);--shiki-light:#D73A49;--shiki-dark:#F47067`).
- * With only ~8 unique color combinations repeated 20K–40K times, this bloats
- * uncompressed page size by 1.6–3.2 MB — especially in the RSC flight payload.
+ * Registered in `vocs.config.ts` via `codeHighlight.transformers`. Runs after
+ * all other transformers (`enforce: "post"`) so it sees the final HAST output.
  *
- * This transformer deduplicates those styles into global CSS classes. New CSS
- * rules are stored on the `<pre>` element via a `data-shiki-css` attribute,
- * then injected into a shared `<style>` tag at runtime by
- * {@link injectShikiColors}.
+ * For each code block:
+ * 1. Find the <pre> → <code> structure
+ * 2. Walk every <span> with an inline style
+ * 3. Split the style into color vs. non-color parts
+ * 4. Replace color styles with a class name (from the global map)
+ * 5. Store any *new* CSS rules as `data-shiki-css` on the <pre>
  */
 export function shikiStyleToClass() {
   return {
@@ -84,6 +135,7 @@ export function shikiStyleToClass() {
       );
       if (!code) return;
 
+      // Collect CSS rules for colors we haven't seen before
       const newRules: [string, string][] = [];
 
       walkSpans(code, (span: HastNode) => {
@@ -96,6 +148,7 @@ export function shikiStyleToClass() {
         const { color, rest } = splitStyle(style);
         if (!color) return;
 
+        // Reuse existing class or create a new one
         let cls = colorToClass.get(color);
         if (!cls) {
           cls = `sc${classIndex++}`;
@@ -103,11 +156,13 @@ export function shikiStyleToClass() {
           newRules.push([color, cls]);
         }
 
+        // Replace inline style with class reference
         const spanClasses = span.properties.class
           ? `${span.properties.class} ${cls}`
           : cls;
         span.properties.class = spanClasses;
 
+        // Keep non-color styles (e.g. font-style:italic) inline
         if (rest) {
           span.properties.style = rest;
         } else {
@@ -115,13 +170,17 @@ export function shikiStyleToClass() {
         }
       });
 
+      // No new colors in this block — nothing to emit
       if (newRules.length === 0) return;
 
       const css = newRules.map(([style, cls]) => `.${cls}{${style}}`).join("");
 
-      // Store CSS on the <pre> element as a data attribute.
-      // A <style> HAST element would be stripped by the MDX/RSC pipeline,
-      // but data attributes survive through React rendering.
+      // Attach CSS rules to the <pre> as a data attribute.
+      //
+      // We can't inject a <style> HAST element here because Vocs's MDX pipeline
+      // maps <pre>, <code>, <span>, <div>, etc. to React components but has no
+      // mapping for <style> — so it gets silently dropped during RSC rendering.
+      // Data attributes on <pre> survive because CodeBlock spreads all props.
       const existing = pre.properties["data-shiki-css"];
       pre.properties["data-shiki-css"] = existing ? `${existing}${css}` : css;
     },
@@ -129,10 +188,18 @@ export function shikiStyleToClass() {
 }
 
 /**
- * Inline script that reads `data-shiki-css` attributes from `<pre>` elements
- * and injects the rules into a shared `<style>` tag. Call this once in the
- * page layout. It handles both initial load and client-side navigation via
- * MutationObserver.
+ * Client-side script that activates the CSS classes (runtime).
+ *
+ * Injected via `_layout.tsx` using dangerouslySetInnerHTML. This runs once
+ * per page load and:
+ *
+ * 1. Creates a single shared <style data-shiki-colors> in <head>
+ * 2. Finds all <pre data-shiki-css="..."> elements
+ * 3. Appends their CSS rules to the shared <style> (deduplicating by content)
+ * 4. Removes the data-shiki-css attribute (cleanup)
+ * 5. Sets up a MutationObserver to handle code blocks added during
+ *    client-side navigation (Vocs uses RSC streaming, so new <pre>
+ *    elements can appear after the initial render)
  */
 export const injectShikiColors = `
 (function(){

--- a/src/shiki-style-to-class.ts
+++ b/src/shiki-style-to-class.ts
@@ -1,3 +1,5 @@
+import type { Plugin } from "vite";
+
 const COLOR_PROPS = new Set([
   "color",
   "background-color",
@@ -47,7 +49,13 @@ function walkSpans(node: HastNode, cb: (span: HastNode) => void) {
   }
 }
 
-let scopeCounter = 0;
+/**
+ * Global color→class registry shared across all code blocks.
+ * Since the same Shiki themes produce the same color strings site-wide,
+ * a single global map deduplicates them into one stylesheet.
+ */
+const colorToClass = new Map<string, string>();
+let classIndex = 0;
 
 /**
  * Shiki transformer that replaces repeated inline color styles with CSS classes.
@@ -56,7 +64,10 @@ let scopeCounter = 0;
  * (e.g. `color:light-dark(#D73A49,#F47067);--shiki-light:#D73A49;--shiki-dark:#F47067`).
  * With only ~8 unique color combinations repeated 20K–40K times, this bloats
  * uncompressed page size by 1.6–3.2 MB — especially in the RSC flight payload.
- * This transformer deduplicates those styles into scoped CSS classes.
+ *
+ * This transformer deduplicates those styles into global CSS classes, and
+ * {@link shikiColorsPlugin} injects the collected rules as a single `<style>`
+ * in the HTML `<head>`.
  */
 export function shikiStyleToClass() {
   return {
@@ -73,21 +84,6 @@ export function shikiStyleToClass() {
       );
       if (!code) return;
 
-      const colorToClass = new Map<string, string>();
-      let classIndex = 0;
-      const scopeId = `sc${scopeCounter++}`;
-
-      // Add scope class to <pre>
-      const existing = pre.properties?.class;
-      const classes = Array.isArray(existing)
-        ? [...existing]
-        : typeof existing === "string"
-          ? existing.split(" ")
-          : [];
-      classes.push(scopeId);
-      pre.properties.class = classes.join(" ");
-
-      // Walk all spans and replace color styles with classes
       walkSpans(code, (span: HastNode) => {
         const style =
           typeof span.properties.style === "string"
@@ -100,11 +96,10 @@ export function shikiStyleToClass() {
 
         let cls = colorToClass.get(color);
         if (!cls) {
-          cls = `s${classIndex++}`;
+          cls = `sc${classIndex++}`;
           colorToClass.set(color, cls);
         }
 
-        // Replace style with class
         const spanClasses = span.properties.class
           ? `${span.properties.class} ${cls}`
           : cls;
@@ -116,22 +111,31 @@ export function shikiStyleToClass() {
           delete span.properties.style;
         }
       });
+    },
+  };
+}
 
-      if (colorToClass.size === 0) return;
-
-      // Build CSS rules scoped to this code block
+/**
+ * Vite plugin that injects a single global `<style>` with all collected
+ * Shiki color classes into the HTML `<head>`.
+ */
+export function shikiColorsPlugin(): Plugin {
+  return {
+    name: "shiki-colors",
+    enforce: "post",
+    transformIndexHtml() {
+      if (colorToClass.size === 0) return [];
       const rules = Array.from(colorToClass.entries())
-        .map(([style, cls]) => `.${scopeId} .${cls}{${style}}`)
+        .map(([style, cls]) => `.${cls}{${style}}`)
         .join("");
-
-      // Inject <style> as sibling before <pre> in the root
-      const preIndex = root.children.indexOf(pre);
-      root.children.splice(preIndex, 0, {
-        type: "element",
-        tagName: "style",
-        properties: { "data-shiki-colors": "" },
-        children: [{ type: "text", value: rules }],
-      });
+      return [
+        {
+          tag: "style",
+          attrs: { "data-shiki-colors": "" },
+          children: rules,
+          injectTo: "head",
+        },
+      ];
     },
   };
 }

--- a/src/shiki-style-to-class.ts
+++ b/src/shiki-style-to-class.ts
@@ -1,5 +1,3 @@
-import type { Plugin } from "vite";
-
 const COLOR_PROPS = new Set([
   "color",
   "background-color",
@@ -52,7 +50,8 @@ function walkSpans(node: HastNode, cb: (span: HastNode) => void) {
 /**
  * Global color→class registry shared across all code blocks.
  * Since the same Shiki themes produce the same color strings site-wide,
- * a single global map deduplicates them into one stylesheet.
+ * a single global map deduplicates them into one set of class names.
+ * Only the first code block that encounters a new color emits a CSS rule.
  */
 const colorToClass = new Map<string, string>();
 let classIndex = 0;
@@ -65,9 +64,9 @@ let classIndex = 0;
  * With only ~8 unique color combinations repeated 20K–40K times, this bloats
  * uncompressed page size by 1.6–3.2 MB — especially in the RSC flight payload.
  *
- * This transformer deduplicates those styles into global CSS classes, and
- * {@link shikiColorsPlugin} injects the collected rules as a single `<style>`
- * in the HTML `<head>`.
+ * This transformer deduplicates those styles into global CSS classes. Class names
+ * are shared across all code blocks, and CSS rules are only emitted once per
+ * unique color combination (in whichever block first encounters it).
  */
 export function shikiStyleToClass() {
   return {
@@ -84,6 +83,8 @@ export function shikiStyleToClass() {
       );
       if (!code) return;
 
+      const newRules: [string, string][] = [];
+
       walkSpans(code, (span: HastNode) => {
         const style =
           typeof span.properties.style === "string"
@@ -98,6 +99,7 @@ export function shikiStyleToClass() {
         if (!cls) {
           cls = `sc${classIndex++}`;
           colorToClass.set(color, cls);
+          newRules.push([color, cls]);
         }
 
         const spanClasses = span.properties.class
@@ -111,31 +113,20 @@ export function shikiStyleToClass() {
           delete span.properties.style;
         }
       });
-    },
-  };
-}
 
-/**
- * Vite plugin that injects a single global `<style>` with all collected
- * Shiki color classes into the HTML `<head>`.
- */
-export function shikiColorsPlugin(): Plugin {
-  return {
-    name: "shiki-colors",
-    enforce: "post",
-    transformIndexHtml() {
-      if (colorToClass.size === 0) return [];
-      const rules = Array.from(colorToClass.entries())
+      if (newRules.length === 0) return;
+
+      const rules = newRules
         .map(([style, cls]) => `.${cls}{${style}}`)
         .join("");
-      return [
-        {
-          tag: "style",
-          attrs: { "data-shiki-colors": "" },
-          children: rules,
-          injectTo: "head",
-        },
-      ];
+
+      const preIndex = root.children.indexOf(pre);
+      root.children.splice(preIndex, 0, {
+        type: "element",
+        tagName: "style",
+        properties: { "data-shiki-colors": "" },
+        children: [{ type: "text", value: rules }],
+      });
     },
   };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { defineConfig, loadEnv } from "vite";
 import mkcert from "vite-plugin-mkcert";
 import { configDefaults } from "vitest/config";
 import { vocs } from "vocs/vite";
+import { shikiColorsPlugin } from "./src/shiki-style-to-class.js";
 
 const commitSha = child_process
   .execSync("git rev-parse --short HEAD")
@@ -83,6 +84,7 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       preloadFonts(),
+      shikiColorsPlugin(),
       stubRehypeMermaid(),
       Icons({ compiler: "jsx", jsx: "react" }),
       react(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,6 @@ import { defineConfig, loadEnv } from "vite";
 import mkcert from "vite-plugin-mkcert";
 import { configDefaults } from "vitest/config";
 import { vocs } from "vocs/vite";
-import { shikiColorsPlugin } from "./src/shiki-style-to-class.js";
 
 const commitSha = child_process
   .execSync("git rev-parse --short HEAD")
@@ -84,7 +83,6 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       preloadFonts(),
-      shikiColorsPlugin(),
       stubRehypeMermaid(),
       Icons({ compiler: "jsx", jsx: "react" }),
       react(),

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -846,6 +846,8 @@ export default defineConfig({
   ],
   title: "MPP — Machine Payments Protocol",
   titleTemplate: "%s | MPP",
+  // Replaces repeated inline Shiki color styles with CSS classes, reducing
+  // uncompressed page size by ~1.5 MB. See src/shiki-style-to-class.ts.
   codeHighlight: {
     transformers: [shikiStyleToClass()],
   },

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, McpSource } from "vocs/config";
+import { shikiStyleToClass } from "./src/shiki-style-to-class.js";
 
 const baseUrl = (() => {
   if (process.env.VERCEL_ENV === "production")
@@ -845,6 +846,9 @@ export default defineConfig({
   ],
   title: "MPP — Machine Payments Protocol",
   titleTemplate: "%s | MPP",
+  codeHighlight: {
+    transformers: [shikiStyleToClass()],
+  },
   twoslash: {
     twoslashOptions: {
       compilerOptions: {


### PR DESCRIPTION
## Problem

Shiki's dual-theme output puts a ~77-char inline `style` attribute on every token `<span>`:

```
color:light-dark(#D73A49, #F47067);--shiki-light:#D73A49;--shiki-dark:#F47067
```

There are only **~8 unique color combinations** across all tokens, but they're repeated **20K–40K times per page**, then duplicated in the RSC flight payload. This makes uncompressed page sizes 3–5 MB.

| Page | Uncompressed Size |
|------|------------------|
| `/quickstart/client` | 3.0 MB |
| `/sdk/.../Mppx.create` | 5.4 MB |
| `/payment-methods/tempo/charge` | 2.8 MB |
| `/payment-methods/stripe/charge` | 2.4 MB |

## Solution

A two-phase approach following the [recommendation from the Shiki maintainer](https://github.com/shikijs/shiki/issues/671#issuecomment-3605208867):

### Phase 1: Build time (Shiki transformer)

`shikiStyleToClass()` runs during MDX compilation as a Shiki transformer (`enforce: "post"`). It:

1. Walks every `<span>` inside `<code>`, extracts color-related inline styles
2. Deduplicates them into global CSS classes (`sc0`, `sc1`, ...) via a shared `Map`
3. Stores new CSS rules as a `data-shiki-css` attribute on the `<pre>` element
4. Preserves non-color styles (e.g. `font-style: italic`) inline

### Phase 2: Runtime (inline script)

`injectShikiColors` is a tiny self-executing script injected via `_layout.tsx`. It:

1. Creates a single shared `<style data-shiki-colors>` in `<head>`
2. Reads `data-shiki-css` from every `<pre>` and appends the CSS rules
3. Uses a `MutationObserver` to handle code blocks added during client-side navigation

### Why this architecture?

Vocs uses RSC/Waku, which means:
- **`transformIndexHtml`** never fires — there's no traditional `index.html`
- **HAST `<style>` elements** get stripped — Vocs's MDX component overrides don't map `<style>`
- **`data-` attributes on `<pre>`** survive because `CodeBlock` spreads all props through React

## Results

| Page | Before | After | Reduction |
|------|--------|-------|-----------|
| `/quickstart/client` | 3.0 MB | **1.6 MB** | **-48%** |
| `/sdk/.../Mppx.create` | 5.4 MB | **3.0 MB** | **-44%** |

Zero inline Shiki color styles remain on spans — all replaced by class references. The global map means each unique color combination only emits one CSS rule site-wide.

## Files

- `src/shiki-style-to-class.ts` — transformer + runtime script (well-commented)
- `src/shiki-style-to-class.test.ts` — unit tests (3 passing)
- `src/pages/_layout.tsx` — injects the runtime script
- `vocs.config.ts` — registers the transformer via `codeHighlight.transformers`