### PR TITLE
fix: update OG image text for Go and Ruby SDKs blog post

### DIFF
--- a/src/pages/blog/go-and-ruby-sdks.mdx
+++ b/src/pages/blog/go-and-ruby-sdks.mdx
@@ -5,7 +5,7 @@ showAskAi: false
 showFeedback: false
 showSearch: false
 description: "Two new MPP SDKs: `mpp-go` maintained by Tempo Labs and `mpp-rb` maintained by Stripe."
-imageDescription: "Accept stablecoin payments in Go and Ruby"
+imageDescription: "Process machine payments with Go and Ruby SDKs"
 ---
 
 <div className="blog-narrow">


### PR DESCRIPTION
Updates `imageDescription` from "Accept stablecoin payments in Go and Ruby" to "Process machine payments with Go and Ruby SDKs".