### PR TITLE
feat: add Tack IPFS pinning service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1875,6 +1875,63 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Tack ───────────────────────────────────────────────────────────────
+  {
+    id: "tack",
+    name: "Tack",
+    url: "https://tack.inferenceroom.ai",
+    serviceUrl: "https://tack.inferenceroom.ai",
+    description:
+      "Storage for agents. Upload files or pin CIDs, pay per use — no account or API key required.",
+
+    categories: ["storage"],
+    integration: "first-party",
+    tags: ["ipfs", "pinning", "storage", "files", "upload", "cid", "gateway"],
+    docs: {
+      homepage: "https://tack.inferenceroom.ai",
+      llmsTxt: "https://tack.inferenceroom.ai/llms.txt",
+      apiReference: "https://ipfs.github.io/pinning-services-api-spec/",
+    },
+    provider: { name: "Inference Room", url: "https://inferenceroom.ai" },
+    realm: "tack.inferenceroom.ai",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /pins",
+        desc: "Pin content by CID — dynamic pricing based on size and duration ($0.10/GB/month, min $0.001)",
+        dynamic: true,
+        amountHint: "$0.001+",
+      },
+      {
+        route: "POST /upload",
+        desc: "Upload and pin a file (multipart/form-data, max 100MB) — dynamic pricing ($0.10/GB/month, min $0.001)",
+        dynamic: true,
+        amountHint: "$0.001+",
+      },
+      {
+        route: "GET /ipfs/:cid",
+        desc: "Retrieve content by CID — free by default; owners may attach a paywall via meta.retrievalPrice",
+      },
+      {
+        route: "GET /pins",
+        desc: "List your pins (owner auth token required)",
+      },
+      {
+        route: "GET /pins/:requestid",
+        desc: "Get a specific pin (owner auth token required)",
+      },
+      {
+        route: "POST /pins/:requestid",
+        desc: "Replace a pin (owner auth token required)",
+      },
+      {
+        route: "DELETE /pins/:requestid",
+        desc: "Delete a pin (owner auth token required)",
+      },
+    ],
+  },
+
   // ── StableEmail ────────────────────────────────────────────────────────
   {
     id: "stableemail",


### PR DESCRIPTION
## Summary

- Adds **Tack** (`tack.inferenceroom.ai`) to the MPP service registry
- Tack is an IPFS pinning and content retrieval service with native MPP support (USDC.e on Tempo via mppx)
- First-party integration — tack handles MPP payment verification and settlement directly


## Service details

| Field | Value |
|---|---|
| id | `tack` |
| categories | `["storage"]` |
| integration | `first-party` |
| realm | `tack.inferenceroom.ai` |
| payments | Tempo USDC.e |
| pricing | dynamic ($0.10/GB/month, min $0.001) |

## Endpoints covered

- `POST /pins` — Pin by CID (dynamic price)
- `POST /upload` — Upload + pin file (dynamic price)
- `GET /ipfs/:cid` — Retrieve content (free by default; optional owner-set paywall via `meta.retrievalPrice`)
- `GET /pins`, `GET /pins/:requestid`, `POST /pins/:requestid`, `DELETE /pins/:requestid` — Owner management (bearer token)

## Discovery surfaces (all live)

- `homepage`: https://tack.inferenceroom.ai
- `llmsTxt`: https://tack.inferenceroom.ai/llms.txt
- `apiReference`: https://ipfs.github.io/pinning-services-api-spec/
- A2A agent card: `GET /.well-known/agent.json` ✅
- OpenAPI 3.1 (AgentCash discovery): `GET /openapi.json` ✅ 
## Checks

- [x] `pnpm check:types` — passes (after `node scripts/generate-discovery.ts` to regenerate `schemas/discovery.json`)
- [x] `pnpm check` (biome) — passes (no fixes needed after `--write`)
- [x] `pnpm check:sdk-drift` — pre-existing failure on `main` (unrelated to this PR; same set of mppx exports flagged before tack was added)
- [x] `categories: ["storage"]` — confirmed valid enum value in `CATEGORIES`

## Verification

```
$ curl -s -o /dev/null -w "%{http_code}\n" https://tack.inferenceroom.ai/
200
$ curl -s -o /dev/null -w "%{http_code}\n" https://tack.inferenceroom.ai/llms.txt
200
$ curl -s -o /dev/null -w "%{http_code}\n" https://tack.inferenceroom.ai/.well-known/agent.json
200
$ curl -s -o /dev/null -w "%{http_code}\n" https://tack.inferenceroom.ai/openapi.json
200
```