### PR TITLE
docs: expand SDK capabilities matrix

### DIFF
--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -25,9 +25,11 @@ import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, GoSdkCard, WalletCliCard
 | **Core types** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
 | **Charge intent** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
 | **Session intent** | <Badge variant="success">✓</Badge> | <Badge variant="warning">—</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="warning">—</Badge> |
+| **Stripe method** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="warning">—</Badge> |
 | **Fee sponsorship** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
 | **Proof credentials** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> |
-| **Framework middleware** | Next.js, Hono, Express | FastAPI | Axum | net/http, Gin, Echo, Chi |
+| **MCP support** | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="success">✓</Badge> | <Badge variant="warning">—</Badge> |
+| **Framework middleware** | Next.js, Hono, Express, Elysia | FastAPI | Axum, Tower | net/http, Gin, Echo, Chi |
 | **HTTP transport** | fetch polyfill | httpx transport | reqwest-middleware | http.RoundTripper |
 
 ## Other languages


### PR DESCRIPTION
Audited all four SDKs against their source code and expanded the capabilities matrix with missing rows.

## Changes

Added three new capability rows after auditing `mppx`, `pympp`, `mpp-rs`, and `mpp-go`:

| Capability | TypeScript | Python | Rust | Go |
|---|---|---|---|---|
| **Stripe method** | ✓ | ✓ | ✓ | — |
| **MCP support** | ✓ | ✓ | ✓ | — |

Updated existing rows:
- **Framework middleware**: added Elysia (TypeScript) and Tower (Rust)

## Audit methodology

Inspected the source of each SDK:
- **mppx** (wevm/mppx): 17 export paths, sessions, Stripe SPT, MCP client/server, Elysia middleware
- **pympp** (tempoxyz/pympp): charge + Stripe intents, MCP extension (`pympp[mcp]`), no sessions
- **mpp-rs** (tempoxyz/mpp-rs): sessions, Stripe, MCP, Axum extractor, Tower layer, reqwest-middleware
- **mpp-go** (tempoxyz/mpp-go): charge only, fee sponsorship, proof credentials, 4 framework middlewares