### PR TITLE
Add mpps.io — attestation for agent commerce

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6496,6 +6496,56 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── mpps.io ────────────────────────────────────────────────────────────
+  {
+    id: "mpps",
+    name: "mpps.io",
+    url: "https://api.mpps.io",
+    serviceUrl: "https://api.mpps.io",
+    description:
+      "Cryptographic attestation for agent commerce. Proof of delivery for every MPP transaction.",
+
+    categories: ["data"],
+    integration: "third-party",
+    tags: [
+      "attestation",
+      "proof",
+      "trust",
+      "notarize",
+      "certificate",
+      "audit",
+      "receipt",
+      "delivery",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://mpps.io",
+      llmsTxt: "https://api.mpps.io/llms.txt",
+      apiReference: "https://github.com/gdlg-ai/mpps.io/blob/main/docs/api.md",
+    },
+    provider: { name: "GlideLogic Corp.", url: "https://glidelogic.ai" },
+    realm: "api.mpps.io",
+    intent: "charge",
+    payments: [STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/notarize",
+        desc: "Free HSM-signed attestation (10/hour)",
+      },
+      {
+        route: "POST /v1/certify",
+        desc: "Certified attestation with metadata and certificate",
+        amount: "1",
+      },
+      { route: "GET /v1/verify/:uuid", desc: "Verify any attestation" },
+      {
+        route: "GET /v1/public-key",
+        desc: "Public key for offline verification",
+      },
+      { route: "GET /v1/health", desc: "Service health check" },
+    ],
+  },
+
   // ── Papercut ───────────────────────────────────────────────────────────
   {
     id: "papercut",


### PR DESCRIPTION
mpps.io provides cryptographic attestation for MPP transactions.

MPP receipts prove money moved. mpps.io proves what was delivered. It is the only service on this registry that serves the MPP ecosystem itself: every other service uses MPP to get paid, while mpps.io makes every MPP transaction more trustworthy.

After any MPP payment, either party can call mpps.io to attest what was exchanged, creating a complete evidence chain.

Details:
- Live API: https://api.mpps.io
- Free: 10 attestations/hour, 10 certified/day (no auth)
- Paid: $0.01/attestation via Stripe MPP
- HSM-signed (AWS KMS, FIPS 140-2 Level 3)
- 10-year immutable storage (S3 Object Lock, Compliance Mode)
- Open source: https://github.com/gdlg-ai/mpps.io (MIT)
- llms.txt: https://api.mpps.io/llms.txt
- Website: https://mpps.io

Built by GlideLogic Corp. (OTCQB: GDLG).

Validation:
- `pnpm generate:discovery`
- `pnpm check:types`
- `pnpm check:ci` (passes with existing noExplicitAny warnings)
- `git diff --check`