### PR TITLE
expose docs tools with WebMCP

### DIFF
--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,45 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://mpp.dev/.well-known/api-catalog",
+      "item": [
+        {
+          "href": "https://mpp.dev/api/mcp",
+          "title": "MPP documentation MCP server",
+          "type": "text/event-stream"
+        }
+      ]
+    },
+    {
+      "anchor": "https://mpp.dev/api/mcp",
+      "service-desc": [
+        {
+          "href": "https://mpp.dev/.well-known/mcp.json",
+          "title": "MCP server card",
+          "type": "application/json"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://mpp.dev/guides/building-with-an-llm",
+          "title": "Build with an LLM",
+          "type": "text/html"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://mpp.dev/api/ping",
+          "title": "Service status",
+          "type": "text/plain"
+        }
+      ],
+      "service-meta": [
+        {
+          "href": "https://mpp.dev/.well-known/agent-skills/index.json",
+          "title": "Agent Skills discovery index",
+          "type": "application/json"
+        }
+      ]
+    }
+  ]
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,7 @@
 User-agent: *
 Allow: /
 
-Content-Signal: ai-train=yes, ai-input=yes, search=yes
+Content-Signal: ai-train=no, search=yes, ai-input=no
 
 User-agent: ClaudeBot
 Allow: /

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -425,6 +425,295 @@ function useLogoFullReload() {
   }, []);
 }
 
+interface WebMcpTool {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (input: Record<string, unknown>) => Promise<unknown>;
+  annotations?: {
+    readOnlyHint?: boolean;
+    untrustedContentHint?: boolean;
+  };
+}
+
+interface ModelContext {
+  provideContext?: (context: { tools: WebMcpTool[] }) => void;
+  registerTool?: (tool: WebMcpTool, options?: { signal?: AbortSignal }) => void;
+}
+
+declare global {
+  interface Navigator {
+    modelContext?: ModelContext;
+  }
+}
+
+type ServiceRecord = {
+  id: string;
+  name: string;
+  url: string;
+  serviceUrl?: string;
+  description?: string;
+  categories?: string[];
+  tags?: string[];
+  endpoints?: Array<{
+    method: string;
+    path: string;
+    description?: string;
+    payment?: {
+      intent?: string;
+      amount?: string;
+      decimals?: number;
+      currency?: string;
+      dynamic?: true;
+      amountHint?: string;
+    } | null;
+  }>;
+};
+
+function docToolsReadOnly() {
+  return { readOnlyHint: true, untrustedContentHint: false };
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const response = await fetch(path);
+  if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+  return response.json() as Promise<T>;
+}
+
+async function fetchServicesForTools(): Promise<ServiceRecord[]> {
+  const data = await fetchJson<{ services: ServiceRecord[] }>("/api/services");
+  return data.services;
+}
+
+function normalizeToolPath(value: unknown): string {
+  const path = String(value ?? "").trim();
+  if (!path) return "/";
+  if (path.startsWith("http://") || path.startsWith("https://")) {
+    const url = new URL(path);
+    return `${url.pathname}${url.search}${url.hash}` || "/";
+  }
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+function serviceToolSummary(service: ServiceRecord) {
+  const endpoints = service.endpoints ?? [];
+  return {
+    id: service.id,
+    name: service.name,
+    url: service.url,
+    serviceUrl: service.serviceUrl,
+    description: service.description,
+    categories: service.categories ?? [],
+    tags: service.tags ?? [],
+    endpointCount: endpoints.length,
+    paidEndpointCount: endpoints.filter((endpoint) => endpoint.payment).length,
+    endpoints: endpoints.map((endpoint) => ({
+      method: endpoint.method,
+      path: endpoint.path,
+      description: endpoint.description,
+      payment: endpoint.payment
+        ? {
+            intent: endpoint.payment.intent,
+            amount: endpoint.payment.amount,
+            amountHint:
+              endpoint.payment.amountHint ??
+              (endpoint.payment.dynamic ? "dynamic" : undefined),
+            currency: endpoint.payment.currency,
+          }
+        : null,
+    })),
+  };
+}
+
+function createWebMcpTools(): WebMcpTool[] {
+  const readOnly = docToolsReadOnly();
+
+  return [
+    {
+      name: "mpp.search_docs",
+      title: "Search MPP docs",
+      description:
+        "Search the MPP documentation index for pages about protocol concepts, SDKs, guides, payment methods, and services.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Case-insensitive search text.",
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+      annotations: readOnly,
+      async execute(input) {
+        const query = String(input.query ?? "")
+          .trim()
+          .toLowerCase();
+        if (!query) throw new Error("query is required");
+
+        const response = await fetch("/llms.txt");
+        if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+        const text = await response.text();
+        const matches = text
+          .split("\n")
+          .map((line) => line.trim())
+          .filter((line) => line.toLowerCase().includes(query))
+          .slice(0, 20);
+
+        return { query, matches };
+      },
+    },
+    {
+      name: "mpp.open_page",
+      title: "Open MPP docs page",
+      description:
+        "Navigate the browser to an MPP documentation path, such as /quickstart/client, /sdk/typescript, or /advanced/discovery.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Docs path or mpp.dev URL to open.",
+          },
+        },
+        required: ["path"],
+        additionalProperties: false,
+      },
+      async execute(input) {
+        const path = normalizeToolPath(input.path);
+        window.history.pushState({}, "", path);
+        window.dispatchEvent(new PopStateEvent("popstate"));
+        return { opened: true, path };
+      },
+    },
+    {
+      name: "mpp.list_services",
+      title: "List MPP services",
+      description:
+        "List services available through MPP, including ids, names, categories, service URLs, and endpoint counts.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Optional case-insensitive filter across service id, name, description, categories, tags, and endpoint paths.",
+          },
+        },
+        additionalProperties: false,
+      },
+      annotations: readOnly,
+      async execute(input) {
+        const query = String(input.query ?? "")
+          .trim()
+          .toLowerCase();
+        const services = await fetchServicesForTools();
+        const filtered = query
+          ? services.filter((service) =>
+              [
+                service.id,
+                service.name,
+                service.description,
+                service.serviceUrl,
+                ...(service.categories ?? []),
+                ...(service.tags ?? []),
+                ...(service.endpoints ?? []).map(
+                  (endpoint) =>
+                    `${endpoint.method} ${endpoint.path} ${endpoint.description ?? ""}`,
+                ),
+              ]
+                .join(" ")
+                .toLowerCase()
+                .includes(query),
+            )
+          : services;
+
+        return filtered.map((service) => {
+          const endpoints = service.endpoints ?? [];
+          return {
+            id: service.id,
+            name: service.name,
+            serviceUrl: service.serviceUrl,
+            description: service.description,
+            categories: service.categories ?? [],
+            endpointCount: endpoints.length,
+            paidEndpointCount: endpoints.filter((endpoint) => endpoint.payment)
+              .length,
+          };
+        });
+      },
+    },
+    {
+      name: "mpp.get_service",
+      title: "Get MPP service",
+      description:
+        "Return endpoint and payment details for one service in the MPP service catalog.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          serviceId: {
+            type: "string",
+            description:
+              "Service id, such as openai, anthropic, exa, or storage.",
+          },
+        },
+        required: ["serviceId"],
+        additionalProperties: false,
+      },
+      annotations: readOnly,
+      async execute(input) {
+        const serviceId = String(input.serviceId ?? "")
+          .trim()
+          .toLowerCase();
+        if (!serviceId) throw new Error("serviceId is required");
+
+        const services = await fetchServicesForTools();
+        const service = services.find((item) => item.id === serviceId);
+        if (!service) throw new Error(`Unknown service: ${serviceId}`);
+        return serviceToolSummary(service);
+      },
+    },
+    {
+      name: "mpp.get_api_catalog",
+      title: "Get MPP API catalog",
+      description:
+        "Return the RFC 9727 API catalog with links to MPP machine-readable descriptions, documentation, and status endpoints.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      annotations: readOnly,
+      async execute() {
+        return fetchJson("/.well-known/api-catalog");
+      },
+    },
+  ];
+}
+
+function useWebMcpTools() {
+  useEffect(() => {
+    const modelContext = navigator.modelContext;
+    if (!modelContext) return;
+
+    const tools = createWebMcpTools();
+    if (typeof modelContext.provideContext === "function") {
+      modelContext.provideContext({ tools });
+      return () => modelContext.provideContext?.({ tools: [] });
+    }
+
+    if (typeof modelContext.registerTool === "function") {
+      const controller = new AbortController();
+      for (const tool of tools) {
+        modelContext.registerTool(tool, { signal: controller.signal });
+      }
+      return () => controller.abort();
+    }
+  }, []);
+}
+
 export default function Layout(
   props: React.PropsWithChildren<{
     path: string;
@@ -433,6 +722,7 @@ export default function Layout(
   usePostHog();
   useGoogleAnalytics();
   useLogoFullReload();
+  useWebMcpTools();
 
   const ahrefsKey = import.meta.env.VITE_AHREFS_VERIFICATION;
 

--- a/vercel.mjs
+++ b/vercel.mjs
@@ -12,6 +12,20 @@ const OPENAPI_DISCOVERY_LINK_VALUE = [
   '</.well-known/agent-skills/index.json>; rel="describedby"; type="application/json"',
 ].join(", ");
 
+const API_CATALOG_HEADERS = [
+  header("Access-Control-Allow-Origin", "*"),
+  header("Cache-Control", "public, max-age=300"),
+  header(
+    "Content-Type",
+    'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+  ),
+  header(
+    "Link",
+    '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+  ),
+  header("X-Content-Type-Options", "nosniff"),
+];
+
 const CACHE_HEADERS = [
   header("Cache-Control", "public, max-age=300"),
   header("X-Content-Type-Options", "nosniff"),
@@ -37,6 +51,7 @@ const DISCOVERY_PAGE_SOURCES = [
 
 export const config = {
   headers: [
+    headerRule("/.well-known/api-catalog", API_CATALOG_HEADERS),
     headerRule("/.well-known/:path*", [
       header("Access-Control-Allow-Origin", "*"),
       ...CACHE_HEADERS,
@@ -46,12 +61,6 @@ export const config = {
     ...DISCOVERY_PAGE_SOURCES.map((source) =>
       headerRule(source, [header("Link", DOC_DISCOVERY_LINK_VALUE)]),
     ),
-  ],
-  rewrites: [
-    {
-      source: "/.well-known/api-catalog",
-      destination: "/api/api-catalog",
-    },
   ],
   redirects: [
     {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,6 @@
 import * as child_process from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import react from "@vitejs/plugin-react";
 import Icons from "unplugin-icons/vite";
 import type { Plugin } from "vite";
@@ -90,6 +92,30 @@ function stubMermaid(): Plugin {
   };
 }
 
+const CONTENT_SIGNAL_DIRECTIVE =
+  "Content-Signal: ai-train=no, search=yes, ai-input=no";
+
+function contentSignalsRobotsTxt(): Plugin {
+  return {
+    name: "content-signals-robots-txt",
+    enforce: "post",
+    async writeBundle(options) {
+      if (!options.dir?.endsWith("/public")) return;
+
+      const robotsPath = path.join(options.dir, "robots.txt");
+      const current = await fs.readFile(robotsPath, "utf8");
+      const next = current.includes("Content-Signal:")
+        ? current.replace(/^Content-Signal:.*$/m, CONTENT_SIGNAL_DIRECTIVE)
+        : current.replace(
+            /(User-agent: \*\nAllow: \/\n)/,
+            `$1\n${CONTENT_SIGNAL_DIRECTIVE}\n`,
+          );
+
+      if (next !== current) await fs.writeFile(robotsPath, next, "utf8");
+    },
+  };
+}
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   for (const key of Object.keys(env)) {
@@ -110,6 +136,7 @@ export default defineConfig(({ mode }) => {
       Icons({ compiler: "jsx", jsx: "react" }),
       react(),
       vocs(),
+      contentSignalsRobotsTxt(),
       ...(mode !== "production"
         ? [mkcert({ force: true, hosts: ["localhost"] })]
         : []),


### PR DESCRIPTION
## Summary

- Register WebMCP tools from the shared docs layout when `navigator.modelContext` is available.
- Expose docs search/navigation, MPP service catalog lookup, service detail lookup, and API catalog discovery to browser-based AI agents.
- Publish a static `/.well-known/api-catalog` linkset and set `application/linkset+json` discovery headers from the existing `vercel.mjs` config.
- Declare Content Signals in `robots.txt` with `ai-train=no, search=yes, ai-input=no`, including a post-build guard so Vocs-generated robots output keeps the directive.
- Support both `provideContext({ tools })` and the draft `registerTool(tool, { signal })` WebMCP API shape.
