### PR TITLE
docs: add Go SDK pages for mpp-go

### DIFF
--- a/src/components/cards.tsx
+++ b/src/components/cards.tsx
@@ -143,6 +143,17 @@ export function RustSdkCard() {
   );
 }
 
+export function GoSdkCard() {
+  return (
+    <Card
+      description="Get started with `mpp-go`, the official MPP SDK for Go"
+      icon="simple-icons:go"
+      title="Go"
+      to="/sdk/go"
+    />
+  );
+}
+
 export function MppxCreateReferenceCard({ to }: { to: string }) {
   return (
     <Card
@@ -415,6 +426,39 @@ export function StripeChargeCard() {
       icon="lucide:credit-card"
       title="Charge"
       to="/payment-methods/stripe/charge"
+    />
+  );
+}
+
+export function GoCoreTypesCard() {
+  return (
+    <Card
+      description="Challenge, Credential, Receipt types"
+      icon="lucide:box"
+      title="Core types"
+      to="/sdk/go/core"
+    />
+  );
+}
+
+export function GoClientCard() {
+  return (
+    <Card
+      description="Handle 402 responses automatically"
+      icon="lucide:send"
+      title="Client"
+      to="/sdk/go/client"
+    />
+  );
+}
+
+export function GoServerCard() {
+  return (
+    <Card
+      description="Protect endpoints with payments"
+      icon="lucide:server"
+      title="Server"
+      to="/sdk/go/server"
     />
   );
 }

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -6,7 +6,7 @@ imageDescription: "The open protocol for machine-to-machine payments"
 import { Cards } from 'vocs'
 import { SpecCard } from '../components/SpecCard'
 import { TerminalPing } from '../components/TerminalPing'
-import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, QuickstartCard, ProtocolConceptsCard } from '../components/cards'
+import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, GoSdkCard, QuickstartCard, ProtocolConceptsCard } from '../components/cards'
 import { PaymentFlowDiagram } from '../components/PaymentFlowDiagram'
 
 # Machine Payments Protocol [The open protocol for machine-to-machine payments]
@@ -67,6 +67,7 @@ MPP comes with a suite of official SDKs maintained by [Tempo Labs](https://tempo
   <TypeScriptSdkCard />
   <PythonSdkCard />
   <RustSdkCard />
+  <GoSdkCard />
 </Cards>
 
 ## Next steps

--- a/src/pages/sdk/go/client.mdx
+++ b/src/pages/sdk/go/client.mdx
@@ -1,0 +1,135 @@
+---
+imageDescription: "Handle paid APIs automatically in Go"
+---
+
+# Client [Handle 402 responses automatically]
+
+The `client.Client` wraps `http.Client` and intercepts `402` responses—it parses the Challenge, signs a stablecoin transfer, and retries with the Credential.
+
+## Quick start
+
+```go [client.go]
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/tempoxyz/mpp-go/pkg/client"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/client"
+)
+
+method, err := charge.New(charge.Config{
+	PrivateKey: "0xac0974bec...",
+	RPCURL:     "https://rpc.tempo.xyz",
+})
+if err != nil {
+	log.Fatal(err)
+}
+c := client.New([]client.Method{method})
+
+resp, err := c.Get(context.Background(), "https://api.example.com/resource")
+if err != nil {
+	log.Fatal(err)
+}
+defer resp.Body.Close()
+fmt.Println("Status:", resp.StatusCode)
+```
+
+When the server returns `402`, the client:
+
+1. Parses the Challenge from the `WWW-Authenticate` header
+2. Calls `CreateCredential` on the matching method to sign a stablecoin transfer
+3. Retries the request with the Credential in the `Authorization` header
+
+## `charge.Config` parameters
+
+### ChainID (optional)
+
+- **Type:** `int64`
+
+Explicitly set the chain ID. Auto-detected from the RPC URL if omitted.
+
+### ClientID (optional)
+
+- **Type:** `string`
+
+Attach an identifier to transactions for attribution.
+
+### CredentialType (optional)
+
+- **Type:** `tempo.CredentialType`
+
+Credential type to use: `transaction`, `hash`, or `proof`. Defaults to `transaction`.
+
+### PrivateKey
+
+- **Type:** `string`
+
+Hex-encoded private key for signing transactions.
+
+### RPC (optional)
+
+- **Type:** `tempo.RPCClient`
+
+Custom RPC client instance. Takes precedence over `RPCURL`.
+
+### RPCURL (optional)
+
+- **Type:** `string`
+- **Default:** auto-detected from chain
+
+Tempo RPC endpoint URL.
+
+### Signer (optional)
+
+- **Type:** `*temposigner.Signer`
+
+Custom signer instance. Takes precedence over `PrivateKey`.
+
+## Custom HTTP client
+
+Pass an existing `http.Client` with `client.WithHTTPClient`:
+
+```go
+c := client.New(
+	[]client.Method{method},
+	client.WithHTTPClient(&http.Client{Timeout: 30 * time.Second}),
+)
+```
+
+## Transport
+
+For composing with an existing `http.Client`, use `client.NewTransport` to wrap a base `http.RoundTripper`:
+
+```go
+transport := client.NewTransport([]client.Method{method}, http.DefaultTransport)
+httpClient := &http.Client{Transport: transport}
+
+req, _ := http.NewRequest("GET", "https://api.example.com/resource", nil)
+resp, err := httpClient.Do(req)
+```
+
+## Convenience methods
+
+| Method | Description |
+|--------|-------------|
+| `Get(ctx, url)` | GET request with automatic `402` handling |
+| `Post(ctx, url, contentType, body)` | POST request with automatic `402` handling |
+| `Do(req)` | Execute any `*http.Request` with automatic `402` handling |
+
+## Payment Receipts
+
+Parse the `Payment-Receipt` header from the response:
+
+```go
+import "github.com/tempoxyz/mpp-go/pkg/mpp"
+
+receipt, err := mpp.ParseReceipt(resp.Header.Get("Payment-Receipt"))
+if err != nil {
+	log.Fatal(err)
+}
+fmt.Println("Status:", receipt.Status)
+fmt.Println("Reference:", receipt.Reference)
+```
+
+For manual Challenge and Credential handling, see [Core types](/sdk/go/core).

--- a/src/pages/sdk/go/core.mdx
+++ b/src/pages/sdk/go/core.mdx
@@ -1,0 +1,74 @@
+---
+imageDescription: "Core MPP types for Go"
+---
+
+# Core types [Challenge, Credential, and Receipt primitives]
+
+These types map directly to HTTP headers—`WWW-Authenticate`, `Authorization`, and `Payment-Receipt`—and can be used independently of the higher-level client and server APIs.
+
+```go
+import "github.com/tempoxyz/mpp-go/pkg/mpp"
+```
+
+## Parse a Challenge
+
+Parse a `WWW-Authenticate` header into a typed `Challenge`:
+
+```go
+challenge, err := mpp.ParseChallenge(
+	`Payment id="...", realm="...", method="tempo", intent="charge", request="eyJ..."`,
+)
+if err != nil {
+	log.Fatal(err)
+}
+
+fmt.Println("Method:", challenge.Method)
+fmt.Println("Intent:", challenge.Intent)
+```
+
+## Create and serialize a Credential
+
+Build a `Credential` from a Challenge echo and payment proof:
+
+```go
+credential := &mpp.Credential{
+	Challenge: challenge.ToEcho(),
+	Payload: map[string]any{
+		"type":      "transaction",
+		"signature": "0x...",
+	},
+	Source: "did:pkh:eip155:4217:0xa726a1...",
+}
+
+header := credential.ToAuthorization()
+// header = "Payment eyJ..."
+```
+
+## Parse and serialize a Receipt
+
+Parse the `Payment-Receipt` response header:
+
+```go
+receipt, err := mpp.ParseReceipt(headerValue)
+if err != nil {
+	log.Fatal(err)
+}
+
+fmt.Println("Status:", receipt.Status)
+fmt.Println("Reference:", receipt.Reference)
+```
+
+Serialize a Receipt back to a header value:
+
+```go
+header := receipt.ToPaymentReceipt()
+```
+
+## Type reference
+
+| Type | Description |
+|------|-------------|
+| `Challenge` | Server Challenge parsed from `WWW-Authenticate` |
+| `ChallengeEcho` | Echoed Challenge fields in a Credential |
+| `Credential` | Client Credential for the `Authorization` header |
+| `Receipt` | Server Receipt parsed from `Payment-Receipt` |

--- a/src/pages/sdk/go/index.mdx
+++ b/src/pages/sdk/go/index.mdx
@@ -1,0 +1,128 @@
+---
+imageDescription: "MPP client and server library for Go"
+---
+
+import * as SdkBadge from '../../../components/SdkBadge'
+
+# Go SDK [The mpp-go library]
+
+## Overview
+
+The `mpp-go` library provides a typed interface over the Machine Payments Protocol, from high-level abstractions to low-level primitives and building blocks.
+
+<div className="flex gap-2">
+  <SdkBadge.GitHub repo="tempoxyz/mpp-go" />
+  <SdkBadge.Maintainer name="Tempo" href="https://github.com/tempoxyz" />
+</div>
+
+## Install
+
+```bash [install.sh]
+$ go get github.com/tempoxyz/mpp-go
+```
+
+## Requirements
+
+- Go 1.21+
+- `go-ethereum` for Tempo signing
+
+## Quick start
+
+### Server
+
+```go [server.go]
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/tempoxyz/mpp-go/pkg/server"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
+)
+
+func main() {
+	intent, _ := charge.NewIntent(charge.IntentConfig{
+		RPCURL: "https://rpc.tempo.xyz",
+	})
+	method := charge.NewMethod(charge.MethodConfig{
+		Intent:    intent,
+		Currency:  "0x20c0000000000000000000000000000000000000",
+		Recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+	})
+	payment := server.New(method, "api.example.com", os.Getenv("MPP_SECRET_KEY"))
+
+	mux := http.NewServeMux()
+	mux.Handle("/resource", server.ChargeMiddleware(payment, server.ChargeParams{
+		Amount:      "0.50",
+		Description: "Paid resource",
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		credential := server.CredentialFromContext(r.Context())
+		json.NewEncoder(w).Encode(map[string]any{
+			"data":  "paid content",
+			"payer": credential.Source,
+		})
+	})))
+
+	log.Fatal(http.ListenAndServe(":3000", mux))
+}
+```
+
+### Client
+
+```go [client.go]
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/tempoxyz/mpp-go/pkg/client"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/client"
+)
+
+func main() {
+	method, err := charge.New(charge.Config{
+		PrivateKey: os.Getenv("PRIVATE_KEY"),
+		RPCURL:     "https://rpc.tempo.xyz",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	c := client.New([]client.Method{method})
+
+	resp, err := c.Get(context.Background(), "https://api.example.com/resource")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	fmt.Println("Status:", resp.StatusCode)
+}
+```
+
+## Package layout
+
+| Package | Description |
+|---------|-------------|
+| `pkg/client` | HTTP client with automatic `402` handling |
+| `pkg/mpp` | Core protocol primitives (Challenge, Credential, Receipt) |
+| `pkg/server` | Server-side payment handler and middleware |
+| `pkg/server/echo` | Echo framework middleware |
+| `pkg/server/gin` | Gin framework middleware |
+| `pkg/tempo/client` | Tempo charge client method |
+| `pkg/tempo/server` | Tempo charge server method |
+
+## Next steps
+
+import { Cards } from 'vocs'
+import { GoCoreTypesCard, GoClientCard, GoServerCard } from '../../../components/cards'
+
+<Cards>
+  <GoCoreTypesCard />
+  <GoClientCard />
+  <GoServerCard />
+</Cards>

--- a/src/pages/sdk/go/server.mdx
+++ b/src/pages/sdk/go/server.mdx
@@ -1,0 +1,318 @@
+---
+imageDescription: "Charge for your Go API endpoints"
+---
+
+# Server [Protect endpoints with payment requirements]
+
+Create a payment handler with `server.New()` and use `ChargeMiddleware` or call `Charge()` directly. The `charge.NewMethod` factory configures `Currency` and `Recipient` once, then every charge uses those defaults.
+
+## Quick start
+
+```go [server.go]
+import (
+	"github.com/tempoxyz/mpp-go/pkg/server"
+	charge "github.com/tempoxyz/mpp-go/pkg/tempo/server"
+)
+
+intent, _ := charge.NewIntent(charge.IntentConfig{
+	RPCURL: "https://rpc.tempo.xyz",
+})
+method := charge.NewMethod(charge.MethodConfig{
+	Intent:    intent,
+	Currency:  "0x20c0000000000000000000000000000000000000",
+	Recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+})
+payment := server.New(method, "api.example.com", "my-server-secret")
+
+result, err := payment.Charge(ctx, server.ChargeParams{
+	Authorization: r.Header.Get("Authorization"),
+	Amount:        "0.50",
+})
+
+if result.IsChallenge() {
+	server.WriteChallenge(w, result.Challenge, payment.Realm())
+	return
+}
+// result.Receipt is the verified Receipt
+```
+
+## Framework middleware
+
+### net/http
+
+Use `server.ChargeMiddleware` to wrap any `http.Handler`:
+
+```go
+mux := http.NewServeMux()
+mux.Handle("/resource", server.ChargeMiddleware(payment, server.ChargeParams{
+	Amount:      "0.50",
+	Description: "Paid resource",
+})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	credential := server.CredentialFromContext(r.Context())
+	json.NewEncoder(w).Encode(map[string]any{
+		"data":  "paid content",
+		"payer": credential.Source,
+	})
+})))
+```
+
+### Gin
+
+Use `ginadapter.ChargeMiddleware` from `pkg/server/gin`:
+
+```go
+import ginadapter "github.com/tempoxyz/mpp-go/pkg/server/gin"
+
+r := gin.Default()
+r.GET("/resource", ginadapter.ChargeMiddleware(payment, server.ChargeParams{
+	Amount: "0.50",
+}), func(c *gin.Context) {
+	credential := server.CredentialFromContext(c.Request.Context())
+	c.JSON(200, gin.H{"payer": credential.Source})
+})
+```
+
+### Echo
+
+Use `echoadapter.ChargeMiddleware` from `pkg/server/echo`:
+
+```go
+import echoadapter "github.com/tempoxyz/mpp-go/pkg/server/echo"
+
+e := echo.New()
+e.GET("/resource", func(c echo.Context) error {
+	credential := server.CredentialFromContext(c.Request().Context())
+	return c.JSON(200, map[string]any{"payer": credential.Source})
+}, echoadapter.ChargeMiddleware(payment, server.ChargeParams{
+	Amount: "0.50",
+}))
+```
+
+### Chi
+
+Use `server.ChargeMiddleware` with `chi.With`:
+
+```go
+r := chi.NewRouter()
+r.With(server.ChargeMiddleware(payment, server.ChargeParams{
+	Amount: "0.50",
+})).Get("/resource", func(w http.ResponseWriter, r *http.Request) {
+	credential := server.CredentialFromContext(r.Context())
+	json.NewEncoder(w).Encode(map[string]any{"payer": credential.Source})
+})
+```
+
+## `MethodConfig` parameters
+
+### ChainID (optional)
+
+- **Type:** `int64`
+
+Explicitly set the chain ID. Auto-detected from the RPC URL if omitted.
+
+### Currency (optional)
+
+- **Type:** `string`
+- **Default:** USDC.e on mainnet, pathUSD on testnet
+
+TIP-20 token address for charges.
+
+### Decimals (optional)
+
+- **Type:** `int`
+- **Default:** `6`
+
+Token decimal places for dollar-to-base-unit conversion.
+
+### FeePayer (optional)
+
+- **Type:** `bool`
+- **Default:** `false`
+
+Enable fee sponsorship for all Challenges. When enabled, the server co-signs and sponsors transaction gas fees.
+
+### FeePayerURL (optional)
+
+- **Type:** `string`
+
+URL of a remote co-signer when the server does not sign locally.
+
+### Intent
+
+- **Type:** `*charge.Intent`
+
+Intent instance created by `charge.NewIntent`.
+
+### Memo (optional)
+
+- **Type:** `string`
+
+Default memo attached to Challenges.
+
+### Recipient (optional)
+
+- **Type:** `string`
+
+Default recipient address for charges.
+
+### SupportedModes (optional)
+
+- **Type:** `[]tempo.ChargeMode`
+
+Supported Credential submission modes (for example, `pull`, `push`).
+
+## `IntentConfig` parameters
+
+### FeePayerPrivateKey (optional)
+
+- **Type:** `string`
+
+Hex-encoded private key for fee sponsorship. The server co-signs and sponsors transaction gas fees.
+
+### FeePayerSigner (optional)
+
+- **Type:** `*temposigner.Signer`
+
+Custom signer for fee sponsorship. Takes precedence over `FeePayerPrivateKey`.
+
+### RPC (optional)
+
+- **Type:** `tempo.RPCClient`
+
+Custom RPC client instance. Takes precedence over `RPCURL`.
+
+### RPCURL (optional)
+
+- **Type:** `string`
+- **Default:** `"https://rpc.tempo.xyz"`
+
+Tempo RPC endpoint URL.
+
+### Store (optional)
+
+- **Type:** `tempo.Store`
+
+Replay-protection store for hash and proof Credentials. Defaults to an in-memory store.
+
+## `ChargeParams` parameters
+
+### Amount
+
+- **Type:** `string`
+
+Payment amount in dollars (for example, `"0.50"` for $0.50). Automatically converted to base units using the configured decimals.
+
+### Authorization (optional)
+
+- **Type:** `string`
+
+The `Authorization` header value from the incoming request.
+
+### ChainID (optional)
+
+- **Type:** `int64`
+
+Override the method's default chain ID for this charge.
+
+### Currency (optional)
+
+- **Type:** `string`
+
+Override the method's default currency address.
+
+### Description (optional)
+
+- **Type:** `string`
+
+Human-readable description attached to the Challenge.
+
+### Expires (optional)
+
+- **Type:** `string`
+
+Challenge expiration as ISO 8601 timestamp. Defaults to 5 minutes from now.
+
+### ExternalID (optional)
+
+- **Type:** `string`
+
+Merchant reference ID for reconciliation.
+
+### FeePayer (optional)
+
+- **Type:** `bool`
+
+Override the method's default fee sponsorship setting for this charge.
+
+### FeePayerURL (optional)
+
+- **Type:** `string`
+
+Override the method's default fee payer URL for this charge.
+
+### Memo (optional)
+
+- **Type:** `string`
+
+Memo attached to this Challenge.
+
+### Meta (optional)
+
+- **Type:** `map[string]string`
+
+Arbitrary metadata attached to the Challenge.
+
+### Recipient (optional)
+
+- **Type:** `string`
+
+Override the method's default recipient address.
+
+### Splits (optional)
+
+- **Type:** `[]tempo.SplitParams`
+
+Split the payment across multiple recipients.
+
+### SupportedModes (optional)
+
+- **Type:** `[]tempo.ChargeMode`
+
+Override supported submission modes for this charge.
+
+## Fee sponsorship
+
+Sponsor gas fees so clients do not need native tokens. Pass `FeePayerPrivateKey` in the `IntentConfig`:
+
+```go
+intent, _ := charge.NewIntent(charge.IntentConfig{
+	RPCURL:             "https://rpc.tempo.xyz",
+	FeePayerPrivateKey: os.Getenv("FEE_PAYER_KEY"),
+})
+method := charge.NewMethod(charge.MethodConfig{
+	Intent:    intent,
+	Currency:  "0x20c0000000000000000000000000000000000000",
+	Recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+})
+```
+
+When fee sponsorship is enabled, the server co-signs transactions and covers gas fees on behalf of the client.
+
+## Context helpers
+
+| Function | Description |
+|----------|-------------|
+| `CredentialFromContext(ctx)` | Extract the verified Credential from request context |
+| `ReceiptFromContext(ctx)` | Extract the verified Receipt from request context |
+| `ContextWithPayment(ctx, credential, receipt)` | Store payment data in context |
+
+## Key types
+
+| Type | Description |
+|------|-------------|
+| `ChargeParams` | Parameters for a single charge |
+| `IntentConfig` | Configuration for `charge.NewIntent` |
+| `MethodConfig` | Configuration for `charge.NewMethod` |
+| `Mpp` | Server handler binding method, realm, and secret |
+| `ChargeResult` | Charge result containing either a Challenge or a Receipt |
+| `SplitParams` | Payment split recipient and amount |

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -24,7 +24,7 @@ import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, GoSdkCard, WalletCliCard
 | **Server** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
 | **Core types** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
 | **Charge intent** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
-| **Session intent** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="warning">—</Badge> |
+| **Session intent** | <Badge variant="success">✓</Badge> | <Badge variant="warning">—</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="warning">—</Badge> |
 | **Fee sponsorship** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
 | **Proof credentials** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
 | **Framework middleware** | Next.js, Hono, Express | FastAPI | Axum | net/http, Gin, Echo, Chi |

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: "SDKs and client libraries"
-description: "Official MPP SDKs in TypeScript, Python, and Rust, plus community SDKs in other languages."
+description: "Official MPP SDKs in TypeScript, Python, Rust, and Go, plus community SDKs in other languages."
 imageDescription: "Official and community SDKs for MPP"
 ---
 
 import { Badge, Cards } from 'vocs'
-import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, WalletCliCard } from '../../components/cards'
+import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, GoSdkCard, WalletCliCard } from '../../components/cards'
 
 # SDKs [Official implementations in multiple languages]
 
@@ -13,7 +13,22 @@ import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, WalletCliCard } from '..
   <TypeScriptSdkCard />
   <PythonSdkCard />
   <RustSdkCard />
+  <GoSdkCard />
 </Cards>
+
+## Capabilities
+
+| Capability | TypeScript | Python | Rust | Go |
+|---|---|---|---|---|
+| **Client** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
+| **Server** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
+| **Core types** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
+| **Charge intent** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
+| **Session intent** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="warning">—</Badge> |
+| **Fee sponsorship** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
+| **Proof credentials** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
+| **Framework middleware** | Next.js, Hono, Express | FastAPI | Axum | net/http, Gin, Echo, Chi |
+| **HTTP transport** | fetch polyfill | httpx transport | reqwest-middleware | http.RoundTripper |
 
 ## Other languages
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -825,6 +825,16 @@ export default defineConfig({
               { text: "Server", link: "/sdk/rust/server" },
             ],
           },
+          {
+            text: "Go",
+            collapsed: true,
+            items: [
+              { text: "Overview", link: "/sdk/go" },
+              { text: "Core types", link: "/sdk/go/core" },
+              { text: "Client", link: "/sdk/go/client" },
+              { text: "Server", link: "/sdk/go/server" },
+            ],
+          },
         ],
       },
       {


### PR DESCRIPTION
Add Go SDK documentation to the MPP docs site, formatted to match the existing Python and Rust SDK pages.

## New pages

- `/sdk/go` — Overview with install, quick start (client + server), and package layout
- `/sdk/go/core` — Challenge, Credential, and Receipt primitives
- `/sdk/go/client` — `client.Client` with automatic `402` handling, transport, and config reference
- `/sdk/go/server` — `server.New` + middleware for net/http, Gin, Echo, and Chi, fee sponsorship, full parameter reference

## Updated pages

- **SDK index** — Added Go card and SDK capabilities matrix comparing TypeScript, Python, Rust, and Go
- **Overview** — Added Go card to the SDKs section
- **Sidebar** — Added Go section with Overview, Core types, Client, and Server
- **cards.tsx** — Added `GoSdkCard`, `GoCoreTypesCard`, `GoClientCard`, `GoServerCard`

## SDK capabilities matrix

The SDK index now includes a feature comparison table showing support for:
- Client, Server, Core types, Charge intent, Session intent, Fee sponsorship, Proof credentials, Framework middleware, and HTTP transport

Go supports everything except session intent (not yet implemented in mpp-go).