### PR TITLE
[codex] preserve Content Signals in generated robots.txt

### DIFF
--- a/patches/vocs@0.0.0.patch
+++ b/patches/vocs@0.0.0.patch
@@ -1,5 +1,18 @@
+diff --git a/dist/internal/vite-plugins.js b/dist/internal/vite-plugins.js
+index 7a4e11786d59dc23595eb04bfcbbd058571a6a12..220d1ed34c94c9d587a33a30c892a8c8a47ab631 100644
+--- a/dist/internal/vite-plugins.js
++++ b/dist/internal/vite-plugins.js
+@@ -312,6 +312,8 @@ export function sitemap(config) {
+             'User-agent: *',
+             'Allow: /',
+             '',
++            'Content-Signal: ai-train=no, search=yes, ai-input=no',
++            '',
+             `Sitemap: ${siteUrl.replace(/\/$/, '')}/sitemap.xml`,
+             '',
+         ].join('\n');
 diff --git a/dist/waku/internal/patches/vite-plugins/fs-router-typegen.js b/dist/waku/internal/patches/vite-plugins/fs-router-typegen.js
-index a7b7d3960968f311765cbd2d5c4eb22e1dfa2a44..100d2078687b30987758e899f4b1b0b33be18f70 100644
+index a7b7d3960968f311765cbd2d5c4eb22e1dfa2a44..43650f5a2770ee7e9700a83beb752c617e714ca9 100644
 --- a/dist/waku/internal/patches/vite-plugins/fs-router-typegen.js
 +++ b/dist/waku/internal/patches/vite-plugins/fs-router-typegen.js
 @@ -1,6 +1,6 @@
@@ -27,3 +40,16 @@ index a7b7d3960968f311765cbd2d5c4eb22e1dfa2a44..100d2078687b30987758e899f4b1b0b3
          jsx: 'preserve',
      });
      return parseAstAsync(transformed.code, { jsx: true });
+diff --git a/src/internal/vite-plugins.ts b/src/internal/vite-plugins.ts
+index 99e16501f703aa4ed4c0184093c05bdc5d4b48d0..34ac6c50beee9e01d33e8a5f1117eb6bcab6a6f5 100644
+--- a/src/internal/vite-plugins.ts
++++ b/src/internal/vite-plugins.ts
+@@ -338,6 +338,8 @@ export function sitemap(config: Config.Config): PluginOption {
+       'User-agent: *',
+       'Allow: /',
+       '',
++      'Content-Signal: ai-train=no, search=yes, ai-input=no',
++      '',
+       `Sitemap: ${siteUrl.replace(/\/$/, '')}/sitemap.xml`,
+       '',
+     ].join('\n')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   vocs@0.0.0:
-    hash: 5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323
+    hash: bd60f23f65929b4a79f45dddd2ffe1175c3e8a53f3975423f2095a3090a4efa8
     path: patches/vocs@0.0.0.patch
 
 importers:
@@ -48,7 +48,7 @@ importers:
         version: 2.47.17(typescript@6.0.2)(zod@4.3.6)
       vocs:
         specifier: https://pkg.pr.new/vocs@425
-        version: https://pkg.pr.new/vocs@425(patch_hash=5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323)(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(mermaid@11.14.0)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.5)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.5)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: https://pkg.pr.new/vocs@425(patch_hash=bd60f23f65929b4a79f45dddd2ffe1175c3e8a53f3975423f2095a3090a4efa8)(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(mermaid@11.14.0)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.5)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.5)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       wagmi:
         specifier: ^3.6.1
         version: 3.6.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.5))(@types/react@19.2.14)(ox@0.14.15(typescript@6.0.2)(zod@4.3.6))(react@19.2.5)(typescript@6.0.2)(viem@2.47.17(typescript@6.0.2)(zod@4.3.6))
@@ -7979,7 +7979,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@https://pkg.pr.new/vocs@425(patch_hash=5b340733de5440b4e6ed05bb7181d1dcb81e595422ba76d685a4c14062177323)(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(mermaid@11.14.0)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.5)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.5)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vocs@https://pkg.pr.new/vocs@425(patch_hash=bd60f23f65929b4a79f45dddd2ffe1175c3e8a53f3975423f2095a3090a4efa8)(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(mermaid@11.14.0)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.5)(rollup@4.60.1)(typescript@6.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(waku@1.0.0-alpha.7(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.5(react@19.2.5))(react-server-dom-webpack@19.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.5)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@base-ui/react': 1.4.0(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Summary
- Patch Vocs' generated `robots.txt` output to include `Content-Signal: ai-train=no, search=yes, ai-input=no`.
- Keep the existing Vocs compatibility patch for `transformWithOxc` and update the lockfile patch hash.

## Why
Cloudflare's scan is reading the generated production `/robots.txt`, which is still the 61-byte Vocs default:

```txt
User-agent: *
Allow: /

Sitemap: https://mpp.dev/sitemap.xml
```

The previous PR changed `public/robots.txt` and added a post-build guard, but production is still serving the Vocs-generated default. This patch makes Vocs generate the Content-Signal line directly.

## Validation
- `pnpm build`
- `pnpm check:types`

Build output check:
- `dist/public/robots.txt` is 250 bytes and includes `Content-Signal: ai-train=no, search=yes, ai-input=no`.

Note: the pre-commit `pnpm check` still reports existing unrelated `noExplicitAny` warnings in untouched files, but exits successfully.