### PR TITLE
feat(extensions): add @quicknode/mpp

### DIFF
--- a/src/pages/extensions.mdx
+++ b/src/pages/extensions.mdx
@@ -7,5 +7,6 @@ Third-party packages that extend MPP with new payment methods, middleware, and u
 | `@insumermodel/mppx-token-gate` | TypeScript, JavaScript | Token-gate mppx routes—free access for NFT/token holders across 32 chains | [npm](https://www.npmjs.com/package/@insumermodel/mppx-token-gate) |
 | `mpp-inspector` | TypeScript, JavaScript | CLI toolkit to inspect, debug, and test HTTP 402 MPP endpoints—parse challenges, verify receipts, compare pricing, and dry-run payment flows | [npm](https://www.npmjs.com/package/mpp-inspector) · [GitHub](https://github.com/amgb20/MPP-Inspector) |
 | `x402-proxy` | TypeScript, JavaScript | `curl` for MPP and x402 paid APIs—auto-pays one-shot charges and session-based streaming (per-token voucher cycling), with built-in wallet management (EVM + Solana), spend limits, and MCP stdio proxy for AI agents | [npm](https://www.npmjs.com/package/x402-proxy) · [GitHub](https://github.com/cascade-protocol/x402-proxy) |
+| `@quicknode/mpp` | TypeScript, JavaScript | Extends MPP with payments on Ethereum, Base, and other EVM networks, with support for `permit2`, EIP-3009 `authorization` and `hash` credential types | [npm](https://www.npmjs.com/package/@quicknode/mpp) · [GitHub](https://github.com/quiknode-labs/mpp) |
 
 Want to build your own? See [Custom payment methods](/payment-methods/custom).


### PR DESCRIPTION
Adds `@quicknode/mpp` to the Extensions page.

## What it does

The SDK extends MPP with on-chain payments on multiple EVM compatible networks. It supports ERC-20 and native-coin settlement, with three credential types:

- `permit2` — strong binding via EIP-712 witness, server-paid gas, any ERC-20
- `authorization` — strong binding via on-chain nonce, server-paid gas, EIP-3009 tokens (e.g. USDC)
- `hash` — post-hoc receipt matching, client-paid

The package follows the [first-party SDK extension pattern](https://mpp.dev/payment-methods/custom#first-party-sdk) (root + `/client` + `/server` entry points) and implements the credential types defined in [`draft-evm-charge-00`](https://github.com/tempoxyz/mpp-specs/blob/2f6bfcee6f9e448d2ded15dc350dc92967e17513/specs/methods/evm/draft-evm-charge-00.md). Native-coin settlement is a non-normative extension to that draft.

## Links
- npm: https://www.npmjs.com/package/@quicknode/mpp
- GitHub: https://github.com/quiknode-labs/mpp

Thank you!