### PR TITLE
feat: add StableCoozie service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -2002,6 +2002,38 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── StableCoozie ──────────────────────────────────────────────────────
+  {
+    id: "stablecoozie",
+    name: "StableCoozie",
+    url: "https://stablemerch-coozies.vercel.app",
+    serviceUrl: "https://stablemerch-coozies.vercel.app",
+    description:
+      "Custom printed coozies (can coolers) via x402. Upload your image, pick a size, get coozies shipped.",
+    categories: ["web"],
+    integration: "first-party",
+    tags: ["merch", "print-on-demand", "coozies", "ecommerce", "printify"],
+    docs: {
+      homepage: "https://stablemerch-coozies.vercel.app",
+      llmsTxt: "https://stablemerch-coozies.vercel.app/llms.txt",
+    },
+    provider: {
+      name: "StableCoozie",
+      url: "https://stablemerch-coozies.vercel.app",
+    },
+    realm: "stablemerch-coozies.vercel.app",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /api/coozie",
+        desc: "Order custom printed coozies",
+        dynamic: true,
+        amountHint: "$10 - $12",
+      },
+    ],
+  },
+
   // ── StableEnrich ───────────────────────────────────────────────────────
   {
     id: "stableenrich",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -2029,7 +2029,7 @@ export const services: ServiceDef[] = [
         route: "POST /api/coozie",
         desc: "Order custom printed coozies",
         dynamic: true,
-        amountHint: "$10 - $12",
+        amountHint: "$5 - $8",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Adds StableCoozie to the MPP Services registry (`schemas/services.ts`)
- Custom printed coozies (can coolers) via x402 micropayments on Tempo
- Live endpoint: `POST /api/coozie` at https://stablemerch-coozies.vercel.app
- Dynamic pricing: $10-$12 per coozie (6-pack discount at $10/each)
- Discovery document live at https://stablemerch-coozies.vercel.app/openapi.json

## Details
- Print fulfillment via Printify (Blueprint 951, dye-sublimation)
- Supports Regular Can and Slim Can sizes
- Optional commission support for referral agents
- Entry placed alphabetically between StableEmail and StableEnrich