### PR TITLE
fix: Ruby SDK docs — correct maintainer, gem name, sidebar, and links

### DIFF
--- a/src/pages/blog/go-and-ruby-sdks.mdx
+++ b/src/pages/blog/go-and-ruby-sdks.mdx
@@ -107,19 +107,19 @@ The middleware returns a `402` with a Challenge; the client handles it automatic
 Install:
 
 ```bash [terminal]
-$ gem install mpp
+$ gem install mpp-rb
 ```
 
 Or add to your Gemfile:
 
 ```ruby [Gemfile]
-gem "mpp"
+gem "mpp-rb"
 ```
 
 Charge for a route:
 
 ```ruby [server.rb]
-require "mpp"
+require "mpp-rb"
 
 server = Mpp.create(
   method: Mpp::Methods::Tempo.tempo(
@@ -149,7 +149,7 @@ end
 Make a paid request:
 
 ```ruby [client.rb]
-require "mpp"
+require "mpp-rb"
 
 account = Mpp::Methods::Tempo::Account.from_key(ENV.fetch("MPP_PRIVATE_KEY"))
 
@@ -167,7 +167,7 @@ transport = Mpp::Client::Transport.new(
 response = transport.request(:get, "https://api.example.com/paid")
 ```
 
-`mpp-rb` supports both Tempo and Stripe payment methods. It works with any Rack-based framework—Rails, Sinatra, or plain Rack. Full docs at [github.com/stripe/mpp-rb](https://github.com/stripe/mpp-rb). Ruby SDK reference docs are coming soon to [mpp.dev/sdk](/sdk).
+`mpp-rb` supports both Tempo and Stripe payment methods. It works with any Rack-based framework—Rails, Sinatra, or plain Rack. Full docs at [mpp.dev/sdk/ruby](/sdk/ruby).
 
 ## Get started
 

--- a/src/pages/sdk/features.mdx
+++ b/src/pages/sdk/features.mdx
@@ -9,7 +9,7 @@ This page tracks which features are implemented in each official SDK.
 
 ## Core
 
-| Component | [TypeScript](https://github.com/wevm/mppx) | [Rust](https://github.com/tempoxyz/mpp-rs) | [Python](https://github.com/tempoxyz/pympp) | [Ruby](https://github.com/tempoxyz/mpp-rb) |
+| Component | [TypeScript](https://github.com/wevm/mppx) | [Rust](https://github.com/tempoxyz/mpp-rs) | [Python](https://github.com/tempoxyz/pympp) | [Ruby](https://github.com/stripe/mpp-rb) |
 |---|---|---|---|---|
 | Client | ✓ | ✓ | ✓ | ✓ |
 | Server | ✓ | ✓ | ✓ | ✓ |

--- a/src/pages/sdk/ruby/index.mdx
+++ b/src/pages/sdk/ruby/index.mdx
@@ -11,8 +11,8 @@ import * as SdkBadge from '../../../components/SdkBadge'
 The `mpp-rb` Ruby gem provides a typed interface over the Machine Payments Protocol, from high-level abstractions to low-level primitives and building blocks.
 
 <div className="flex gap-2">
-  <SdkBadge.GitHub repo="tempoxyz/mpp-rb" />
-  <SdkBadge.Maintainer name="Tempo" href="https://github.com/tempoxyz" />
+  <SdkBadge.GitHub repo="stripe/mpp-rb" />
+  <SdkBadge.Maintainer name="Stripe" href="https://github.com/stripe" />
 </div>
 
 ## Install

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -836,6 +836,16 @@ export default defineConfig({
               { text: "Server", link: "/sdk/go/server" },
             ],
           },
+          {
+            text: "Ruby",
+            collapsed: true,
+            items: [
+              { text: "Overview", link: "/sdk/ruby" },
+              { text: "Core types", link: "/sdk/ruby/core" },
+              { text: "Client", link: "/sdk/ruby/client" },
+              { text: "Server", link: "/sdk/ruby/server" },
+            ],
+          },
         ],
       },
       {


### PR DESCRIPTION
- Change Ruby SDK maintainer from Tempo to Stripe (`stripe/mpp-rb`)
- Fix gem name from `mpp` to `mpp-rb` and `require` from `"mpp"` to `"mpp-rb"` in blog post
- Add Ruby to sidebar under Go
- Link blog post to `/sdk/ruby` instead of GitHub
- Fix Ruby GitHub link on features page