### PR TITLE
docs: add agent wallet tools (Privy, AgentCash, mppx)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   vocs@0.0.0:
-    hash: b6201463391530d93d9b2d62ffecdaf01da7b2bfddc2dfe38607dfa40d257bc9
+    hash: 5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323
     path: patches/vocs@0.0.0.patch
 
 importers:
@@ -48,7 +48,7 @@ importers:
         version: 2.47.10(typescript@6.0.2)(zod@4.3.6)
       vocs:
         specifier: https://pkg.pr.new/wevm/vocs@2fb25c2
-        version: https://pkg.pr.new/wevm/vocs@2fb25c2(patch_hash=b6201463391530d93d9b2d62ffecdaf01da7b2bfddc2dfe38607dfa40d257bc9)(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: https://pkg.pr.new/wevm/vocs@2fb25c2(patch_hash=5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323)(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       wagmi:
         specifier: ^3.6.1
         version: 3.6.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(@types/react@19.2.14)(ox@0.14.10(typescript@6.0.2)(zod@4.3.6))(react@19.2.4)(typescript@6.0.2)(viem@2.47.10(typescript@6.0.2)(zod@4.3.6))
@@ -8763,7 +8763,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@https://pkg.pr.new/wevm/vocs@2fb25c2(patch_hash=b6201463391530d93d9b2d62ffecdaf01da7b2bfddc2dfe38607dfa40d257bc9)(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vocs@https://pkg.pr.new/wevm/vocs@2fb25c2(patch_hash=5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323)(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@base-ui/react': 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   vocs@0.0.0:
-    hash: 5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323
+    hash: b6201463391530d93d9b2d62ffecdaf01da7b2bfddc2dfe38607dfa40d257bc9
     path: patches/vocs@0.0.0.patch
 
 importers:
@@ -48,7 +48,7 @@ importers:
         version: 2.47.10(typescript@6.0.2)(zod@4.3.6)
       vocs:
         specifier: https://pkg.pr.new/wevm/vocs@2fb25c2
-        version: https://pkg.pr.new/wevm/vocs@2fb25c2(patch_hash=5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323)(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: https://pkg.pr.new/wevm/vocs@2fb25c2(patch_hash=b6201463391530d93d9b2d62ffecdaf01da7b2bfddc2dfe38607dfa40d257bc9)(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       wagmi:
         specifier: ^3.6.1
         version: 3.6.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(@types/react@19.2.14)(ox@0.14.10(typescript@6.0.2)(zod@4.3.6))(react@19.2.4)(typescript@6.0.2)(viem@2.47.10(typescript@6.0.2)(zod@4.3.6))
@@ -8763,7 +8763,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@https://pkg.pr.new/wevm/vocs@2fb25c2(patch_hash=5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323)(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vocs@https://pkg.pr.new/wevm/vocs@2fb25c2(patch_hash=b6201463391530d93d9b2d62ffecdaf01da7b2bfddc2dfe38607dfa40d257bc9)(@cfworker/json-schema@4.1.1)(@types/react@19.2.14)(mermaid@11.14.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.6(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react-server-dom-webpack@19.2.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@base-ui/react': 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/src/pages/quickstart/agent.mdx
+++ b/src/pages/quickstart/agent.mdx
@@ -9,6 +9,13 @@ import { Badge, Card, Cards, Tab, Tabs } from 'vocs'
 
 Agents can automatically interact with MPP-enabled services, paying for API calls without human intervention. Learn more about [agentic payments](/use-cases/agentic-payments) or get started below.
 
+| Tool | Best for | Setup |
+|------|----------|-------|
+| [Tempo Wallet](#tempo-wallet) | MPP services with spend controls and service discovery | `tempo wallet login` |
+| [Privy Agent CLI](#privy-agent-cli) | Multi-chain agent wallets with browser-based funding | `privy-agent-wallets login` |
+| [AgentCash](#agentcash) | Instant access to 300+ premium APIs via MPP | `npx agentcash onboard` |
+| [`mppx` CLI](#mppx) | Lightweight MPP client for development and debugging | `mppx account create` |
+
 ## Tempo Wallet <Badge variant="info" data-toc-exclude>Recommended</Badge>
 
 The [Tempo Wallet](https://wallet.tempo.xyz) is a managed MPP client with built in spend controls and service discovery. Agents can use `tempo wallet` to pay for powerful new capabilities on demand.
@@ -97,6 +104,104 @@ mppx https://mpp.dev/api/ping/paid
 
 ::::
 
+## Privy Agent CLI
+
+[Privy Agent CLI](https://docs.privy.io/recipes/agent-integrations/agent-cli) gives agents a CLI-first way to create, fund, and manage wallets with no integration code. It pairs with the [Agent Sandbox](https://agents.privy.io/) where users track agent spending, manage funds, and revoke access.
+
+The agent never holds the wallet private key—each CLI session generates a P-256 keypair used to sign authorization payloads.
+
+<Tabs>
+<Tab title="Agent">
+
+Paste this into your agent to set up Privy Agent CLI:
+
+```
+Set up https://agents.privy.io/skill.md
+```
+
+</Tab>
+<Tab title="Human">
+::::steps
+
+#### Install
+
+```bash
+npm install -g @privy-io/agent-wallet-cli
+```
+
+#### Log in
+
+```bash
+privy-agent-wallets login
+```
+
+This opens a browser flow—complete Privy auth, approve signer access, then paste the credential back into the terminal.
+
+#### Fund wallets
+
+```bash
+privy-agent-wallets fund
+```
+
+#### List wallets
+
+```bash
+privy-agent-wallets list-wallets
+```
+
+#### Send a transaction
+
+```bash
+privy-agent-wallets rpc --json '{"method": "eth_sendTransaction", "params": {"to": "0xRecipient", "value": "0.01"}}'
+```
+
+::::
+</Tab>
+</Tabs>
+
+Privy supports Ethereum (`personal_sign`, `eth_sendTransaction`, `eth_signTypedData_v4`, EIP-7702, ERC-4337) and Solana (`signTransaction`, `signAndSendTransaction`, `signMessage`). Sessions expire after seven days—revoke early from [agents.privy.io/manage](https://agents.privy.io/manage).
+
+## AgentCash
+
+[AgentCash](https://agentcash.dev/docs/introduction) gives agents instant access to 300+ premium APIs—enrichment, social data, image generation, web scraping, email—paid per-request with USDC micropayments via MPP. No API keys or subscriptions.
+
+<Tabs>
+<Tab title="Agent">
+
+Paste this into your agent to set up AgentCash:
+
+```
+Set up agentcash.dev/skill.md
+```
+
+</Tab>
+<Tab title="Human">
+::::steps
+
+#### Onboard and get free credits
+
+Visit [agentcash.dev/onboard](https://agentcash.dev/onboard) to claim a sign-up bonus, then redeem in your terminal:
+
+```bash
+npx agentcash onboard <CODE>
+```
+
+#### Discover available services
+
+```bash
+npx agentcash discover
+```
+
+#### Install as MCP server (optional)
+
+```bash
+claude mcp add agentcash --scope user -- npx -y agentcash@latest
+```
+
+::::
+</Tab>
+</Tabs>
+
 ## Next steps
 
 <Cards>
@@ -105,5 +210,11 @@ mppx https://mpp.dev/api/ping/paid
     icon="lucide:list"
     title="Services"
     to="/services"
+  />
+  <Card
+    description="Agent wallets, funding, and spend controls"
+    icon="lucide:wallet"
+    title="Wallets"
+    to="/tools/wallet"
   />
 </Cards>

--- a/src/pages/quickstart/agent.mdx
+++ b/src/pages/quickstart/agent.mdx
@@ -14,17 +14,16 @@ Agents can automatically interact with MPP-enabled services, paying for API call
 | [Tempo Wallet](#tempo-wallet) | MPP services with spend controls and service discovery | `tempo wallet login` |
 | [Privy Agent CLI](#privy-agent-cli) | Multi-chain agent wallets with browser-based funding | `privy-agent-wallets login` |
 | [AgentCash](#agentcash) | Instant access to 300+ premium APIs via MPP | `npx agentcash onboard` |
-| [`mppx` CLI](#mppx) | Lightweight MPP client for development and debugging | `mppx account create` |
+| [`mppx` CLI](#mppx) | Development and debugging | `mppx account create` |
 
 ## Tempo Wallet <Badge variant="info" data-toc-exclude>Recommended</Badge>
 
-The [Tempo Wallet](https://wallet.tempo.xyz) is a managed MPP client with built in spend controls and service discovery. Agents can use `tempo wallet` to pay for powerful new capabilities on demand.
+The [Tempo Wallet](https://wallet.tempo.xyz) is a managed MPP client with built in spend controls and service discovery. Agents can use `tempo wallet` to discovery and pay for MPP-enabled services on demand.
 
 <Tabs>
 <Tab title="Agent">
 
 Paste this into your agent to set up Tempo Wallet:
-
 
 ```
 Read https://tempo.xyz/SKILL.md and set up tempo
@@ -69,40 +68,6 @@ tempo request -X POST \
 ::::
 </Tab>
 </Tabs>
-
-## mppx
-
-The [`mppx`](/sdk/typescript/cli) CLI is a lightweight MPP client bundled with the `mppx` package. It is designed for simple use cases and debugging during development.
-
-::::steps
-
-### Install
-
-:::code-group
-```bash [npm]
-npm install -g mppx
-```
-```bash [pnpm]
-pnpm add -g mppx
-```
-```bash [bun]
-bun add -g mppx
-```
-:::
-
-### Create an account
-
-```bash
-mppx account create
-```
-
-### Make a paid request
-
-```bash
-mppx https://mpp.dev/api/ping/paid
-```
-
-::::
 
 ## Privy Agent CLI
 
@@ -199,6 +164,41 @@ claude mcp add agentcash --scope user -- npx -y agentcash@latest
 ::::
 </Tab>
 </Tabs>
+
+## mppx
+
+The [`mppx`](/sdk/typescript/cli) CLI is a lightweight MPP client bundled with the `mppx` package. It is designed for simple use cases and debugging during development.
+
+::::steps
+
+### Install
+
+:::code-group
+```bash [npm]
+npm install -g mppx
+```
+```bash [pnpm]
+pnpm add -g mppx
+```
+```bash [bun]
+bun add -g mppx
+```
+:::
+
+### Create an account
+
+```bash
+mppx account create
+```
+
+### Make a paid request
+
+```bash
+mppx https://mpp.dev/api/ping/paid
+```
+
+::::
+
 
 ## Next steps
 

--- a/src/pages/quickstart/agent.mdx
+++ b/src/pages/quickstart/agent.mdx
@@ -13,7 +13,7 @@ Agents can automatically interact with MPP-enabled services, paying for API call
 |------|----------|-------|
 | [Tempo Wallet](#tempo-wallet) | MPP services with spend controls and service discovery | `tempo wallet login` |
 | [Privy Agent CLI](#privy-agent-cli) | Multi-chain agent wallets with browser-based funding | `privy-agent-wallets login` |
-| [AgentCash](#agentcash) | Instant access to 300+ premium APIs via MPP | `npx agentcash onboard` |
+| [AgentCash](#agentcash) | Discover and use 300+ premium APIs via MPP | `npx agentcash onboard` |
 | [`mppx` CLI](#mppx) | Development and debugging | `mppx account create` |
 
 ## Tempo Wallet <Badge variant="info" data-toc-exclude>Recommended</Badge>
@@ -126,7 +126,7 @@ privy-agent-wallets rpc --json '{"method": "eth_sendTransaction", "params": {"to
 
 ## AgentCash
 
-[AgentCash](https://agentcash.dev/docs/introduction) gives agents instant access to 300+ premium APIs—enrichment, social data, image generation, web scraping, email—paid per-request with USDC micropayments via MPP. No API keys or subscriptions required. 
+[AgentCash](https://agentcash.dev) gives agents instant access to 300+ premium APIs for data enrichment, social data, image generation, web scraping, email, and much more, all through one USDC balance.
 
 <Tabs>
 <Tab title="Agent">
@@ -149,10 +149,18 @@ Visit [agentcash.dev/onboard](https://agentcash.dev/onboard) to claim a sign-up 
 npx agentcash onboard <CODE>
 ```
 
-#### Discover available services
+#### Search for services
 
 ```bash
-npx agentcash discover
+npx agentcash search "image generation"
+```
+
+#### Use a service
+
+```bash
+npx agentcash fetch https://stableenrich.dev/api/exa/search \
+    --method POST \
+    --body '{"query":"agentcash.dev"}'
 ```
 
 #### Install as MCP server (optional)

--- a/src/pages/quickstart/agent.mdx
+++ b/src/pages/quickstart/agent.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Connect your coding agent to MPP-enabled services. Set up Tempo Wallet or the mppx SDK to handle 402 payment flows automatically."
+description: "Connect your coding agent to MPP-enabled services. Set up a wallet to handle payment flows automatically."
 imageDescription: "Connect your agent to paid APIs"
 ---
 
@@ -159,11 +159,9 @@ privy-agent-wallets rpc --json '{"method": "eth_sendTransaction", "params": {"to
 </Tab>
 </Tabs>
 
-Privy supports Ethereum (`personal_sign`, `eth_sendTransaction`, `eth_signTypedData_v4`, EIP-7702, ERC-4337) and Solana (`signTransaction`, `signAndSendTransaction`, `signMessage`). Sessions expire after seven days—revoke early from [agents.privy.io/manage](https://agents.privy.io/manage).
-
 ## AgentCash
 
-[AgentCash](https://agentcash.dev/docs/introduction) gives agents instant access to 300+ premium APIs—enrichment, social data, image generation, web scraping, email—paid per-request with USDC micropayments via MPP. No API keys or subscriptions.
+[AgentCash](https://agentcash.dev/docs/introduction) gives agents instant access to 300+ premium APIs—enrichment, social data, image generation, web scraping, email—paid per-request with USDC micropayments via MPP. No API keys or subscriptions required. 
 
 <Tabs>
 <Tab title="Agent">

--- a/src/pages/tools/wallet.mdx
+++ b/src/pages/tools/wallet.mdx
@@ -1,0 +1,251 @@
+---
+description: "Agent wallets for MPP—compare Tempo Wallet, Privy Agent CLI, and AgentCash for managing funds, signing transactions, and paying for APIs."
+imageDescription: "Give your agent a wallet and a spending limit"
+---
+
+import { Badge, Card, Cards, Tab, Tabs } from 'vocs'
+
+# Wallets [Give your agent a wallet]
+
+Agents need a wallet to pay for MPP-enabled services. Choose the wallet that fits your use case.
+
+| Wallet | Best for | Supported methods | Setup |
+|--------|----------|-------------------|-------|
+| [Tempo Wallet](#tempo-wallet) | MPP services with spend controls and service discovery | `tempo` | `tempo wallet login` |
+| [Privy Agent CLI](#privy-agent-cli) | Multi-chain agent wallets with browser-based funding | `tempo`, `solana` | `privy-agent-wallets login` |
+| [AgentCash](#agentcash) | Instant access to 300+ premium APIs via MPP | `tempo` | `npx agentcash onboard` |
+| [`mppx` CLI](#mppx) | Lightweight MPP client for development and debugging | All | `mppx account create` |
+
+## Tempo Wallet <Badge variant="info" data-toc-exclude>Recommended</Badge>
+
+The [Tempo Wallet](https://wallet.tempo.xyz) is a managed MPP client with built-in spend controls and service discovery. Agents use `tempo wallet` to pay for capabilities on demand.
+
+<Tabs>
+<Tab title="Agent">
+
+Paste this into your agent:
+
+```
+Read https://tempo.xyz/SKILL.md and set up tempo
+```
+
+</Tab>
+<Tab title="Human">
+::::steps
+
+### Install the CLI
+
+```bash
+curl -fsSL https://tempo.xyz/install | bash
+```
+
+### Connect your wallet
+
+```bash
+tempo wallet login
+```
+
+### Verify setup
+
+```bash
+tempo wallet whoami
+```
+
+### List available services
+
+```bash
+tempo wallet services
+```
+
+### Make a paid request
+
+```bash
+tempo request -X POST \
+  --json '{"prompt": "a sunset over the ocean"}' \
+  https://fal.mpp.tempo.xyz/fal-ai/flux/dev
+```
+
+::::
+</Tab>
+</Tabs>
+
+**Supported methods:** <Badge variant="note">tempo.charge</Badge> <Badge variant="note">tempo.session</Badge>
+
+**Key features:**
+
+- **Service discovery**—`tempo wallet services` lists endpoints, pricing, and request schemas
+- **Spend controls**—scoped access keys enforce per-key spending limits
+- **Dry-run previews**—`tempo request --dry-run` validates cost before committing funds
+- **TOON output**—`-t` flag gives compact, machine-readable output for agent tooling
+
+## Privy Agent CLI
+
+[Privy Agent CLI](https://docs.privy.io/recipes/agent-integrations/agent-cli) gives agents a CLI-first way to create, fund, and manage wallets with no integration code. It pairs with the [Agent Sandbox](https://agents.privy.io/) where users track spending, manage funds, and revoke access.
+
+The agent never holds the wallet private key—each session generates a P-256 keypair used to sign authorization payloads.
+
+<Tabs>
+<Tab title="Agent">
+
+Paste this into your agent:
+
+```
+Set up https://agents.privy.io/skill.md
+```
+
+</Tab>
+<Tab title="Human">
+::::steps
+
+### Install
+
+```bash
+npm install -g @privy-io/agent-wallet-cli
+```
+
+### Log in
+
+```bash
+privy-agent-wallets login
+```
+
+This opens a browser flow—complete Privy auth, approve signer access, then paste the credential back into the terminal.
+
+### Fund wallets
+
+```bash
+privy-agent-wallets fund
+```
+
+### List wallets
+
+```bash
+privy-agent-wallets list-wallets
+```
+
+### Send a transaction
+
+```bash
+privy-agent-wallets rpc --json '{"method": "eth_sendTransaction", "params": {"to": "0xRecipient", "value": "0.01"}}'
+```
+
+::::
+</Tab>
+</Tabs>
+
+**Supported methods:** <Badge variant="note">tempo.charge</Badge> <Badge variant="note">tempo.session</Badge> <Badge variant="note">solana.charge</Badge>
+
+**Key features:**
+
+- **No private key exposure**—each session generates a P-256 keypair; the agent signs authorization payloads, never holds the wallet key
+- **Browser-based funding**—the human owner retains a visual dashboard to check balances, view history, and onramp funds
+- **Session management**—sessions stored in the OS credential manager, expire after seven days, revocable from [agents.privy.io/manage](https://agents.privy.io/manage)
+
+## AgentCash
+
+[AgentCash](https://agentcash.dev/docs/introduction) gives agents instant access to 300+ premium APIs—enrichment, social data, image generation, web scraping, email—paid per-request with USDC micropayments via MPP. No API keys or subscriptions.
+
+<Tabs>
+<Tab title="Agent">
+
+Paste this into your agent:
+
+```
+Set up agentcash.dev/skill.md
+```
+
+</Tab>
+<Tab title="Human">
+::::steps
+
+### Onboard and get free credits
+
+Visit [agentcash.dev/onboard](https://agentcash.dev/onboard) to claim a sign-up bonus, then redeem:
+
+```bash
+npx agentcash onboard <CODE>
+```
+
+### Discover available services
+
+```bash
+npx agentcash discover
+```
+
+### Install as MCP server (optional)
+
+```bash
+claude mcp add agentcash --scope user -- npx -y agentcash@latest
+```
+
+::::
+</Tab>
+</Tabs>
+
+**Supported methods:** <Badge variant="note">tempo.charge</Badge>
+
+**Key features:**
+
+- **300+ premium APIs**—enrichment, social data, image generation, web scraping, email, all accessible instantly
+- **No API keys**—pay per request with USDC micropayments, no subscriptions or manual sign-up flows
+- **MPP compatible**—any service that implements MPP is automatically discoverable and usable
+
+## `mppx`
+
+The [`mppx`](/sdk/typescript/cli) CLI is a lightweight MPP client bundled with the `mppx` package. It handles `402` responses automatically using a local keychain account—ideal for development, testing, and debugging.
+
+::::steps
+
+### Install
+
+:::code-group
+```bash [npm]
+npm install -g mppx
+```
+```bash [pnpm]
+pnpm add -g mppx
+```
+```bash [bun]
+bun add -g mppx
+```
+:::
+
+### Create an account
+
+```bash
+mppx account create
+```
+
+### Make a paid request
+
+```bash
+mppx https://mpp.dev/api/ping/paid
+```
+
+::::
+
+**Supported methods:** <Badge variant="note">tempo.charge</Badge> <Badge variant="note">tempo.session</Badge> <Badge variant="note">stripe.charge</Badge> <Badge variant="note">solana.charge</Badge>
+
+**Key features:**
+
+- **Zero config**—create an account and start making paid requests immediately
+- **All payment methods**—supports every payment method implemented in the `mppx` SDK
+- **Local keychain**—private keys stored in the OS keychain, configurable via `MPPX_PRIVATE_KEY` env var
+- **Development-first**—designed for testing and debugging MPP integrations
+
+## Next steps
+
+<Cards>
+  <Card
+    description="Connect your agent to MPP-enabled services"
+    icon="lucide:bot"
+    title="Use with agents"
+    to="/quickstart/agent"
+  />
+  <Card
+    description="Browse available MPP services and their endpoints"
+    icon="lucide:list"
+    title="Services"
+    to="/services"
+  />
+</Cards>

--- a/src/pages/tools/wallet.mdx
+++ b/src/pages/tools/wallet.mdx
@@ -13,7 +13,7 @@ Agents need a wallet to pay for MPP-enabled services. Choose the wallet that fit
 |--------|----------|-------------------|-------|
 | [Tempo Wallet](#tempo-wallet) | Tempo MPP services with spend controls and service discovery | `tempo` | `tempo wallet login` |
 | [Privy Agent CLI](#privy-agent-cli) | Multi-chain agent wallets with browser-based funding | `tempo`, `solana` | `privy-agent-wallets login` |
-| [AgentCash](#agentcash) | Instant access to 300+ premium APIs via MPP | `tempo` | `npx agentcash onboard` |
+| [AgentCash](#agentcash) | Discover and use 300+ premium APIs via MPP | `tempo` | `npx agentcash onboard` |
 | [`mppx` CLI](#mppx) | Development and debugging | All | `mppx account create` |
 
 ## Tempo Wallet 
@@ -143,7 +143,7 @@ privy-agent-wallets rpc --json '{"method": "eth_sendTransaction", "params": {"to
 
 ## AgentCash
 
-[AgentCash](https://agentcash.dev/docs/introduction) gives agents instant access to 300+ premium APIs—enrichment, social data, image generation, web scraping, email—paid per-request with USDC micropayments via MPP. No API keys or subscriptions required.
+[AgentCash](https://agentcash.dev) gives agents instant access to 300+ premium APIs for data enrichment, social data, image generation, web scraping, email, and much more, all through one USDC balance.
 
 <Tabs>
 <Tab title="Agent">
@@ -160,16 +160,24 @@ Set up agentcash.dev/skill.md
 
 ### Onboard and get free credits
 
-Visit [agentcash.dev/onboard](https://agentcash.dev/onboard) to claim a sign-up bonus, then redeem:
+Visit [agentcash.dev/onboard](https://agentcash.dev/onboard) to claim a sign-up bonus, then redeem in your terminal:
 
 ```bash
 npx agentcash onboard <CODE>
 ```
 
-### Discover available services
+### Search for services
 
 ```bash
-npx agentcash discover
+npx agentcash search "image generation"
+```
+
+### Use a service
+
+```bash
+npx agentcash fetch https://stableenrich.dev/api/exa/search \
+    --method POST \
+    --body '{"query":"agentcash.dev"}'
 ```
 
 ### Install as MCP server (optional)
@@ -186,9 +194,10 @@ claude mcp add agentcash --scope user -- npx -y agentcash@latest
 
 **Key features:**
 
-- **300+ premium APIs**—enrichment, social data, image generation, web scraping, email, all accessible instantly
-- **No API keys**—pay per request with USDC micropayments, no subscriptions or manual sign-up flows
-- **MPP compatible**—any service that implements MPP is automatically discoverable and usable
+- **300+ premium APIs** - enrichment, social data, image generation, web scraping, email, all accessible instantly
+- **No human required** - pay per request with USDC, no subscriptions or manual sign-up flows
+- **API and tool discovery** - any service that implements MPP is automatically discoverable and usable
+- **MPPScan integration** — easily discover and use services via [mppscan.com](https://www.mppscan.com/)
 
 ## `mppx`
 

--- a/src/pages/tools/wallet.mdx
+++ b/src/pages/tools/wallet.mdx
@@ -14,11 +14,11 @@ Agents need a wallet to pay for MPP-enabled services. Choose the wallet that fit
 | [Tempo Wallet](#tempo-wallet) | Tempo MPP services with spend controls and service discovery | `tempo` | `tempo wallet login` |
 | [Privy Agent CLI](#privy-agent-cli) | Multi-chain agent wallets with browser-based funding | `tempo`, `solana` | `privy-agent-wallets login` |
 | [AgentCash](#agentcash) | Instant access to 300+ premium APIs via MPP | `tempo` | `npx agentcash onboard` |
-| [`mppx` CLI](#mppx) | Lightweight MPP client for development and debugging | All | `mppx account create` |
+| [`mppx` CLI](#mppx) | Development and debugging | All | `mppx account create` |
 
-## Tempo Wallet <Badge variant="info" data-toc-exclude>Recommended</Badge>
+## Tempo Wallet 
 
-The [Tempo Wallet](https://wallet.tempo.xyz) is a managed MPP client with built-in spend controls and service discovery. Agents use `tempo wallet` to pay for capabilities on demand.
+The [Tempo Wallet](https://wallet.tempo.xyz) is a managed MPP client with built-in spend controls and service discovery. Agents use `tempo wallet` to discovery and pay for MPP-enabled services on demand.
 
 <Tabs>
 <Tab title="Agent">
@@ -69,14 +69,14 @@ tempo request -X POST \
 </Tab>
 </Tabs>
 
-**Supported methods:** <Badge variant="note">tempo.charge</Badge> <Badge variant="note">tempo.session</Badge>
+**Supported methods:** <Badge variant="info">tempo.charge</Badge> <Badge variant="info">tempo.session</Badge>
 
 **Key features:**
 
 - **Service discovery**—`tempo wallet services` lists endpoints, pricing, and request schemas
 - **Spend controls**—scoped access keys enforce per-key spending limits
 - **Dry-run previews**—`tempo request --dry-run` validates cost before committing funds
-- **TOON output**—`-t` flag gives compact, machine-readable output for agent tooling
+- **Efficient output**—`-t` flag gives compact, machine-readable output for agent tooling
 
 ## Privy Agent CLI
 
@@ -133,7 +133,7 @@ privy-agent-wallets rpc --json '{"method": "eth_sendTransaction", "params": {"to
 </Tab>
 </Tabs>
 
-**Supported methods:** <Badge variant="note">tempo.charge</Badge> <Badge variant="note">tempo.session</Badge> <Badge variant="note">solana.charge</Badge>
+**Supported methods:** <Badge variant="info">tempo.charge</Badge> <Badge variant="info">tempo.session</Badge> <Badge variant="info">solana.charge</Badge>
 
 **Key features:**
 
@@ -182,7 +182,7 @@ claude mcp add agentcash --scope user -- npx -y agentcash@latest
 </Tab>
 </Tabs>
 
-**Supported methods:** <Badge variant="note">tempo.charge</Badge>
+**Supported methods:** <Badge variant="info">tempo.charge</Badge>
 
 **Key features:**
 
@@ -224,7 +224,7 @@ mppx https://mpp.dev/api/ping/paid
 
 ::::
 
-**Supported methods:** <Badge variant="note">tempo.charge</Badge> <Badge variant="note">tempo.session</Badge> <Badge variant="note">stripe.charge</Badge> <Badge variant="note">solana.charge</Badge>
+**Supported methods:** <Badge variant="info">tempo.charge</Badge> <Badge variant="info">tempo.session</Badge> <Badge variant="info">stripe.charge</Badge> <Badge variant="info">solana.charge</Badge>
 
 **Key features:**
 

--- a/src/pages/tools/wallet.mdx
+++ b/src/pages/tools/wallet.mdx
@@ -1,17 +1,17 @@
 ---
-description: "Agent wallets for MPP—compare Tempo Wallet, Privy Agent CLI, and AgentCash for managing funds, signing transactions, and paying for APIs."
-imageDescription: "Give your agent a wallet and a spending limit"
+description: "Agent wallets for MPP -- enable your agent to pay for services."
+imageDescription: "Enable your agent to pay for services"
 ---
 
 import { Badge, Card, Cards, Tab, Tabs } from 'vocs'
 
 # Wallets [Give your agent a wallet]
 
-Agents need a wallet to pay for MPP-enabled services. Choose the wallet that fits your use case.
+Agents need a wallet to pay for MPP-enabled services. Choose the wallet that fits your use case best.
 
 | Wallet | Best for | Supported methods | Setup |
 |--------|----------|-------------------|-------|
-| [Tempo Wallet](#tempo-wallet) | MPP services with spend controls and service discovery | `tempo` | `tempo wallet login` |
+| [Tempo Wallet](#tempo-wallet) | Tempo MPP services with spend controls and service discovery | `tempo` | `tempo wallet login` |
 | [Privy Agent CLI](#privy-agent-cli) | Multi-chain agent wallets with browser-based funding | `tempo`, `solana` | `privy-agent-wallets login` |
 | [AgentCash](#agentcash) | Instant access to 300+ premium APIs via MPP | `tempo` | `npx agentcash onboard` |
 | [`mppx` CLI](#mppx) | Lightweight MPP client for development and debugging | All | `mppx account create` |
@@ -80,7 +80,7 @@ tempo request -X POST \
 
 ## Privy Agent CLI
 
-[Privy Agent CLI](https://docs.privy.io/recipes/agent-integrations/agent-cli) gives agents a CLI-first way to create, fund, and manage wallets with no integration code. It pairs with the [Agent Sandbox](https://agents.privy.io/) where users track spending, manage funds, and revoke access.
+[Privy Agent CLI](https://docs.privy.io/recipes/agent-integrations/agent-cli) gives agents a CLI-first way to create, fund, and manage wallets with no integration code. It pairs with the [Privy Agent Sandbox](https://agents.privy.io/) where users track spending, manage funds, and revoke access.
 
 The agent never holds the wallet private key—each session generates a P-256 keypair used to sign authorization payloads.
 
@@ -143,7 +143,7 @@ privy-agent-wallets rpc --json '{"method": "eth_sendTransaction", "params": {"to
 
 ## AgentCash
 
-[AgentCash](https://agentcash.dev/docs/introduction) gives agents instant access to 300+ premium APIs—enrichment, social data, image generation, web scraping, email—paid per-request with USDC micropayments via MPP. No API keys or subscriptions.
+[AgentCash](https://agentcash.dev/docs/introduction) gives agents instant access to 300+ premium APIs—enrichment, social data, image generation, web scraping, email—paid per-request with USDC micropayments via MPP. No API keys or subscriptions required.
 
 <Tabs>
 <Tab title="Agent">

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -815,6 +815,10 @@ export default defineConfig({
         ],
       },
       {
+        text: "Tools",
+        items: [{ text: "Wallets", link: "/tools/wallet" }],
+      },
+      {
         text: "Use Cases",
         items: [
           {


### PR DESCRIPTION
Adds Privy Agent CLI, AgentCash, and mppx as wallet options for agents.

## Changes

- **Quickstart agent page** — added summary table at the top with all four wallet options (Tempo, Privy, AgentCash, mppx), plus new Privy Agent CLI and AgentCash sections with Agent/Human tabs
- **New tools/wallet page** — dedicated comparison page with setup instructions, supported methods (as badge pills), and key features for each wallet
- **Sidebar** — added "Tools" section below SDKs with a "Wallets" entry

## Links
- [Privy Agent CLI docs](https://docs.privy.io/recipes/agent-integrations/agent-cli)
- [AgentCash docs](https://agentcash.dev/docs/introduction)