### PR TITLE
docs: update mppx to 0.5.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@stripe/stripe-js": "^9.1.0",
     "@vercel/blob": "^2.3.3",
     "mermaid": "^11.14.0",
-    "mppx": "0.5.12",
+    "mppx": "0.5.13",
     "react": "^19",
     "react-dom": "^19",
     "stripe": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^11.14.0
         version: 11.14.0
       mppx:
-        specifier: 0.5.12
-        version: 0.5.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.12)(typescript@6.0.2)(viem@2.47.10(typescript@6.0.2)(zod@4.3.6))
+        specifier: 0.5.13
+        version: 0.5.13(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.12)(typescript@6.0.2)(viem@2.47.10(typescript@6.0.2)(zod@4.3.6))
       react:
         specifier: ^19
         version: 19.2.4
@@ -3335,8 +3335,8 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  mppx@0.5.12:
-    resolution: {integrity: sha512-pr6epOYJd8Q6D+MRMc27G48IMh0naAGMMyY1cZYrxMXVwH8PPn1ZaqUwv31svcjOV+UpSrSAe/MP2hRWJ0KQ7A==}
+  mppx@0.5.13:
+    resolution: {integrity: sha512-HZnsrL2HGJb6Utxhq8tNzw53yQKZqFGVJH5qxepd11icRe4RmoU/HCaOz1t9sq9BI05F8NJeXPBZYb2w3V2FzQ==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
@@ -7784,7 +7784,7 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.5.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.12)(typescript@6.0.2)(viem@2.47.10(typescript@6.0.2)(zod@4.3.6)):
+  mppx@0.5.13(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.12)(typescript@6.0.2)(viem@2.47.10(typescript@6.0.2)(zod@4.3.6)):
     dependencies:
       incur: 0.3.25
       ox: 0.14.10(typescript@6.0.2)(zod@4.3.6)

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -71,6 +71,29 @@ export async function handler(request: Request) {
 }
 ```
 
+### With a custom fee-payer policy
+
+Override the default fee-sponsor limits when you co-sign charges locally.
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.charge({
+      account,
+      feePayer: true,
+      feePayerPolicy: {
+        maxPriorityFeePerGas: 50_000_000_000n,
+      },
+    }),
+  ],
+})
+```
+
 ### With replay protection for zero-dollar auth
 
 Pass `store` when you want zero-dollar proof Credentials to be single-use.
@@ -135,6 +158,16 @@ External identifier for the payment.
 Account or URL for sponsoring transaction fees. Pass a viem `Account` to co-sign locally, a URL string to delegate to a remote [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer), or `true` when the `account` parameter doubles as the fee payer.
 
 This setting only applies to non-zero charges. Zero-amount proof flows do not create a transaction.
+
+### feePayerPolicy (optional)
+
+- **Type:** `{ maxGas?: bigint; maxFeePerGas?: bigint; maxPriorityFeePerGas?: bigint; maxTotalFee?: bigint; maxValidityWindowSeconds?: number }`
+
+Override the fee-sponsor policy when you co-sign charge transactions locally.
+
+Defaults resolve per chain. In `mppx@0.5.13`, Moderato (`42431`) uses a higher default `maxPriorityFeePerGas` ceiling than Tempo mainnet so sponsored charges keep working when testnet tips spike.
+
+If you raise `maxGas` or `maxFeePerGas`, also review `maxTotalFee` so the combined fee budget still fits your policy.
 
 ### getClient (optional)
 


### PR DESCRIPTION
## Summary
- bump `mppx` from `0.5.12` to `0.5.13`
- document the new `feePayerPolicy` server option for `tempo.charge()`
- note the chain-aware default policy behavior for Moderato (`42431`)

## Context
- follows the `mppx` release and docs work for the chain-aware fee-payer policy added in wevm/mppx#342

## Verification
- `pnpm check:ci`
- `pnpm check:types`
- `pnpm build`