### PR TITLE
feat(services): add C2PAVerify — C2PA manifest verification

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -789,6 +789,44 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── C2PAVerify ─────────────────────────────────────────────────────────
+  {
+    id: "c2paverify",
+    name: "C2PAVerify",
+    url: "https://c2pa.mppfy.com",
+    serviceUrl: "https://c2pa.mppfy.com",
+    description:
+      "Verify C2PA (Coalition for Content Provenance and Authenticity) manifests on images, video, and audio. Extracts embedded manifest, validates the signature chain against the CAI trust list, returns a structured provenance report with trust_chain classification (valid | partial | unknown).",
+    categories: ["media"],
+    integration: "third-party",
+    tags: [
+      "c2pa",
+      "provenance",
+      "authenticity",
+      "content-credentials",
+      "deepfake",
+      "ai-generated",
+      "compliance",
+      "cai",
+    ],
+    docs: {
+      homepage: "https://c2pa.mppfy.com",
+      llmsTxt: "https://c2pa.mppfy.com/llms.txt",
+      apiReference: "https://github.com/mppfy/C2PAVerify",
+    },
+    provider: { name: "MPPFY", url: "https://mppfy.com" },
+    realm: "c2pa.mppfy.com",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /verify",
+        desc: "Verify C2PA manifest on uploaded asset (multipart) or fetched URL (JSON)",
+        amount: "10000",
+      },
+    ],
+  },
+
   // ── Codex ──────────────────────────────────────────────────────────────
   {
     id: "codex",


### PR DESCRIPTION
## Summary

Adds **C2PAVerify** to the MPP services registry — a third-party service for verifying [C2PA](https://c2pa.org) (Content Provenance and Authenticity) manifests on images, video, and audio.

- **Live:** https://c2pa.mppfy.com
- **Source:** https://github.com/mppfy/C2PAVerify
- **OpenAPI discovery:** https://c2pa.mppfy.com/openapi.json
- **llms.txt:** https://c2pa.mppfy.com/llms.txt

## What it does

Extracts embedded C2PA manifest, validates signature chain against the [CAI trust list](https://contentcredentials.org/trust/) (27 anchors + 114 end-entity certs bundled), returns structured provenance report with `trust_chain` classification (`valid` | `partial` | `unknown`). Powered by [c2pa-rs](https://github.com/contentauth/c2pa-rs) compiled to WASM, running on Cloudflare Workers.

Useful for agents verifying AI-generated content claims, deepfake detection, and content-provenance compliance workflows.

## Endpoint

| Route | Description | Price |
|-------|-------------|-------|
| `POST /verify` | Verify C2PA manifest on uploaded asset (multipart) or fetched URL (JSON) | 10000 base units (0.01 USDC.e) |

## Payment

- Method: `tempo` (Tempo mainnet, chainId 4217)
- Currency: USDC.e (`0x20c0…e8b50`)
- Realm: `c2pa.mppfy.com`
- Intent: `charge`

## Proof of live
