### PR TITLE
feat: add Tack IPFS pinning service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6496,6 +6496,63 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Tack ──────────────────────────────────────────────────────────────────
+  {
+    id: "tack",
+    name: "Tack",
+    url: "https://tack.taiko.xyz",
+    serviceUrl: "https://tack.taiko.xyz",
+    description:
+      "IPFS pinning and content retrieval for agents. Pin by CID or upload files — pay by size and duration, no account needed.",
+
+    categories: ["storage"],
+    integration: "first-party",
+    tags: ["ipfs", "pinning", "storage", "files", "upload", "cid", "taiko"],
+    docs: {
+      homepage: "https://tack.taiko.xyz",
+      llmsTxt: "https://tack.taiko.xyz/llms.txt",
+      apiReference: "https://ipfs.github.io/pinning-services-api-spec/",
+    },
+    provider: { name: "Taiko", url: "https://taiko.xyz" },
+    realm: "tack.taiko.xyz",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /pins",
+        desc: "Pin content by CID — dynamic pricing based on size and duration ($0.10/GB/month, min $0.001)",
+        dynamic: true,
+        amountHint: "$0.001+",
+      },
+      {
+        route: "POST /upload",
+        desc: "Upload and pin a file (multipart/form-data) — dynamic pricing ($0.10/GB/month, min $0.001)",
+        dynamic: true,
+        amountHint: "$0.001+",
+      },
+      {
+        route: "GET /ipfs/:cid",
+        desc: "Retrieve content by CID — free by default, optionally gated by owner-set retrieval price",
+      },
+      {
+        route: "GET /pins",
+        desc: "List your pins (owner bearer token required)",
+      },
+      {
+        route: "GET /pins/:requestid",
+        desc: "Get a specific pin (owner bearer token required)",
+      },
+      {
+        route: "POST /pins/:requestid",
+        desc: "Replace a pin (owner bearer token required)",
+      },
+      {
+        route: "DELETE /pins/:requestid",
+        desc: "Delete a pin (owner bearer token required)",
+      },
+    ],
+  },
+
   // ── Papercut ───────────────────────────────────────────────────────────
   {
     id: "papercut",


### PR DESCRIPTION
## Summary

- Adds **Tack** (`tack.taiko.xyz`) to the MPP service registry
- Tack is an IPFS pinning and content retrieval service with native MPP support (USDC.e on Tempo via mppx)
- First-party integration — tack handles payment verification and settlement directly

## Service details

| Field | Value |
|---|---|
| id | `tack` |
| categories | `["storage"]` |
| integration | `first-party` |
| realm | `tack.taiko.xyz` |
| payments | Tempo USDC.e |
| pricing | dynamic ($0.10/GB/month, min $0.001) |

## Endpoints covered

- `POST /pins` — Pin by CID (dynamic price)
- `POST /upload` — Upload + pin file (dynamic price)
- `GET /ipfs/:cid` — Retrieve content (free / owner-gated)
- `GET /pins`, `GET /pins/:requestid`, `POST /pins/:requestid`, `DELETE /pins/:requestid` — Owner management (bearer token)

## Docs references

- `homepage`: https://tack.taiko.xyz
- `llmsTxt`: https://tack.taiko.xyz/llms.txt (being added in a companion tack PR)
- `apiReference`: https://ipfs.github.io/pinning-services-api-spec/ (IPFS Pinning Service API)

## Checks

- [x] `pnpm check:types` — passes
- [x] `pnpm check` (biome) — passes (`No fixes applied`)
- [x] `pnpm check:sdk-drift` — pre-existing failure on `main` (unrelated to this PR)
- [x] `categories: ["storage"]` — confirmed valid enum value in `CATEGORIES` array

## Hard requirements met

- [x] Live and accepting MPP payments at `tack.taiko.xyz`
- [x] Entry added to `schemas/services.ts`
- [x] `/.well-known/agent.json` confirmed live (A2A agent card)