### PR TITLE
feat: add Rungate to service registry

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -5847,11 +5847,11 @@ export const services: ServiceDef[] = [
     url: "https://api.rungate.ai",
     serviceUrl: "https://api.rungate.ai",
     description:
-      "OpenAI-compatible LLM inference API. Supports streaming via Tempo Sessions.",
+      "OpenAI-compatible LLM inference API.",
 
     categories: ["ai"],
     integration: "first-party",
-    tags: ["llm", "chat", "inference", "openai-compatible", "streaming", "aggregator"],
+    tags: ["llm", "chat", "inference", "openai-compatible", "streaming"],
     docs: { homepage: "https://rungate.xyz" },
     provider: { name: "Rungate", url: "https://rungate.xyz" },
     realm: "api.rungate.ai",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -5840,6 +5840,39 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Rungate ──────────────────────────────────────────────────────────
+  {
+    id: "rungate",
+    name: "Rungate",
+    url: "https://api.rungate.ai",
+    serviceUrl: "https://api.rungate.ai",
+    description:
+      "OpenAI-compatible LLM inference API. Supports streaming via Tempo Sessions.",
+
+    categories: ["ai"],
+    integration: "first-party",
+    tags: ["llm", "chat", "inference", "openai-compatible", "streaming", "aggregator"],
+    docs: { homepage: "https://rungate.xyz" },
+    provider: { name: "Rungate", url: "https://rungate.xyz" },
+    realm: "api.rungate.ai",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /v1/models",
+        desc: "List available models (free)",
+        docs: false,
+      },
+      {
+        route: "POST /v1/chat/completions",
+        desc: "Chat completions (streaming and non-streaming) — price varies by model and token usage",
+        dynamic: true,
+        amountHint: "Model-dependent",
+        intent: "session",
+      },
+    ],
+  },
+
   // ── ScreenshotOne ────────────────────────────────────────────────────
   {
     id: "screenshotone",


### PR DESCRIPTION
## Summary

- Adds [Rungate](https://www.rungate.ai/docs/access/mpp) as a first-party MPP service in the catalog
- OpenAI-compatible LLM inference API
- `GET /v1/models` is free; `POST /v1/chat/completions` uses dynamic Tempo pricing — one-shot charge for non-streaming, Tempo Session for streaming

## Test plan

- [ ] Verify Rungate appears in the services catalog UI at `/services`
- [ ] Confirm `POST /v1/chat/completions` shows as dynamic/session-priced
- [ ] Confirm `GET /v1/models` shows as free (no price badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)