### PR TITLE
docs: clarify payment auth request and opaque encoding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,13 @@ Current protocol context from this repo:
 - Receipts acknowledge successful payment
 - Transports include HTTP and MCP
 
+When documenting HTTP Payment auth parameters, follow `paymentauth.org` as the source of truth:
+
+- `request` and `opaque` are base64url-encoded JCS JSON on the wire
+- In the credential `challenge` object, `opaque` is a `string`, not an expanded JSON object
+- Clients MUST return `id` unchanged and MUST return `opaque` unchanged when present
+- Challenge binding includes `opaque` as the final optional slot, using an empty string when absent
+
 ## File Location
 
 Reference pages live under `src/pages/sdk/typescript/`:

--- a/src/pages/guides/monetize-mcp-server.mdx
+++ b/src/pages/guides/monetize-mcp-server.mdx
@@ -38,6 +38,10 @@ Add per-call payments to any [MCP](https://modelcontextprotocol.io) server. When
 
 This maps directly to the standard MPP challenge → credential → receipt flow, encoded as JSON-RPC instead of HTTP headers. See the [MCP transport spec](/protocol/transports/mcp) for the full encoding.
 
+:::info
+This guide uses the MCP transport, so Challenge, Credential, and Receipt data travel as native JSON in `error.data` and `_meta`. The base64url-encoded `request` and `opaque` auth-params apply to the HTTP transport.
+:::
+
 ## Prompt mode
 
 Paste this into your coding agent to build a paid MCP server in one prompt:

--- a/src/pages/protocol/challenges.mdx
+++ b/src/pages/protocol/challenges.mdx
@@ -14,6 +14,7 @@ WWW-Authenticate: Payment id="qB3wErTyU7iOpAsD9fGhJk",
     method="tempo",
     intent="charge",
     expires="2025-01-15T12:05:00Z",
+    opaque="eyJyb3V0ZSI6Ii92MS9zZWFyY2gifQ",
     request="eyJhbW91bnQiOiIxMDAwIiwiY3VycmVuY3kiOiJ1c2QifQ"
 ```
 
@@ -25,7 +26,7 @@ WWW-Authenticate: Payment id="qB3wErTyU7iOpAsD9fGhJk",
 | `realm` | Protection space identifier (typically the API domain) |
 | `method` | Payment method identifier (such as `tempo` or `stripe`) |
 | `intent` | Payment intent type (such as `charge` or `session`) |
-| `request` | Base64url-encoded JSON with payment details |
+| `request` | Base64url-encoded JCS JSON with payment details |
 
 ### Optional parameters
 
@@ -33,10 +34,15 @@ WWW-Authenticate: Payment id="qB3wErTyU7iOpAsD9fGhJk",
 |-----------|-------------|
 | `expires` | ISO 8601 timestamp when the challenge expires |
 | `description` | Human-readable description of what's being paid for |
+| `opaque` | Base64url-encoded JCS JSON for server-defined correlation data |
+
+## `request` and `opaque` encoding
+
+In HTTP headers, both `request` and `opaque` use base64url-encoded [JCS](https://www.rfc-editor.org/rfc/rfc8785) JSON strings. Parse them after header processing to recover the structured values.
 
 ## `request` object
 
-The `request` parameter contains method-specific payment details encoded as base64url JSON:
+The `request` parameter contains method-specific payment details encoded as base64url JCS JSON:
 
 ```json [Decoded request object]
 {
@@ -45,6 +51,16 @@ The `request` parameter contains method-specific payment details encoded as base
   "recipient": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 }
 ```
+
+Servers can also attach correlation data in `opaque`:
+
+```json [Decoded opaque object]
+{
+  "route": "/v1/search"
+}
+```
+
+Clients must echo `opaque` back unchanged when they submit a Credential.
 
 Common fields across payment methods:
 
@@ -75,8 +91,12 @@ Challenges must be cryptographically bound to their parameters through the `id` 
 Typical binding includes:
 
 - `realm`, `method`, `intent`
-- Hash of the `request` object
-- `expires` timestamp
+- `request`
+- `expires`
+- `digest`
+- `opaque`
+
+For HMAC-bound IDs, the canonical input sequence is `realm | method | intent | request | expires | digest | opaque`. When `expires`, `digest`, or `opaque` is absent, use an empty string for that slot.
 
 Use an [HMAC-bound](https://en.wikipedia.org/wiki/HMAC) challenge ID to prevent clients from reusing a challenge ID with modified payment terms.
 

--- a/src/pages/protocol/credentials.mdx
+++ b/src/pages/protocol/credentials.mdx
@@ -17,20 +17,23 @@ The credential is a base64url-encoded JSON object:
 ```json
 {
   "challenge": {
+    "expires": "2025-01-15T12:05:00Z",
     "id": "qB3wErTyU7iOpAsD9fGhJk",
-    "realm": "mpp.dev",
-    "method": "tempo",
     "intent": "charge",
+    "method": "tempo",
+    "opaque": "eyJyb3V0ZSI6Ii92MS9zZWFyY2gifQ",
+    "realm": "mpp.dev",
     "request": "eyJhbW91bnQiOiIxMDAwIi4uLn0",
-    "expires": "2025-01-15T12:05:00Z"
   },
-  "source": "did:pkh:eip155:4217:0x1234567890abcdef...",
   "payload": {
-    "type": "transaction",
-    "signature": "0xabc123..."
-  }
+    "signature": "0xabc123...",
+    "type": "transaction"
+  },
+  "source": "did:pkh:eip155:4217:0x1234567890abcdef..."
 }
 ```
+
+The echoed Challenge keeps the original HTTP wire values. In a Credential, `challenge.request` and `challenge.opaque` remain the same base64url-encoded JCS JSON strings from the `WWW-Authenticate` header.
 
 ### Fields
 
@@ -67,16 +70,17 @@ Tempo charge currently uses three Credential payload shapes:
 {
   "challenge": {
     "id": "zL4xCvBnM6kJhGfD8sAaWe",
-    "realm": "mpp.dev",
-    "method": "tempo",
     "intent": "charge",
+    "method": "tempo",
+    "opaque": "eyJyb3V0ZSI6Ii92MS9zZWFyY2gifQ",
+    "realm": "mpp.dev",
     "request": "eyJhbW91bnQiOiI1MDAwIiwiY3VycmVuY3kiOiJ1c2QiLCJyZWNpcGllbnQiOiIweDc0MmQzNUNjNjYzNEMwNTMyOTI1YTNiODQ0QmM5ZTc1OTVmOGZFMDAifQ"
   },
-  "source": "did:pkh:eip155:4217:0x1234567890abcdef1234567890abcdef12345678",
   "payload": {
-    "type": "transaction",
-    "signature": "0x1b2c3d4e5f6a7b8c9d0e..."
-  }
+    "signature": "0x1b2c3d4e5f6a7b8c9d0e...",
+    "type": "transaction"
+  },
+  "source": "did:pkh:eip155:4217:0x1234567890abcdef1234567890abcdef12345678"
 }
 ```
 

--- a/src/pages/protocol/transports/http.mdx
+++ b/src/pages/protocol/transports/http.mdx
@@ -63,7 +63,7 @@ Content-Type: application/json
 
 ## Header encoding
 
-Challenges are encoded as [auth-params](https://www.rfc-editor.org/rfc/rfc9110#section-11.2) in `WWW-Authenticate`. Credentials and receipts use base64url-encoded JSON.
+Challenges are encoded as [auth-params](https://www.rfc-editor.org/rfc/rfc9110#section-11.2) in `WWW-Authenticate`. The `request` and `opaque` auth-params use base64url-encoded JCS JSON strings. Credentials echo those same challenge values inside the base64url-encoded `Authorization` payload, and receipts use base64url-encoded JSON in `Payment-Receipt`.
 
 ## Full specification
 

--- a/src/pages/sdk/go/core.mdx
+++ b/src/pages/sdk/go/core.mdx
@@ -26,6 +26,8 @@ fmt.Println("Method:", challenge.Method)
 fmt.Println("Intent:", challenge.Intent)
 ```
 
+On the wire, `request` and optional `opaque` are base64url-encoded JSON strings in the `WWW-Authenticate` header. `ParseChallenge` decodes them into structured fields for application code.
+
 ## Create and serialize a Credential
 
 Build a `Credential` from a Challenge echo and payment proof:
@@ -43,6 +45,8 @@ credential := &mpp.Credential{
 header := credential.ToAuthorization()
 // header = "Payment eyJ..."
 ```
+
+`challenge.ToEcho()` preserves the original wire values. In the serialized Credential, `challenge.request` and `challenge.opaque` remain base64url strings inside the `Authorization` payload.
 
 ## Parse and serialize a Receipt
 

--- a/src/pages/sdk/python/core.mdx
+++ b/src/pages/sdk/python/core.mdx
@@ -18,6 +18,8 @@ challenge = Challenge.from_www_authenticate(
 )
 ```
 
+On the wire, `request` and optional `opaque` are base64url-encoded JSON strings in the `WWW-Authenticate` header. `Challenge.from_www_authenticate(...)` decodes them for application code.
+
 ## Create and serialize a Credential
 
 ```python
@@ -29,6 +31,8 @@ credential = Credential(
 
 header = credential.to_authorization()
 ```
+
+When a Credential echoes a Challenge, `challenge.request` and `challenge.opaque` stay in their base64url string form inside the serialized `Authorization` payload.
 
 ## Parse and serialize a Receipt
 

--- a/src/pages/sdk/rust/core.mdx
+++ b/src/pages/sdk/rust/core.mdx
@@ -24,6 +24,8 @@ println!("Method: {}", challenge.method);
 println!("Intent: {}", challenge.intent);
 ```
 
+On the wire, `request` and optional `opaque` are base64url-encoded JSON strings in the `WWW-Authenticate` header. `mpp-rs` stores them as `Base64UrlJson`, so you can decode them when you need structured values.
+
 Decode the base64url-encoded request to a typed struct:
 
 ```rust
@@ -49,6 +51,8 @@ let credential = PaymentCredential::with_source(
 let header = format_authorization(&credential)?;
 // header = "Payment eyJ..."
 ```
+
+`challenge.to_echo()` preserves the original wire values. In the serialized Credential, `challenge.request` and `challenge.opaque` remain base64url strings inside the `Authorization` payload.
 
 ## Parse a Receipt
 

--- a/src/pages/sdk/typescript/core/Challenge.deserialize.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.deserialize.mdx
@@ -29,7 +29,7 @@ const challenge = Challenge.deserialize(header, { methods: [Methods.charge] })
 type ReturnType = Challenge
 ```
 
-The deserialized Challenge object. If the serialized header contains an `opaque` parameter, it is deserialized and stored as `opaque` on the Challenge (accessible via `Challenge.meta`).
+The deserialized Challenge object. `mppx` decodes `request` and `opaque` from their base64url-encoded JCS strings back to structured values. If the serialized header contains an `opaque` parameter, the parsed value is accessible via `Challenge.meta`.
 
 ## Parameters
 

--- a/src/pages/sdk/typescript/core/Challenge.from.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.from.mdx
@@ -2,7 +2,7 @@
 
 Creates a challenge from the given parameters.
 
-If `secretKey` option is provided, the challenge ID is computed as HMAC-SHA256 over the challenge parameters (realm|method|intent|request|expires|digest|opaque), cryptographically binding the ID to its contents.
+If `secretKey` option is provided, the challenge ID is computed as HMAC-SHA256 over the challenge parameters (realm|method|intent|request|expires|digest|opaque), cryptographically binding the ID to its contents. When `expires`, `digest`, or `opaque` is absent, that slot is an empty string.
 
 Load `secretKey` from your server environment or secret manager. Do not ship it to clients.
 
@@ -89,7 +89,7 @@ Intent type (for example, `"charge"`, `"session"`).
 
 - **Type:** `Record<string, string>`
 
-Server-defined correlation data, serialized as `opaque` on the Challenge.
+Server-defined correlation data. `mppx` serializes it as the base64url-encoded `opaque` auth-param in HTTP Challenges.
 
 #### method
 
@@ -107,7 +107,7 @@ Server realm (for example, hostname).
 
 - **Type:** `Record<string, unknown>`
 
-Method-specific request data.
+Method-specific request data. `mppx` serializes it as base64url-encoded JCS JSON in the HTTP `request` auth-param.
 
 #### secretKey (when not using id)
 

--- a/src/pages/sdk/typescript/core/Challenge.fromMethod.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.fromMethod.mdx
@@ -75,7 +75,7 @@ Explicit challenge ID.
 
 - **Type:** `Record<string, string>`
 
-Server-defined correlation data. Serialized as `opaque` on the Challenge.
+Server-defined correlation data. `mppx` serializes it as the base64url-encoded `opaque` auth-param in HTTP Challenges.
 
 #### realm
 
@@ -87,7 +87,7 @@ Server realm (for example, hostname).
 
 - **Type:** `z.input<method['schema']['request']>`
 
-Method-specific request data, validated against the method's schema.
+Method-specific request data, validated against the method's schema. `mppx` serializes it as base64url-encoded JCS JSON in the HTTP `request` auth-param.
 
 #### secretKey (when not using id)
 

--- a/src/pages/sdk/typescript/core/Challenge.meta.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.meta.mdx
@@ -20,6 +20,8 @@ type ReturnType = Record<string, string> | undefined
 
 The `opaque` field from the Challenge, or `undefined` if not set.
 
+On HTTP transport, the same data travels in the `opaque` auth-param as base64url-encoded JCS JSON.
+
 ## Parameters
 
 ### challenge

--- a/src/pages/sdk/typescript/core/Challenge.serialize.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.serialize.mdx
@@ -27,7 +27,7 @@ type ReturnType = string
 
 A string suitable for the WWW-Authenticate header value.
 
-The serialized string includes optional fields when present: `description`, `digest`, `expires`, and `opaque` (server-defined correlation data set via `meta` in `Challenge.from`).
+The serialized string includes optional fields when present: `description`, `digest`, `expires`, and `opaque` (server-defined correlation data set via `meta` in `Challenge.from`). In HTTP headers, `request` and `opaque` are emitted as base64url-encoded JCS JSON strings.
 
 ## Parameters
 

--- a/src/pages/sdk/typescript/core/Credential.deserialize.mdx
+++ b/src/pages/sdk/typescript/core/Credential.deserialize.mdx
@@ -19,6 +19,8 @@ type ReturnType = Credential<payload>
 
 The deserialized credential object.
 
+`mppx` parses the echoed Challenge inside the Credential, decoding `request` and `opaque` from their base64url-encoded wire strings back to structured values for application code.
+
 ## Parameters
 
 ### value

--- a/src/pages/sdk/typescript/core/Credential.serialize.mdx
+++ b/src/pages/sdk/typescript/core/Credential.serialize.mdx
@@ -32,6 +32,8 @@ type ReturnType = string
 
 A string suitable for the Authorization header value.
 
+When the Credential includes an echoed Challenge, `mppx` keeps the HTTP wire format intact: `challenge.request` and `challenge.opaque` serialize as the same base64url-encoded strings that came from the Challenge header.
+
 ## Parameters
 
 ### credential

--- a/src/pages/sdk/typescript/core/PaymentRequest.deserialize.mdx
+++ b/src/pages/sdk/typescript/core/PaymentRequest.deserialize.mdx
@@ -1,6 +1,6 @@
 # `PaymentRequest.deserialize` [Deserialize a payment request]
 
-Deserializes a base64url string to a payment request.
+Deserializes a base64url JCS string to a payment request.
 
 ## Usage
 
@@ -25,4 +25,4 @@ The deserialized request object.
 
 - **Type:** `string`
 
-The base64url-encoded string.
+The base64url-encoded JCS string.

--- a/src/pages/sdk/typescript/core/PaymentRequest.serialize.mdx
+++ b/src/pages/sdk/typescript/core/PaymentRequest.serialize.mdx
@@ -1,6 +1,6 @@
 # `PaymentRequest.serialize` [Serialize a payment request to a string]
 
-Serializes a payment request to a base64url string.
+Serializes a payment request to a base64url JCS string.
 
 ## Usage
 
@@ -23,7 +23,7 @@ const serialized = PaymentRequest.serialize(request)
 type ReturnType = string
 ```
 
-A base64url-encoded string (no padding).
+A base64url-encoded JCS string (no padding).
 
 ## Parameters
 

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -270,7 +270,7 @@ ISO 8601 timestamp for when the payment challenge expires.
 
 - **Type:** `Record<string, string>`
 
-Server-defined correlation data, serialized as `opaque` on the Challenge.
+Server-defined correlation data. `mppx` serializes it as the base64url-encoded `opaque` auth-param on the Challenge, and clients echo that same string back in the Credential.
 
 ### recipient
 


### PR DESCRIPTION
## Summary
- document the HTTP wire format for `request` and `opaque` across the protocol pages and TypeScript references
- clarify that credentials echo `challenge.opaque` as the original base64url string, not an expanded object
- align the Rust, Python, and Go SDK docs with the behavior already implemented in their SDKs
- update `AGENTS.md` so future docs work follows the same normative rules
