### PR TITLE
Add Megapot service to directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -3960,6 +3960,41 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Megapot ─────────────────────────────────────────────────────────────
+  {
+    id: "megapot",
+    name: "Megapot",
+    url: "https://megapot.io",
+    serviceUrl: "https://megapot.mpp.paysponge.com",
+    description:
+      "Global internet lottery tickets. AI agents can purchase Megapot tickets and check ticket status through MPP.",
+
+    categories: ["web", "blockchain"],
+    integration: "third-party",
+    tags: ["lottery", "gaming", "tickets", "base", "agent-commerce"],
+    status: "active",
+    docs: {
+      homepage: "https://megapot.io",
+      apiReference: "https://megapot.mpp.paysponge.com/openapi.json",
+    },
+    provider: { name: "Megapot", url: "https://megapot.io" },
+    realm: "megapot.mpp.paysponge.com",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /purchase",
+        desc: "Purchase a Megapot lottery ticket for a recipient wallet",
+        amount: "1000000",
+      },
+      {
+        route: "POST /status",
+        desc: "Check Megapot ticket status and winnings",
+        amount: "0",
+      },
+    ],
+  },
+
   // =========================================================================
   // Locus — Pay-per-use API proxy (paywithlocus.com)
   //


### PR DESCRIPTION
## Summary

Adds Megapot to the MPP service directory as a live Sponge Gateway MPP service for purchasing Megapot tickets and checking ticket status.

- Live service: https://megapot.mpp.paysponge.com/
- OpenAPI: https://megapot.mpp.paysponge.com/openapi.json
- Homepage: https://megapot.io

## Require
- [x] Your service is **live and accepting payments** via MPP (not a placeholder or coming-soon)
- [x] You've added your entry to `schemas/services.ts` following the [contributing guide](https://github.com/tempoxyz/mpp?tab=readme-ov-file#contributing-to-the-service-directory)
- [x] Types pass: `pnpm check:types`
- [x] Build succeeds: `pnpm build`

### Recommended
- [x] Register your service on [MPPScan](https://www.mppscan.com/register) (by Merit Systems) — it follows the standard MPP discovery format and makes your service discoverable by agents immediately, no PR required


## Endpoints

Both endpoints match the live `openapi.json` and MPP challenges from `https://megapot.mpp.paysponge.com`.

- `POST /purchase` — purchase a Megapot lottery ticket for a recipient wallet, 1 USDC.e
- `POST /status` — check Megapot ticket status and winnings, 0 USDC.e

Live on MPPScan: https://mppscan.com/server/bbf105a46ee3308350016a8616676e3b440b1c709cba422a6b0069c1f8c2924b