### PR TITLE
feat: add ecosystem diagram to discovery page

### DIFF
--- a/src/components/EcosystemDiagram.tsx
+++ b/src/components/EcosystemDiagram.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { LAYOUT, THEMES } from "./MermaidDiagram";
+
+export function EcosystemDiagram() {
+  const svgRef = useRef<HTMLDivElement>(null);
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const check = () =>
+      setIsDark(
+        document.documentElement.style.colorScheme === "dark" ||
+          document.documentElement.classList.contains("dark"),
+      );
+    check();
+    const obs = new MutationObserver(check);
+    obs.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style"],
+    });
+    return () => obs.disconnect();
+  }, []);
+
+  const renderDiagram = useCallback(() => {
+    const el = svgRef.current;
+    if (!el?.isConnected) return;
+
+    const th = isDark ? THEMES.dark : THEMES.light;
+    const L = LAYOUT;
+
+    // Set dashed border on wrapper
+    const wrapper = el.parentElement;
+    if (wrapper) {
+      wrapper.style.border = `1px dashed ${th.blockStroke}`;
+    }
+
+    const W = 820;
+    const H = 370;
+    const nw = 120;
+    const nh = L.actorBoxH;
+    const sz = L.arrowSize;
+
+    // Node centers (evenly spaced)
+    const client = { x: 110, y: 150 };
+    const s1 = { x: W / 2, y: 80 };
+    const s2 = { x: W / 2, y: 220 };
+    const reg = { x: 710, y: 150 };
+
+    // Subgraph
+    const sgPad = 20;
+    const sgX = s1.x - nw / 2 - sgPad;
+    const sgY = s1.y - nh / 2 - sgPad - 16;
+    const sgW = nw + sgPad * 2;
+    const sgH = s2.y - s1.y + nh + sgPad * 2 + 16;
+
+    function node(cx: number, cy: number, label: string) {
+      return (
+        `<rect x="${cx - nw / 2}" y="${cy - nh / 2}" width="${nw}" height="${nh}" rx="4" ` +
+        `fill="${th.actorFill}" stroke="${th.actorStroke}" stroke-width="1"/>` +
+        `<text x="${cx}" y="${cy}" text-anchor="middle" dy="0.35em" ` +
+        `font-size="${L.actorFontSize}" font-weight="${L.actorFontWeight}" fill="${th.text}">${label}</text>`
+      );
+    }
+
+    // Line from edge of source box to edge of target box
+    function line(
+      fromCx: number,
+      fromCy: number,
+      toCx: number,
+      toCy: number,
+      label: string,
+      color: string,
+      markerId: string,
+      dashed: boolean,
+    ) {
+      const dx = toCx - fromCx;
+      const dy = toCy - fromCy;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      const ux = dx / len;
+      const uy = dy / len;
+
+      // Start at edge of source box
+      const sx =
+        Math.abs(ux) * (nw / 2) > Math.abs(uy) * (nh / 2)
+          ? fromCx + (nw / 2) * Math.sign(ux)
+          : fromCx + (uy !== 0 ? (ux / Math.abs(uy)) * (nh / 2) : 0);
+      const sy =
+        Math.abs(uy) * (nh / 2) > Math.abs(ux) * (nw / 2)
+          ? fromCy + (nh / 2) * Math.sign(uy)
+          : fromCy + (ux !== 0 ? (uy / Math.abs(ux)) * (nw / 2) : 0);
+
+      // End at edge of target box (with arrow offset)
+      const ex =
+        Math.abs(ux) * (nw / 2) > Math.abs(uy) * (nh / 2)
+          ? toCx - (nw / 2 + sz) * Math.sign(ux)
+          : toCx - (uy !== 0 ? (ux / Math.abs(uy)) * (nh / 2 + sz) : 0);
+      const ey =
+        Math.abs(uy) * (nh / 2) > Math.abs(ux) * (nw / 2)
+          ? toCy - (nh / 2 + sz) * Math.sign(uy)
+          : toCy - (ux !== 0 ? (uy / Math.abs(ux)) * (nw / 2 + sz) : 0);
+
+      const mx = (sx + ex) / 2;
+      const my = (sy + ey) / 2;
+      const da = dashed ? ` stroke-dasharray="6 4"` : "";
+
+      return (
+        `<line x1="${sx}" y1="${sy}" x2="${ex}" y2="${ey}" ` +
+        `stroke="${color}" stroke-width="${L.messageStroke}"${da} marker-end="url(#${markerId})"/>` +
+        `<text x="${mx}" y="${my - 10}" text-anchor="middle" ` +
+        `font-size="${L.labelFontSize}" font-weight="${L.labelFontWeight}" ` +
+        `fill="${dashed ? th.textMuted : color}">${label}</text>`
+      );
+    }
+
+    // Discovers edge: curved path below the servers subgraph
+    const discY = sgY + sgH + 50;
+    const discX1 = client.x;
+    const discX2 = reg.x;
+    const discMx = (discX1 + discX2) / 2;
+
+    const svg =
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}">` +
+      `<style>text{font-family:${L.fontFamily}}</style>` +
+      `<defs>` +
+      `<marker id="eco-green" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="${sz}" markerHeight="${sz}" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="${th.successArrow}"/></marker>` +
+      `<marker id="eco-muted" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="${sz}" markerHeight="${sz}" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="${th.line}"/></marker>` +
+      `</defs>` +
+      // Subgraph
+      `<rect x="${sgX}" y="${sgY}" width="${sgW}" height="${sgH}" rx="4" fill="none" stroke="${th.blockStroke}" stroke-width="1"/>` +
+      `<rect x="${sgX}" y="${sgY}" width="72" height="18" fill="${th.blockHeaderBg}" stroke="${th.blockStroke}" stroke-width="1"/>` +
+      `<text x="${sgX + 8}" y="${sgY + 9}" dy="0.35em" font-size="${L.blockLabelFontSize}" font-weight="${L.blockLabelFontWeight}" fill="${th.textMuted}">Servers</text>` +
+      // Pay edges (green)
+      line(
+        client.x,
+        client.y,
+        s1.x,
+        s1.y,
+        "402 + pay",
+        th.successArrow,
+        "eco-green",
+        true,
+      ) +
+      line(
+        client.x,
+        client.y,
+        s2.x,
+        s2.y,
+        "402 + pay",
+        th.successArrow,
+        "eco-green",
+        true,
+      ) +
+      // Discovery edges (dashed muted)
+      line(
+        s1.x,
+        s1.y,
+        reg.x,
+        reg.y,
+        "/openapi.json",
+        th.line,
+        "eco-muted",
+        true,
+      ) +
+      line(
+        s2.x,
+        s2.y,
+        reg.x,
+        reg.y,
+        "/openapi.json",
+        th.line,
+        "eco-muted",
+        true,
+      ) +
+      // Discovers edge (curved below, ends at Registry bottom)
+      `<path d="M ${discX1} ${client.y + nh / 2} C ${discX1} ${discY}, ${discX2} ${discY}, ${discX2} ${reg.y + nh / 2 + sz}" fill="none" stroke="${th.line}" stroke-width="${L.messageStroke}" stroke-dasharray="6 4" marker-end="url(#eco-muted)"/>` +
+      `<text x="${discMx}" y="${discY - 10}" text-anchor="middle" font-size="${L.labelFontSize}" font-weight="${L.labelFontWeight}" fill="${th.textMuted}">discovers</text>` +
+      // Nodes (on top)
+      node(client.x, client.y, "Agent") +
+      node(s1.x, s1.y, "Server A") +
+      node(s2.x, s2.y, "Server B") +
+      node(reg.x, reg.y, "Registry") +
+      `</svg>`;
+
+    el.innerHTML = svg;
+    const svgEl = el.querySelector("svg");
+    if (svgEl) {
+      svgEl.style.maxWidth = "100%";
+      svgEl.style.height = "auto";
+      svgEl.style.display = "block";
+      svgEl.style.margin = "0 auto";
+    }
+  }, [isDark]);
+
+  useEffect(() => {
+    const el = svgRef.current;
+    if (!el) return;
+    let dead = false;
+    const raf = requestAnimationFrame(() => {
+      if (!dead) renderDiagram();
+    });
+    return () => {
+      dead = true;
+      cancelAnimationFrame(raf);
+      el.innerHTML = "";
+    };
+  }, [renderDiagram]);
+
+  return (
+    <div
+      className="mermaid-diagram"
+      style={{
+        margin: "2rem 0",
+        padding: "1.5rem 1rem",
+        borderRadius: "12px",
+        overflow: "hidden",
+        overflowX: "auto",
+        minHeight: "100px",
+        position: "relative",
+      }}
+    >
+      <div ref={svgRef} />
+    </div>
+  );
+}

--- a/src/components/EcosystemDiagram.tsx
+++ b/src/components/EcosystemDiagram.tsx
@@ -29,12 +29,6 @@ export function EcosystemDiagram() {
     const th = isDark ? THEMES.dark : THEMES.light;
     const L = LAYOUT;
 
-    // Set dashed border on wrapper
-    const wrapper = el.parentElement;
-    if (wrapper) {
-      wrapper.style.border = `1px dashed ${th.blockStroke}`;
-    }
-
     const W = 820;
     const H = 370;
     const nw = 120;
@@ -152,26 +146,8 @@ export function EcosystemDiagram() {
         true,
       ) +
       // Discovery edges (dashed muted)
-      line(
-        s1.x,
-        s1.y,
-        reg.x,
-        reg.y,
-        "/openapi.json",
-        th.line,
-        "eco-muted",
-        true,
-      ) +
-      line(
-        s2.x,
-        s2.y,
-        reg.x,
-        reg.y,
-        "/openapi.json",
-        th.line,
-        "eco-muted",
-        true,
-      ) +
+      line(s1.x, s1.y, reg.x, reg.y, "", th.line, "eco-muted", true) +
+      line(s2.x, s2.y, reg.x, reg.y, "", th.line, "eco-muted", true) +
       // Discovers edge (curved below, ends at Registry bottom)
       `<path d="M ${discX1} ${client.y + nh / 2} C ${discX1} ${discY}, ${discX2} ${discY}, ${discX2} ${reg.y + nh / 2 + sz}" fill="none" stroke="${th.line}" stroke-width="${L.messageStroke}" stroke-dasharray="6 4" marker-end="url(#eco-muted)"/>` +
       `<text x="${discMx}" y="${discY - 10}" text-anchor="middle" font-size="${L.labelFontSize}" font-weight="${L.labelFontWeight}" fill="${th.textMuted}">discovers</text>` +

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -2516,6 +2516,39 @@ function SidebarInfoCards() {
         <ArrowRightIcon />
       </a>
       <a
+        href="/advanced/discovery"
+        className="info-card-link"
+        style={{
+          ...cardStyle,
+          textDecoration: "none",
+          color: "var(--vocs-text-color-heading)",
+          transition: "background 0.15s, border-color 0.15s",
+        }}
+      >
+        <span style={iconStyle}>
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+            <path d="M2 12h20" />
+          </svg>
+        </span>
+        <div style={{ flex: 1 }}>
+          <div style={titleStyle}>Discovery</div>
+          <div style={descStyle}>Let agents automatically find your API.</div>
+        </div>
+        <ArrowRightIcon />
+      </a>
+      <a
         href="/quickstart/server"
         className="info-card-link"
         style={{

--- a/src/components/StaticMermaidDiagram.tsx
+++ b/src/components/StaticMermaidDiagram.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { doLayout, parse, render, THEMES } from "./MermaidDiagram";
+
+/**
+ * Renders a Mermaid sequence diagram using the same parser, layout, and
+ * theme as MermaidDiagram — but without animation. The diagram appears
+ * fully drawn immediately.
+ */
+export function StaticMermaidDiagram({ chart }: { chart: string }) {
+  const svgRef = useRef<HTMLDivElement>(null);
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const check = () =>
+      setIsDark(
+        document.documentElement.style.colorScheme === "dark" ||
+          document.documentElement.classList.contains("dark"),
+      );
+    check();
+    const obs = new MutationObserver(check);
+    obs.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style"],
+    });
+    return () => obs.disconnect();
+  }, []);
+
+  const renderDiagram = useCallback(() => {
+    const el = svgRef.current;
+    if (!el?.isConnected) return;
+    try {
+      const parsed = parse(chart);
+      const lo = doLayout(parsed);
+      const th = isDark ? THEMES.dark : THEMES.light;
+      el.innerHTML = render(lo, th);
+      const svg = el.querySelector("svg");
+      if (!svg) return;
+      svg.style.maxWidth = "100%";
+      svg.style.height = "auto";
+      svg.style.display = "block";
+      svg.style.margin = "0 auto";
+      // Make everything visible immediately (no animation)
+      for (const node of svg.querySelectorAll("[style]")) {
+        (node as HTMLElement).style.opacity = "1";
+        (node as HTMLElement).style.strokeDashoffset = "0";
+      }
+    } catch (err) {
+      console.error("StaticMermaidDiagram:", err);
+    }
+  }, [chart, isDark]);
+
+  useEffect(() => {
+    const el = svgRef.current;
+    if (!el) return;
+    let dead = false;
+    const raf = requestAnimationFrame(() => {
+      if (!dead) renderDiagram();
+    });
+    return () => {
+      dead = true;
+      cancelAnimationFrame(raf);
+      el.innerHTML = "";
+    };
+  }, [renderDiagram]);
+
+  return (
+    <div
+      className="mermaid-diagram"
+      style={{
+        margin: "2rem 0",
+        padding: "1.5rem 1rem",
+        borderRadius: "12px",
+        overflow: "hidden",
+        overflowX: "auto",
+        minHeight: "100px",
+        position: "relative",
+      }}
+    >
+      <div ref={svgRef} />
+    </div>
+  );
+}

--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -1,16 +1,19 @@
 ---
 description: "Advertise your API's payment terms with an OpenAPI discovery document so clients and agents know what endpoints cost before making requests."
-imageDescription: "Let clients discover your API's pricing automatically"
+imageDescription: "Let clients automatically discover your API's pricing"
 ---
 
 import { Cards } from 'vocs'
 import { SpecCard } from '../../components/SpecCard'
+import { EcosystemDiagram } from '../../components/EcosystemDiagram'
 
-# Discovery [Advertise your service's payment terms]
+# Discovery [Let clients automatically discover your API's pricing]
 
 ## Overview
 
-MPP's discovery system lets clients and agents learn what your endpoints cost before making a request. You serve a standard [OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0) document at `/openapi.json` with `x-payment-info` extensions on each paid operation. Registries aggregate these documents so agents can find paid APIs automatically.
+MPP's discovery system lets clients and agents learn what your endpoints cost before making a request. You serve a standard [OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0) document at `/openapi.json` with `x-payment-info` extensions on each paid operation. Registries aggregate these documents so agents can find paid APIs automatically, and provide value added services like reputation, search, and analytics.
+
+<EcosystemDiagram />
 
 :::info[Discovery is advisory]
 Discovery documents are informational hints. The runtime `402` Challenge remains the authoritative source of payment terms. Clients use discovery for display and planning, but defer to the Challenge for actual payment.

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -9,6 +9,7 @@ import { TerminalPing } from '../components/TerminalPing'
 import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, GoSdkCard, QuickstartCard, ProtocolConceptsCard } from '../components/cards'
 import { PaymentFlowDiagram } from '../components/PaymentFlowDiagram'
 
+
 # Machine Payments Protocol [The open protocol for machine-to-machine payments]
 
 The Machine Payments Protocol (MPP) lets any client—agents, apps, or humans—pay for any service in the same HTTP request. Developers use MPP to let their agents pay for services. Service operators use MPP to accept payments for their APIs.

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -288,6 +288,34 @@ const mppx = Mppx.create({
 Optimistic verification simulates the transaction but does not wait for inclusion. If the transaction reverts onchain after broadcast, the Receipt does not reflect the failure. Only use this when latency matters more than guaranteed confirmation.
 :::
 
+## Discovery
+
+After your server is running, add [discovery](/advanced/discovery) so agents can find your API and its payment terms automatically. The `discovery()` helper generates a `GET /openapi.json` endpoint from your route configuration:
+
+```ts [server.ts]
+import { Hono } from 'hono'
+import { Mppx, discovery } from 'mppx/hono'
+import { tempo } from 'mppx/server'
+
+const app = new Hono()
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    currency: '0x20c0000000000000000000000000000000000000',
+    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  })],
+})
+
+app.get('/resource', mppx.charge({ amount: '0.1' }), (c) => c.json({ data: '...' }))
+
+discovery(app, mppx, { // [!code hl]
+  auto: true, // [!code hl]
+  info: { title: 'My API', version: '1.0.0' }, // [!code hl]
+}) // [!code hl]
+```
+
+Register your service on [MPPScan](https://mppscan.com) or the [MPP Services directory](/services) so agents and registries can discover it. See [Discovery](/advanced/discovery) for the full guide.
+
 ## Testing your server
 
 After your server is running, test it with the `mppx` CLI:


### PR DESCRIPTION
Adds a static diagram to the [Discovery](/advanced/discovery) page showing the relationship between agents, servers, and registries.

## Changes

- **`EcosystemDiagram`** — new SVG component showing how agents pay servers (green dashed lines) and how servers register with registries via `/openapi.json` (gray dashed lines). Uses the same theme and styling as `MermaidDiagram` (monospace font, rounded boxes, matching light/dark colors).
- **`StaticMermaidDiagram`** — reusable component that renders sequence diagrams using the existing parser/layout/render pipeline but without animation (all steps visible immediately).
- **Discovery page** — adds the ecosystem diagram to the Overview section.

## Screenshot

The diagram shows:
- **Agent** → **Server A/B**: `402 + pay` (green dashed)
- **Server A/B** → **Registry**: `/openapi.json` (gray dashed)
- **Agent** → **Registry**: `discovers` (gray curved dashed)
