### PR TITLE
docs(extensions): rename insumermodel entry to mppx-condition-gate (v2)

### DIFF
--- a/src/pages/extensions.mdx
+++ b/src/pages/extensions.mdx
@@ -4,7 +4,7 @@ Third-party packages that extend MPP with new payment methods, middleware, and u
 
 | Name | Languages | Description | Link |
 |---|---|---|---|
-| `@insumermodel/mppx-token-gate` | TypeScript, JavaScript | Token-gate mppx routes—free access for NFT/token holders across 32 chains | [npm](https://www.npmjs.com/package/@insumermodel/mppx-token-gate) |
+| `@insumermodel/mppx-condition-gate` | TypeScript, JavaScript | Condition-based access for mppx routes—free access for wallets that meet token, NFT, EAS attestation, or Farcaster ID conditions across 33 chains, returned as ECDSA-signed attestations | [npm](https://www.npmjs.com/package/@insumermodel/mppx-condition-gate) · [GitHub](https://github.com/douglasborthwick-crypto/mppx-condition-gate) |
 | `mpp-inspector` | TypeScript, JavaScript | CLI toolkit to inspect, debug, and test HTTP 402 MPP endpoints—parse challenges, verify receipts, compare pricing, and dry-run payment flows | [npm](https://www.npmjs.com/package/mpp-inspector) · [GitHub](https://github.com/amgb20/MPP-Inspector) |
 | `x402-proxy` | TypeScript, JavaScript | `curl` for MPP and x402 paid APIs—auto-pays one-shot charges and session-based streaming (per-token voucher cycling), with built-in wallet management (EVM + Solana), spend limits, and MCP stdio proxy for AI agents | [npm](https://www.npmjs.com/package/x402-proxy) · [GitHub](https://github.com/cascade-protocol/x402-proxy) |
 | `@quicknode/mpp` | TypeScript, JavaScript | Extends MPP with payments on Ethereum, Base, and other EVM networks, with support for `permit2`, EIP-3009 `authorization` and `hash` credential types | [npm](https://www.npmjs.com/package/@quicknode/mpp) · [GitHub](https://github.com/quiknode-labs/mpp) |


### PR DESCRIPTION
## Summary

The `@insumermodel/mppx-token-gate` package listed on the Extensions page was renamed to `@insumermodel/mppx-condition-gate` (v2.0.0) to align with the broader category it implements. v2 adds two new condition types — `eas_attestation` (EAS-issued claims like Coinbase Verified Account, Gitcoin Passport) and `farcaster_id` — alongside the existing `token_balance` and `nft_ownership`. Mix any of the four in a single call.

## Links

- New package: https://www.npmjs.com/package/@insumermodel/mppx-condition-gate
- Old package (deprecated with redirect message): https://www.npmjs.com/package/@insumermodel/mppx-token-gate
- New repo (auto-redirects from the old URL): https://github.com/douglasborthwick-crypto/mppx-condition-gate

## Other changes in this row

- Chain count corrected from 32 to 33 (Bitcoin support added in v1.0.4)
- Added a GitHub link alongside the npm link, matching the format the other rows use
- Description rewritten to cover all four condition types

## Test plan

- [x] Row renders correctly in MDX (one-line table cell)
- [x] Both npm and GitHub URLs resolve
- [x] No other rows touched

Drop questions here whenever.