### PR TITLE
perf: stub mermaid to cut client JS from 4.9MB to 1.9MB

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,6 +68,28 @@ function stubRehypeMermaid(): Plugin {
   };
 }
 
+// Stub the mermaid library to prevent Vocs's built-in Mermaid.client from
+// bundling the full mermaid package (~2.5 MB of JS chunks). No page uses
+// Vocs's ```mermaid code blocks — all diagrams use the custom
+// MermaidDiagram component which renders pure SVG without mermaid.
+function stubMermaid(): Plugin {
+  return {
+    name: "stub-mermaid",
+    enforce: "pre",
+    resolveId(id) {
+      if (id === "mermaid") return "\0mermaid-stub";
+    },
+    load(id) {
+      if (id === "\0mermaid-stub") {
+        return `export default {
+          initialize() {},
+          async render() { return { svg: '<svg></svg>' } },
+        }`;
+      }
+    },
+  };
+}
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   for (const key of Object.keys(env)) {
@@ -84,6 +106,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       preloadFonts(),
       stubRehypeMermaid(),
+      stubMermaid(),
       Icons({ compiler: "jsx", jsx: "react" }),
       react(),
       vocs(),


### PR DESCRIPTION
## Summary

Stubs the `mermaid` npm package at build time to prevent Vocs's built-in `Mermaid.client` from bundling the full mermaid library. No page uses Vocs's ````mermaid``` code blocks—all diagrams use the custom `MermaidDiagram` component which renders pure SVG without the mermaid dependency.

This eliminates ~2.95 MB of lazy-loaded mermaid/cytoscape/dagre/katex chunks that were included in total page weight (as reported by Ahrefs).

**Before:** 4.92 MB client JS (45 chunks incl. 30+ mermaid diagram types)
**After:** 1.88 MB client JS (45 chunks, no mermaid)

## Changes

- **`vite.config.ts`** — Added `stubMermaid()` plugin that resolves `import('mermaid')` to a no-op stub, alongside the existing `stubRehypeMermaid()`
- **`scripts/check-bundle-size.ts`** — New script that fails if client JS exceeds a 2 MB budget
- **`package.json`** — Added `check:bundle-size` script
- **`.github/workflows/ci.yml`** — Runs `pnpm check:bundle-size` after build to prevent regressions

## Verification

- `pnpm build` ✅
- `pnpm check:types` ✅
- `pnpm test` ✅ (5757 tests, 13 files)
- `pnpm check:bundle-size` ✅ (1.88 MB, under 2 MB budget)