### PR TITLE
feat(services): add P402 Router — OpenAI-compatible AI router with MPP payment gate

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1662,6 +1662,63 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── P402 ───────────────────────────────────────────────────────────────
+  {
+    id: "p402",
+    name: "P402 Router",
+    url: "https://p402.io",
+    serviceUrl: "https://p402.io",
+    description:
+      "OpenAI-compatible AI router with per-request micropayment billing. Route prompts to 13 LLM providers — OpenAI, Anthropic, Gemini, Groq, and more — with intelligent cost/speed/quality routing. Pay per inference in USDC.e on Tempo or USDC on Base. No subscription required.",
+
+    categories: ["ai"],
+    integration: "first-party",
+    tags: [
+      "llm",
+      "router",
+      "openai-compatible",
+      "micropayments",
+      "x402",
+      "multi-provider",
+      "anthropic",
+      "openai",
+      "gemini",
+      "groq",
+      "usdc",
+      "base",
+      "tempo",
+    ],
+    status: "beta",
+    docs: {
+      homepage: "https://p402.io/docs/api",
+      llmsTxt: "https://p402.io/llms.txt",
+      apiReference: "https://p402.io/docs/api",
+    },
+    provider: { name: "P402", url: "https://p402.io" },
+    realm: "p402.io",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /api/v2/chat/completions",
+        desc: "OpenAI-compatible chat completions routed to the best provider — price varies by model and token count",
+        dynamic: true,
+        amountHint: "$0.001 base + model token cost",
+        docs: "https://p402.io/docs/api",
+      },
+      {
+        route: "GET /api/v2/models",
+        desc: "List available models across all 13 supported providers",
+        docs: false,
+      },
+      {
+        route: "GET /api/health",
+        desc: "Service and mppx payment gate health status",
+        docs: false,
+      },
+    ],
+  },
+
   // ── Parallel ───────────────────────────────────────────────────────────
   {
     id: "parallel",


### PR DESCRIPTION
## Add P402 Router

**Service:** P402 Router — OpenAI-compatible AI router with per-request micropayment billing
**URL:** https://p402.io
**npm package:** [`@p402/mpp-method@0.1.0`](https://www.npmjs.com/package/@p402/mpp-method)

### What it does

Routes AI inference requests to 13 LLM providers (OpenAI, Anthropic, Gemini, Groq, etc.) with intelligent cost/speed/quality selection. Payment accepted via:
- **Tempo** (USDC.e, TIP-20) — primary rail
- **Base** (EIP-3009 USDC/EURC) — secondary rail

### mppx integration

Uses `@p402/mpp-method` (published today) — a first-party mppx payment method package with `baseCharge` (EIP-3009) and `p402Charge` (multi-rail) methods. `Authorization: Payment` header accepted on `POST /api/v2/chat/completions`.

```ts
import { Mppx } from 'mppx/server';
import { p402Charge } from '@p402/mpp-method';

const mppx = Mppx.create({
  methods: [p402Charge],
  secretKey: process.env.MPP_SECRET_KEY!,
});
```

### Checklist
- [x] `id` is unique (`p402`)
- [x] All `ServiceDef` fields present and typed correctly
- [x] `status: "beta"` (launched today)
- [x] `integration: "first-party"` (direct mppx integration via `@p402/mpp-method`)
- [x] `payments: [TEMPO_PAYMENT]` (USDC.e on Tempo, primary rail)
- [x] `realm: "p402.io"` (P402 issues its own MPP challenges)