### PR TITLE
fix: patch vocs to use `transformWithOxc` instead of deprecated `transformWithEsbuild`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,10 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ]
+    ],
+    "patchedDependencies": {
+      "vocs@0.0.0": "patches/vocs@0.0.0.patch"
+    }
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm check"

--- a/patches/vocs@0.0.0.patch
+++ b/patches/vocs@0.0.0.patch
@@ -1,0 +1,29 @@
+diff --git a/dist/waku/internal/patches/vite-plugins/fs-router-typegen.js b/dist/waku/internal/patches/vite-plugins/fs-router-typegen.js
+index a7b7d3960968f311765cbd2d5c4eb22e1dfa2a44..100d2078687b30987758e899f4b1b0b33be18f70 100644
+--- a/dist/waku/internal/patches/vite-plugins/fs-router-typegen.js
++++ b/dist/waku/internal/patches/vite-plugins/fs-router-typegen.js
+@@ -1,6 +1,6 @@
+ import { existsSync, readFileSync } from 'node:fs';
+ import { readdir, writeFile } from 'node:fs/promises';
+-import { parseAstAsync, transformWithEsbuild } from 'vite';
++import { parseAstAsync, transformWithOxc } from 'vite';
+ import { EXTENSIONS, SRC_PAGES, SRC_SERVER_ENTRY } from '../constants.js';
+ import { getGrouplessPath } from '../utils/create-pages.js';
+ import { isIgnoredPath } from '../utils/fs-router.js';
+@@ -50,13 +50,13 @@ export function getImportModuleNames(filePaths) {
+ }
+ const parseModule = async (filePath) => {
+     const source = readFileSync(filePath, 'utf8');
+-    const loader = filePath.endsWith('.tsx')
++    const lang = filePath.endsWith('.tsx')
+         ? 'tsx'
+         : filePath.endsWith('.ts')
+             ? 'ts'
+             : 'jsx';
+-    const transformed = await transformWithEsbuild(source, filePath, {
+-        loader,
++    const transformed = await transformWithOxc(source, filePath, {
++        lang,
+         jsx: 'preserve',
+     });
+     return parseAstAsync(transformed.code, { jsx: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  vocs@0.0.0:
+    hash: 5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323
+    path: patches/vocs@0.0.0.patch
+
 importers:
 
   .:
@@ -43,7 +48,7 @@ importers:
         version: 2.47.10(typescript@6.0.2)(zod@4.3.6)
       vocs:
         specifier: https://pkg.pr.new/wevm/vocs@2fb25c2
-        version: https://pkg.pr.new/wevm/vocs@2fb25c2(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: https://pkg.pr.new/wevm/vocs@2fb25c2(patch_hash=5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323)(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       wagmi:
         specifier: ^3.6.1
         version: 3.6.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(@types/react@19.2.14)(ox@0.14.10(typescript@6.0.2)(zod@4.3.6))(react@19.2.4)(typescript@6.0.2)(viem@2.47.10(typescript@6.0.2)(zod@4.3.6))
@@ -3575,7 +3580,6 @@ packages:
   react-server-dom-webpack@19.2.4:
     resolution: {integrity: sha512-zEhkWv6RhXDctC2N7yEUHg3751nvFg81ydHj8LTTZuukF/IF1gcOKqqAL6Ds+kS5HtDVACYPik0IvzkgYXPhlQ==}
     engines: {node: '>=0.10.0'}
-    deprecated: High Security Vulnerability in React Server Components
     peerDependencies:
       react: ^19.2.4
       react-dom: ^19.2.4
@@ -8759,7 +8763,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@https://pkg.pr.new/wevm/vocs@2fb25c2(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vocs@https://pkg.pr.new/wevm/vocs@2fb25c2(patch_hash=5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323)(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@base-ui/react': 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
Vite 8 deprecated `transformWithEsbuild` in favor of `transformWithOxc`. The deprecation warning was coming from vocs's bundled waku `fs-router-typegen.js` plugin. This adds a pnpm patch on vocs to migrate the call.

Can be removed once vocs ships a build with the fix upstream.