### PR TITLE
Add Martin Estate Winery to service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -3940,7 +3940,7 @@ export const services: ServiceDef[] = [
         desc: "List purchasable wines",
       },
       {
-        route: "GET /catalog/{slug}",
+        route: "GET /catalog/:slug",
         desc: "Get wine details by slug",
       },
       {
@@ -3950,11 +3950,11 @@ export const services: ServiceDef[] = [
         amountHint: "Variable depending on wine and quantity",
       },
       {
-        route: "GET /orders/{id}",
+        route: "GET /orders/:id",
         desc: "Retrieve order details",
       },
       {
-        route: "GET /orders/{id}/status",
+        route: "GET /orders/:id/status",
         desc: "Check payment status",
       },
     ],

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -3905,6 +3905,61 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Martin Estate Winery ────────────────────────────────────────────────
+  {
+    id: "martin-estate",
+    name: "Martin Estate Winery",
+    url: "https://www.martinestate.com",
+    serviceUrl: "https://agents.martinestate.com",
+    description:
+      "Estate-grown Napa Valley wine. AI agents can browse and purchase wine with identity verification (KYC, age 21+, US only) via AgentScore.",
+
+    categories: ["web"],
+    integration: "first-party",
+    tags: [
+      "wine",
+      "commerce",
+      "alcohol",
+      "age-restricted",
+      "physical-goods",
+      "napa-valley",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://www.martinestate.com",
+      llmsTxt: "https://agents.martinestate.com/llms.txt",
+      apiReference: "https://agents.martinestate.com/openapi.json",
+    },
+    provider: { name: "Martin Estate", url: "https://www.martinestate.com" },
+    realm: "agents.martinestate.com",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT, STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /catalog",
+        desc: "List purchasable wines",
+      },
+      {
+        route: "GET /catalog/{slug}",
+        desc: "Get wine details by slug",
+      },
+      {
+        route: "POST /purchase",
+        desc: "Purchase wine with identity verification via AgentScore and MPP payment",
+        dynamic: true,
+        amountHint: "Variable depending on wine and quantity",
+      },
+      {
+        route: "GET /orders/{id}",
+        desc: "Retrieve order details",
+      },
+      {
+        route: "GET /orders/{id}/status",
+        desc: "Check payment status",
+      },
+    ],
+  },
+
   // =========================================================================
   // Locus — Pay-per-use API proxy (paywithlocus.com)
   //


### PR DESCRIPTION
## Summary

Adds Martin Estate Winery to the service directory — first regulated physical goods (wine) available via agent commerce. Accepts Tempo USDC and Stripe, with identity verification (KYC, age 21+, US only) enforced via AgentScore before the `POST /purchase` call.

- Live service: https://agents.martinestate.com
- OpenAPI: https://agents.martinestate.com/openapi.json
- llms.txt: https://agents.martinestate.com/llms.txt
- Homepage: https://www.martinestate.com
- MPPScan: https://www.mppscan.com/server/14848dcc85b2faba043c10e7f3a1590daf2d24bd3c1a519e335e1f8cbf46a0dc

## Required checklist

- [x] Service is **live and accepting payments** via MPP (not a placeholder)
- [x] Entry added to `schemas/services.ts`
- [x] Types pass: `pnpm check:types`
- [x] Build succeeds: `pnpm build`
- [x] Tests pass: `pnpm test` (`schemas/services.test.ts`, 5575/5575)
- [x] Biome clean on changed file: `pnpm check schemas/services.ts`

## Recommended

- [x] Registered on MPPScan

## Endpoints

All 5 endpoints match the live `openapi.json`. Paths are written in the repo's `:param` convention (matching AgentMail, DripStack, Dune, etc.) — the live OpenAPI spec uses the equivalent `{param}` form.

- `GET /catalog` — list purchasable wines
- `GET /catalog/:slug` — wine detail
- `POST /purchase` — dynamic price, requires AgentScore identity + MPP payment
- `GET /orders/:id` — order detail
- `GET /orders/:id/status` — payment status