### PR TITLE
Add DeltaSignal MPP service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -819,6 +819,88 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── DeltaSignal ────────────────────────────────────────────────────────
+  {
+    id: "deltasignal",
+    name: "DeltaSignal",
+    url: "https://api.aitrailblazer.net",
+    serviceUrl: "https://api.aitrailblazer.net",
+    description:
+      "Crypto public-company financial intelligence powered by SEC XBRL data, issuer-specific Calculation Linkbases, ATLAS covenant stress, peer ranking, alpha signals, and daily BTC/ETH live-price overlays.",
+
+    categories: ["data", "blockchain"],
+    integration: "first-party",
+    tags: [
+      "crypto",
+      "public-companies",
+      "sec-filings",
+      "xbrl",
+      "risk",
+      "financial-data",
+      "alpha-signals",
+    ],
+    docs: {
+      homepage: "https://api.aitrailblazer.net/help",
+      apiReference: "https://api.aitrailblazer.net/openapi.json",
+    },
+    provider: { name: "AITrailblazer", url: "https://aitrailblazer.net" },
+    realm: "api.aitrailblazer.net",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /mpp/v1/company-fundamentals/:ticker",
+        desc: "Provenance-rich company fundamentals for a single crypto public issuer.",
+        amount: "50000",
+      },
+      {
+        route: "GET /mpp/v1/alpha-signals/:ticker",
+        desc: "Deterministic Phase 1 alpha, resilience, treasury-strength, and regime-fit signals for one issuer.",
+        amount: "70000",
+      },
+      {
+        route: "GET /mpp/v1/alpha-opportunities",
+        desc: "Rank the active DeltaSignal slice by deterministic Phase 1 alpha score.",
+        amount: "50000",
+      },
+      {
+        route: "GET /mpp/v1/covenant-stress/:ticker",
+        desc: "ATLAS covenant stress detail for one issuer.",
+        amount: "100000",
+      },
+      {
+        route: "GET /mpp/v1/covenant-stress",
+        desc: "Screen the latest DeltaSignal covenant stress slice.",
+        amount: "80000",
+      },
+      {
+        route: "GET /mpp/v1/top-stressed",
+        desc: "Top stressed crypto issuers from the current DeltaSignal slice.",
+        amount: "50000",
+      },
+      {
+        route: "GET /mpp/v1/peer-ranking/:ticker",
+        desc: "Peer covenant ranking for a single issuer.",
+        amount: "60000",
+      },
+      {
+        route: "GET /mpp/v1/risk-distribution",
+        desc: "Risk-tier distribution for the active DeltaSignal slice.",
+        amount: "40000",
+      },
+      {
+        route: "GET /mpp/v1/readiness",
+        desc: "Freshness and readiness of the current DeltaSignal slice.",
+        amount: "40000",
+      },
+      {
+        route: "GET /mpp/v1/daily-changes/latest",
+        desc: "Latest published SEC daily-changes snapshot for the tracked slice.",
+        amount: "30000",
+      },
+    ],
+  },
+
   // ── Doma ────────────────────────────────────────────────────────────────
   {
     id: "doma",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -843,7 +843,10 @@ export const services: ServiceDef[] = [
       homepage: "https://api.aitrailblazer.net/help",
       apiReference: "https://api.aitrailblazer.net/openapi.json",
     },
-    provider: { name: "AITrailblazer", url: "https://aitrailblazer.net" },
+    provider: {
+      name: "AITrailblazer",
+      url: "https://aitrailblazer.com",
+    },
     realm: "api.aitrailblazer.net",
     intent: "charge",
     payments: [TEMPO_PAYMENT],


### PR DESCRIPTION
## Summary
Adds **DeltaSignal** (ATLAS-7) to the curated MPP service registry.

DeltaSignal delivers provenance-rich financial intelligence for crypto public companies: SEC XBRL fundamentals, ATLAS covenant stress, peer ranking, readiness, alpha signals, and BTC/ETH-adjusted foresight overlays.

## Live Service
- **API base**: https://api.aitrailblazer.net
- **Provider / Marketing site**: https://aitrailblazer.com
- **Manifest**: https://api.aitrailblazer.net/.well-known/mpp.json
- **OpenAPI**: https://api.aitrailblazer.net/openapi.json
- **Help & full routes**: https://api.aitrailblazer.net/help
- **Logo**: https://api.aitrailblazer.net/deltasignal-logo.png
- **MPPScan**: https://www.mppscan.com/server/8892af70b613b5c2feb932a52fab50b29155f5655363c5e9e56456486187a6a7
- **Skill file**: https://api.aitrailblazer.net/skills/atlas/SKILL.md
- **Install**: `npx agentcash add https://api.aitrailblazer.net/skills/atlas/SKILL.md`

## Payment Proof
Live MPP paid proof completed on production:
- `GET https://api.aitrailblazer.net/mpp/v1/readiness` -> `200`
- `Payment-Receipt` present
- Receipt reference: `0x4bfe9ec0c31616d6435f9f639ffc8fc574b94be46c7236f684cc40cc20637bb7`

Unauthenticated requests return proper `402` with `WWW-Authenticate: Payment ... method="tempo"`.

## MPPScan & Discovery
- Live manifest exposes 10 paid Tempo MPP resources under `/mpp/v1/*`.
- Live manifest exposes `logo`, `icon`, `skill_url`, and install metadata.
- MPPScan visible activity: 1 transaction, $0.04 volume, 1 buyer.
- Note: if MPPScan still shows a `No Tag` section with legacy `/v1/*` rows, those are stale cached rows from an earlier registration. Current live manifest/OpenAPI discovery no longer emits legacy `/v1/*` resources.

## Endpoints (10 paid Tempo USDC.e)
- `GET /mpp/v1/company-fundamentals/:ticker` — $0.05
- `GET /mpp/v1/alpha-signals/:ticker` — $0.07
- `GET /mpp/v1/alpha-opportunities` — $0.05
- `GET /mpp/v1/covenant-stress/:ticker` — $0.10
- `GET /mpp/v1/covenant-stress` — $0.08
- `GET /mpp/v1/top-stressed` — $0.05
- `GET /mpp/v1/peer-ranking/:ticker` — $0.06
- `GET /mpp/v1/risk-distribution` — $0.04
- `GET /mpp/v1/readiness` — $0.04
- `GET /mpp/v1/daily-changes/latest` — $0.03

## Checklist
- [x] Service is live and accepting payments via MPP
- [x] Entry added to `schemas/services.ts`
- [x] Types pass: `corepack pnpm@10.22.0 check:types`
- [x] Build succeeds: `corepack pnpm@10.22.0 build`
- [x] Registered on MPPScan
- Additional: `node scripts/generate-discovery.ts` + `corepack pnpm@10.22.0 check:ci`

**Note:** The only remaining failure is Vercel preview authorization (Tempo team fork permission) — not a service or schema issue.

Ready for human review and merge.


