### PR TITLE
docs: migrate discovery docs to x-payment-info.offers[]

### DIFF
--- a/src/pages/_api/api/openapi.json.ts
+++ b/src/pages/_api/api/openapi.json.ts
@@ -3,7 +3,7 @@ import { mppx } from "../../../mppx.server";
 
 const USDCe = "0x20c000000000000000000000b9537d11c60e8b50";
 
-export const GET = discovery(mppx, {
+const discoveryRoute = discovery(mppx, {
   info: { title: "mpp.dev", version: "1.0.0" },
   routes: [
     {
@@ -25,3 +25,37 @@ export const GET = discovery(mppx, {
     },
   },
 });
+
+export async function GET(request: Request) {
+  const response = await discoveryRoute(request);
+  const document = (await response.json()) as Record<string, unknown>;
+
+  normalizeDiscoveryDocument(document);
+
+  return Response.json(document, {
+    headers: new Headers(response.headers),
+    status: response.status,
+  });
+}
+
+function normalizeDiscoveryDocument(document: Record<string, unknown>) {
+  const paths = document.paths;
+  if (!isRecord(paths)) return;
+
+  for (const pathItem of Object.values(paths)) {
+    if (!isRecord(pathItem)) continue;
+
+    for (const operation of Object.values(pathItem)) {
+      if (!isRecord(operation)) continue;
+
+      const paymentInfo = operation["x-payment-info"];
+      if (!isRecord(paymentInfo) || "offers" in paymentInfo) continue;
+
+      operation["x-payment-info"] = { offers: [paymentInfo] };
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -11,7 +11,7 @@ import { EcosystemDiagram } from '../../components/EcosystemDiagram'
 
 ## Overview
 
-MPP's discovery system lets clients and agents learn what your endpoints cost before making a request. You serve a standard [OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0) document at `/openapi.json` with `x-payment-info` extensions on each paid operation. Registries aggregate these documents so agents can find paid APIs automatically, and provide value added services like reputation, search, and analytics.
+MPP's discovery system lets clients and agents learn what your endpoints cost before making a request. You serve a standard [OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0) document at `/openapi.json` with `x-payment-info` extensions that advertise one or more payment offers for each paid operation. Registries aggregate these documents so agents can find paid APIs automatically, and provide value-added services like reputation, search, and analytics.
 
 <EcosystemDiagram />
 
@@ -58,7 +58,7 @@ discovery(app, mppx, { // [!code hl]
 }) // [!code hl]
 ```
 
-This generates a `GET /openapi.json` endpoint with `x-payment-info` on each paid route.
+This generates a `GET /openapi.json` endpoint with canonical `x-payment-info.offers[]` entries on each paid route.
 
 ### Express
 
@@ -105,7 +105,7 @@ export const GET = discovery(mppx, { // [!code hl]
 
 ## How it works
 
-Your server exposes a `GET /openapi.json` endpoint that returns an OpenAPI document. Paid operations include an `x-payment-info` extension with the payment terms, and the document root can include `x-service-info` for service-level metadata.
+Your server exposes a `GET /openapi.json` endpoint that returns an OpenAPI document. Paid operations include an `x-payment-info` extension with one or more payment offers, and the document root can include `x-service-info` for service-level metadata.
 
 ```json [/openapi.json]
 {
@@ -122,13 +122,24 @@ Your server exposes a `GET /openapi.json` endpoint that returns an OpenAPI docum
   "paths": {
     "/v1/generate": {
       "post": {
-        "x-payment-info": { // [!code highlight]
-          "amount": "1000000", // [!code highlight]
-          "currency": "0x20c0000000000000000000000000000000000001", // [!code highlight]
-          "description": "Generate text", // [!code highlight]
-          "intent": "charge", // [!code highlight]
-          "method": "tempo" // [!code highlight]
-        }, // [!code highlight]
+        "x-payment-info": {
+          "offers": [
+            {
+              "amount": "1000000",
+              "currency": "0x20c0000000000000000000000000000000000001",
+              "description": "Generate text with Tempo",
+              "intent": "charge",
+              "method": "tempo"
+            },
+            {
+              "amount": "100",
+              "currency": "usd",
+              "description": "Generate text with Stripe",
+              "intent": "charge",
+              "method": "stripe"
+            }
+          ]
+        },
         "responses": {
           "200": { "description": "Successful response" },
           "402": { "description": "Payment Required" }
@@ -148,15 +159,37 @@ Your server exposes a `GET /openapi.json` endpoint that returns an OpenAPI docum
 
 ### `x-payment-info`
 
-Added to any operation that requires payment:
+Add this extension to any operation that requires payment. Prefer the canonical multi-offer shape:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `amount` | `string` | Payment amount in base units |
+| `offers` | `Offer[]` | Ordered list of payment offers the client can choose from |
+
+#### `offers[]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `amount` | `string \| null` | Payment amount in base units |
 | `currency` | `string` | Currency code or token address |
 | `description` | `string` | Human-readable description of the charge |
 | `intent` | `string` | Payment intent (`charge` or `session`) |
 | `method` | `string` | Payment method identifier (`tempo`, `stripe`) |
+
+:::note[Compatibility shorthand]
+The flat single-offer form is still valid as shorthand for older emitters, but use it only for backward compatibility. New documents should write the same data under `offers[]`.
+
+```json [openapi.json]
+{
+  "x-payment-info": {
+    "amount": "1000000",
+    "currency": "0x20c0000000000000000000000000000000000001",
+    "description": "Generate text with Tempo",
+    "intent": "charge",
+    "method": "tempo"
+  }
+}
+```
+:::
 
 ### `x-service-info`
 
@@ -192,7 +225,7 @@ Start with a standard OpenAPI 3.1 document:
 
 #### Add `x-payment-info` to paid operations
 
-For each endpoint that requires payment, add the `x-payment-info` extension. Amounts are in base units (for example, `1000000` for $1.00 with 6 decimals).
+For each endpoint that requires payment, add the `x-payment-info` extension with an `offers` array. Add more objects to `offers[]` when the client can choose between alternative payment methods or currencies. Amounts are in base units (for example, `1000000` for $1.00 with 6 decimals).
 
 ```json [openapi.json]
 {
@@ -200,12 +233,16 @@ For each endpoint that requires payment, add the `x-payment-info` extension. Amo
     "/v1/generate": {
       "post": {
         "summary": "Generate text",
-        "x-payment-info": { // [!code highlight]
-          "amount": "1000000", // [!code highlight]
-          "currency": "0x20c0000000000000000000000000000000000001", // [!code highlight]
-          "intent": "charge", // [!code highlight]
-          "method": "tempo" // [!code highlight]
-        }, // [!code highlight]
+        "x-payment-info": {
+          "offers": [
+            {
+              "amount": "1000000",
+              "currency": "0x20c0000000000000000000000000000000000001",
+              "intent": "charge",
+              "method": "tempo"
+            }
+          ]
+        },
         "responses": {
           "200": { "description": "Successful response" },
           "402": { "description": "Payment Required" }
@@ -270,7 +307,7 @@ Common validation issues:
 | Issue | Severity | Description |
 |-------|----------|-------------|
 | Missing `402` response | Error | Operations with `x-payment-info` must include a `402` response |
-| Invalid amount format | Error | `amount` must be a non-negative integer string |
+| Invalid amount format | Error | Each `offers[].amount` value must be a non-negative integer string |
 | Missing `requestBody` | Warning | `POST`/`PUT`/`PATCH` operations without a `requestBody` definition |
 | Invalid URI in docs | Error | `docs` links must be valid URIs or absolute paths |
 

--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -52,10 +52,12 @@ const mppx = Mppx.create({
 
 app.get('/v1/fortune', mppx.charge({ amount: '0.01' }), (c) => c.json({ fortune: 'You will be rich' }))
 
-discovery(app, mppx, { // [!code hl]
-  auto: true, // [!code hl]
-  info: { title: 'Fortune API', version: '1.0.0' }, // [!code hl]
-}) // [!code hl]
+// [!code hl:start]
+discovery(app, mppx, {
+  auto: true,
+  info: { title: 'Fortune API', version: '1.0.0' },
+})
+// [!code hl:end]
 ```
 
 This generates a `GET /openapi.json` endpoint with canonical `x-payment-info.offers[]` entries on each paid route.
@@ -83,10 +85,12 @@ const mppx = Mppx.create({
 const pay = mppx.charge({ amount: '0.01' })
 app.get('/v1/fortune', pay, (req, res) => res.json({ fortune: 'You will be rich' }))
 
-discovery(app, mppx, { // [!code hl]
-  info: { title: 'Fortune API', version: '1.0.0' }, // [!code hl]
-  routes: [{ handler: pay, method: 'get', path: '/v1/fortune' }], // [!code hl]
-}) // [!code hl]
+// [!code hl:start]
+discovery(app, mppx, {
+  info: { title: 'Fortune API', version: '1.0.0' },
+  routes: [{ handler: pay, method: 'get', path: '/v1/fortune' }],
+})
+// [!code hl:end]
 ```
 
 ### Next.js
@@ -97,10 +101,12 @@ In Next.js, `discovery()` returns a route handler you export from an API route.
 import { discovery } from 'mppx/nextjs'
 import { mppx, pay } from '../fortune/route'
 
-export const GET = discovery(mppx, { // [!code hl]
-  info: { title: 'Fortune API', version: '1.0.0' }, // [!code hl]
-  routes: [{ handler: pay, method: 'get', path: '/api/fortune' }], // [!code hl]
-}) // [!code hl]
+// [!code hl:start]
+export const GET = discovery(mppx, {
+  info: { title: 'Fortune API', version: '1.0.0' },
+  routes: [{ handler: pay, method: 'get', path: '/api/fortune' }],
+})
+// [!code hl:end]
 ```
 
 ## How it works
@@ -122,6 +128,7 @@ Your server exposes a `GET /openapi.json` endpoint that returns an OpenAPI docum
   "paths": {
     "/v1/generate": {
       "post": {
+        // [!code hl:start]
         "x-payment-info": {
           "offers": [
             {
@@ -140,6 +147,7 @@ Your server exposes a `GET /openapi.json` endpoint that returns an OpenAPI docum
             }
           ]
         },
+        // [!code hl:end]
         "responses": {
           "200": { "description": "Successful response" },
           "402": { "description": "Payment Required" }
@@ -180,6 +188,7 @@ The flat single-offer form is still valid as shorthand for older emitters, but u
 
 ```json [openapi.json]
 {
+  // [!code hl:start]
   "x-payment-info": {
     "amount": "1000000",
     "currency": "0x20c0000000000000000000000000000000000001",
@@ -187,6 +196,7 @@ The flat single-offer form is still valid as shorthand for older emitters, but u
     "intent": "charge",
     "method": "tempo"
   }
+  // [!code hl:end]
 }
 ```
 :::
@@ -233,6 +243,7 @@ For each endpoint that requires payment, add the `x-payment-info` extension with
     "/v1/generate": {
       "post": {
         "summary": "Generate text",
+        // [!code hl:start]
         "x-payment-info": {
           "offers": [
             {
@@ -243,6 +254,7 @@ For each endpoint that requires payment, add the `x-payment-info` extension with
             }
           ]
         },
+        // [!code hl:end]
         "responses": {
           "200": { "description": "Successful response" },
           "402": { "description": "Payment Required" }
@@ -263,14 +275,16 @@ Add service-level metadata to the document root:
 
 ```json [openapi.json]
 {
-  "x-service-info": { // [!code highlight]
-    "categories": ["ai", "text-generation"], // [!code highlight]
-    "docs": { // [!code highlight]
-      "homepage": "https://example.com", // [!code highlight]
-      "apiReference": "https://example.com/docs/api", // [!code highlight]
-      "llms": "https://example.com/llms.txt" // [!code highlight]
-    } // [!code highlight]
-  } // [!code highlight]
+  // [!code hl:start]
+  "x-service-info": {
+    "categories": ["ai", "text-generation"],
+    "docs": {
+      "homepage": "https://example.com",
+      "apiReference": "https://example.com/docs/api",
+      "llms": "https://example.com/llms.txt"
+    }
+  }
+  // [!code hl:end]
 }
 ```
 

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -314,7 +314,9 @@ discovery(app, mppx, { // [!code hl]
 }) // [!code hl]
 ```
 
-Register your service on [MPPScan](https://mppscan.com) or the [MPP Services directory](/services) so agents and registries can discover it. See [Discovery](/advanced/discovery) for the full guide.
+The generated document advertises each paid route with canonical `x-payment-info.offers[]` entries. See [Discovery](/advanced/discovery) for the full document shape, multi-offer examples, and flat-shorthand compatibility notes.
+
+Register your service on [MPPScan](https://mppscan.com) or the [MPP Services directory](/services) so agents and registries can discover it.
 
 ## Testing your server
 

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -308,10 +308,12 @@ const mppx = Mppx.create({
 
 app.get('/resource', mppx.charge({ amount: '0.1' }), (c) => c.json({ data: '...' }))
 
-discovery(app, mppx, { // [!code hl]
-  auto: true, // [!code hl]
-  info: { title: 'My API', version: '1.0.0' }, // [!code hl]
-}) // [!code hl]
+// [!code hl:start]
+discovery(app, mppx, {
+  auto: true,
+  info: { title: 'My API', version: '1.0.0' },
+})
+// [!code hl:end]
 ```
 
 The generated document advertises each paid route with canonical `x-payment-info.offers[]` entries. See [Discovery](/advanced/discovery) for the full document shape, multi-offer examples, and flat-shorthand compatibility notes.


### PR DESCRIPTION
## Summary
- update the discovery guide to prefer canonical `x-payment-info.offers[]` and document the old flat form as compatibility shorthand only
- keep the quickstart discovery section small and point to the advanced discovery page for the full multi-offer model
- normalize the docs site's own `/api/openapi.json` output to canonical `offers[]` so the dogfood example matches the new guidance
