### PR TITLE
docs: update mppx 0.6 reference pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@stripe/stripe-js": "^9.3.1",
     "@vercel/blob": "^2.3.3",
     "mermaid": "^11.14.0",
-    "mppx": "0.6.5",
+    "mppx": "0.6.17",
     "react": "^19",
     "react-dom": "^19",
     "stripe": "^22.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^11.14.0
         version: 11.14.0
       mppx:
-        specifier: 0.6.5
-        version: 0.6.5(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.16)(typescript@6.0.3)(viem@2.48.4(typescript@6.0.3)(zod@4.3.6))
+        specifier: 0.6.17
+        version: 0.6.17(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.16)(typescript@6.0.3)(viem@2.48.4(typescript@6.0.3)(zod@4.3.6))
       react:
         specifier: ^19
         version: 19.2.5
@@ -2498,8 +2498,8 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  incur@0.3.25:
-    resolution: {integrity: sha512-jrSkzauM42ilbQJ6THVkAY6dTulkyVW0sZpVHdA8gfiBwrLrLnLUf8U3bAOegAKBIMSOFgk1idchgu9xm9HMng==}
+  incur@0.4.5:
+    resolution: {integrity: sha512-4WFlqm5e+IKNoX+lDIjjpebO8ResPx3vPUBChxNfnNo3oGp0ooo6piiiTspOMub2dq2mcG/AmlUq0ejuGfKobg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3028,14 +3028,14 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  mppx@0.6.5:
-    resolution: {integrity: sha512-av6EDYiR7eqpRW3vERfEPPJITrRH3D5gyeATnQNU6CC/eI48FnwsS2shghdra1Ev5CgUDm5f1+sOlgpA/YPYYg==}
+  mppx@0.6.17:
+    resolution: {integrity: sha512-qGATWL6BFE0J1rsZj/pXWapKRKlqgZvZNui/2hGHeifVoftxYcBesHLs0NNplFF5mPfVSAOqbemoz358YOUlPQ==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.14'
+      hono: '>=4.12.18'
       viem: '>=2.47.5'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -3122,8 +3122,8 @@ packages:
   outvariant@1.4.0:
     resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
 
-  ox@0.14.15:
-    resolution: {integrity: sha512-3TubCmbKen/cuZQzX0qDbOS5lojjdSZ90lqKxWIDWd5siuJ0IJBaTXMYs8eMPLcraqnOwGZazz3apHPGiRCkGQ==}
+  ox@0.14.18:
+    resolution: {integrity: sha512-1Irk/tvMsw7xJDuCTT/u9azSjz0YX9hrYFgJOacIuFwibaW2zZBXAMrpzegndYb5o8GLpxB6/0qro4/c40q6VQ==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -3263,7 +3263,6 @@ packages:
   react-server-dom-webpack@19.2.4:
     resolution: {integrity: sha512-zEhkWv6RhXDctC2N7yEUHg3751nvFg81ydHj8LTTZuukF/IF1gcOKqqAL6Ds+kS5HtDVACYPik0IvzkgYXPhlQ==}
     engines: {node: '>=0.10.0'}
-    deprecated: High Security Vulnerability in React Server Components
     peerDependencies:
       react: ^19.2.4
       react-dom: ^19.2.4
@@ -6464,7 +6463,7 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  incur@0.3.25:
+  incur@0.4.5:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/server': 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
@@ -7226,10 +7225,10 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.6.5(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.16)(typescript@6.0.3)(viem@2.48.4(typescript@6.0.3)(zod@4.3.6)):
+  mppx@0.6.17(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.16)(typescript@6.0.3)(viem@2.48.4(typescript@6.0.3)(zod@4.3.6)):
     dependencies:
-      incur: 0.3.25
-      ox: 0.14.15(typescript@6.0.3)(zod@4.4.3)
+      incur: 0.4.5
+      ox: 0.14.18(typescript@6.0.3)(zod@4.4.3)
       viem: 2.48.4(typescript@6.0.3)(zod@4.3.6)
       zod: 4.4.3
     optionalDependencies:
@@ -7291,7 +7290,7 @@ snapshots:
 
   outvariant@1.4.0: {}
 
-  ox@0.14.15(typescript@6.0.3)(zod@4.4.3):
+  ox@0.14.18(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0

--- a/src/pages/sdk/typescript/cli.mdx
+++ b/src/pages/sdk/typescript/cli.mdx
@@ -73,6 +73,26 @@ $ mppx example.com/content -M channel=0x123 -M deposit=1000000
 
 For Tempo session payments, use `channel` and `deposit`. For Stripe, use `paymentMethod`.
 
+## JSON output
+
+Pass `--format json` to commands that support structured output. This is useful when another tool calls `mppx`.
+
+```bash [terminal]
+$ mppx account list --format json
+```
+
+```json
+{
+  "accounts": [
+    {
+      "address": "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb",
+      "isDefault": true,
+      "name": "main"
+    }
+  ]
+}
+```
+
 ## Init command
 
 Create an `mppx.config.ts` file in the current directory:
@@ -104,6 +124,27 @@ Use `--dry-run` to validate and parse a Challenge without signing:
 ```bash [terminal]
 $ mppx sign --challenge 'Payment method="tempo-session";...' --dry-run
 ```
+
+## Account commands
+
+Manage local keychain-backed accounts with `mppx account`.
+
+```bash [terminal]
+$ mppx account create --account main
+$ mppx account default --account main
+$ mppx account list
+$ mppx account view --account main
+```
+
+Export a local account private key when you need to import it into another wallet or tool:
+
+```bash [terminal]
+$ mppx account export --account main
+```
+
+:::warning
+`mppx account export` prints the private key. Don't commit it, paste it into shared logs, or use it in client-side code.
+:::
 
 ## Stripe payments
 

--- a/src/pages/sdk/typescript/client/Fetch.from.mdx
+++ b/src/pages/sdk/typescript/client/Fetch.from.mdx
@@ -1,0 +1,88 @@
+---
+description: "Wrap fetch with automatic MPP payments without changing global fetch."
+imageDescription: "Wrap fetch for paid API calls"
+---
+
+# `Fetch.from` [Create a payment-aware fetch wrapper]
+
+Creates a scoped `fetch` wrapper that handles `402` Payment Required responses without modifying `globalThis.fetch`.
+
+## Usage
+
+```ts twoslash
+import { Fetch, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+const fetch = Fetch.from({
+  methods: [tempo({ account })],
+})
+
+const response = await fetch('https://mpp.dev/api/ping/paid')
+console.log(response.status)
+// @log: 200
+```
+
+### With allowed origins
+
+Use `acceptPaymentPolicy` to control where the wrapper injects `Accept-Payment`.
+
+```ts twoslash
+import { Fetch, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+const fetch = Fetch.from({
+  acceptPaymentPolicy: {
+    origins: ['https://api.example.com', '*.paid.example.com'],
+  },
+  methods: [tempo({ account })],
+})
+```
+
+## Return type
+
+```ts
+type ReturnType = (
+  input: RequestInfo | URL,
+  init?: RequestInit & { context?: AnyContextFor<methods> }
+) => Promise<Response>
+```
+
+## Parameters
+
+### acceptPayment (optional)
+
+- **Type:** `AcceptPayment.Resolved<methods>`
+
+Resolved `Accept-Payment` header and preference data. Most callers should use `methods` and `paymentPreferences` on `Mppx.create` instead.
+
+### acceptPaymentPolicy (optional)
+
+- **Type:** `'always' | 'same-origin' | 'never' | { origins: readonly string[] }`
+- **Default:** `'always'`
+
+Controls when `Accept-Payment` is injected.
+
+Use `'same-origin'` in browsers when you only want same-origin payment discovery. Use `{ origins }` when paid APIs live on specific origins. Origin patterns support `*.` subdomain wildcards.
+
+### fetch (optional)
+
+- **Type:** `typeof globalThis.fetch`
+- **Default:** `globalThis.fetch`
+
+Custom fetch function to wrap.
+
+### methods
+
+- **Type:** `readonly Method.AnyClient[]`
+
+Array of payment methods to use for `402` responses.
+
+### onChallenge (optional)
+
+- **Type:** `(challenge, helpers) => Promise<string | undefined>`
+
+Called after a `402` Challenge is selected and before the wrapper retries the request. Return a Credential string to override the default credential flow.

--- a/src/pages/sdk/typescript/client/Fetch.polyfill.mdx
+++ b/src/pages/sdk/typescript/client/Fetch.polyfill.mdx
@@ -1,0 +1,83 @@
+---
+description: "Install a global fetch wrapper that handles MPP payments automatically."
+imageDescription: "Install paid fetch globally"
+---
+
+# `Fetch.polyfill` [Install a global payment-aware fetch]
+
+Replaces `globalThis.fetch` with a payment-aware wrapper that handles `402` Payment Required responses.
+
+## Usage
+
+```ts twoslash
+import { Fetch, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+Fetch.polyfill({
+  methods: [tempo({ account })],
+})
+
+const response = await fetch('https://mpp.dev/api/ping/paid')
+console.log(response.status)
+// @log: 200
+```
+
+### With cross-origin payments
+
+In browsers, `Fetch.polyfill` defaults to same-origin `Accept-Payment` injection. Pass `acceptPaymentPolicy` when your paid API lives on another origin.
+
+```ts twoslash
+import { Fetch, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+Fetch.polyfill({
+  acceptPaymentPolicy: {
+    origins: ['https://api.example.com'],
+  },
+  methods: [tempo({ account })],
+})
+```
+
+## Return type
+
+```ts
+type ReturnType = void
+```
+
+## Parameters
+
+### acceptPayment (optional)
+
+- **Type:** `AcceptPayment.Resolved<methods>`
+
+Resolved `Accept-Payment` header and preference data.
+
+### acceptPaymentPolicy (optional)
+
+- **Type:** `'always' | 'same-origin' | 'never' | { origins: readonly string[] }`
+- **Default:** `'same-origin'` in browsers, `'always'` otherwise
+
+Controls when `Accept-Payment` is injected.
+
+### fetch (optional)
+
+- **Type:** `typeof globalThis.fetch`
+- **Default:** `globalThis.fetch`
+
+Custom fetch function to wrap.
+
+### methods
+
+- **Type:** `readonly Method.AnyClient[]`
+
+Array of payment methods to use for `402` responses.
+
+### onChallenge (optional)
+
+- **Type:** `(challenge, helpers) => Promise<string | undefined>`
+
+Called after a `402` Challenge is selected and before the wrapper retries the request.

--- a/src/pages/sdk/typescript/client/Fetch.restore.mdx
+++ b/src/pages/sdk/typescript/client/Fetch.restore.mdx
@@ -1,0 +1,33 @@
+---
+description: "Restore the original fetch after installing the MPP fetch polyfill."
+imageDescription: "Restore the original fetch"
+---
+
+# `Fetch.restore` [Restore global fetch]
+
+Restores the original `globalThis.fetch` after `Fetch.polyfill` or `Mppx.create` installs a payment-aware wrapper.
+
+## Usage
+
+```ts twoslash
+import { Fetch, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+Fetch.polyfill({
+  methods: [tempo({ account })],
+})
+
+Fetch.restore()
+```
+
+## Return type
+
+```ts
+type ReturnType = void
+```
+
+## Parameters
+
+None.

--- a/src/pages/sdk/typescript/client/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/client/Mppx.create.mdx
@@ -65,6 +65,26 @@ if (response.status === 402) {
 // [!code hl:end]
 ```
 
+Pass `acceptPayment` to override method selection for this one response:
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const mppx = Mppx.create({
+  methods: [tempo()],
+  polyfill: false,
+})
+
+const response = await fetch('https://mpp.dev/api/ping/paid')
+
+const credential = await mppx.createCredential(
+  response,
+  { account: privateKeyToAccount('0x...') },
+  { acceptPayment: 'tempo/charge;q=1, tempo/session;q=0' }, // [!code focus]
+)
+```
+
 ## Return type
 
 ```ts
@@ -81,6 +101,7 @@ type Mppx = {
   createCredential: (
     response: Response,
     context?: Context,
+    options?: { acceptPayment?: string | AcceptPayment.Entry[] },
   ) => Promise<string>
 }
 ```
@@ -105,6 +126,29 @@ const raw = await mppx.rawFetch('https://api.example.com/ws-auth') // [!code foc
 ```
 
 ## Parameters
+
+### acceptPaymentPolicy (optional)
+
+- **Type:** `'always' | 'same-origin' | 'never' | { origins: readonly string[] }`
+- **Default:** `'same-origin'` when `polyfill` is `true` in browsers, `'always'` otherwise
+
+Controls when `mppx` injects `Accept-Payment` on outgoing requests. Browser polyfills default to same-origin injection to avoid CORS preflight failures on APIs that don't support payment discovery.
+
+Use `{ origins }` for cross-origin paid APIs. Origin patterns support `*.` subdomain wildcards.
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+Mppx.create({
+  acceptPaymentPolicy: {
+    origins: ['https://api.example.com', '*.paid.example.com'],
+  }, // [!code focus]
+  methods: [tempo({ account })],
+})
+```
 
 ### fetch (optional)
 
@@ -253,6 +297,14 @@ Mppx.create({
   }, // [!code focus:end]
 })
 ```
+
+## Manual credential options
+
+### acceptPayment (optional)
+
+- **Type:** `string | readonly AcceptPayment.Entry[]`
+
+Request-local method preference override for `mppx.createCredential(response, context, options)`. Use this when you manually fetch a `402` response and want to select from the returned Challenges without changing the client's default `paymentPreferences`.
 
 ### transport (optional)
 

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -278,6 +278,12 @@ Server-defined correlation data. `mppx` serializes it as the base64url-encoded `
 
 Address to receive the payment.
 
+### scope (optional)
+
+- **Type:** `string`
+
+Route or resource scope bound into the Challenge metadata. Use this to prevent a Credential issued for one route from being replayed against another route with the same payment terms.
+
 ### splits (optional)
 
 - **Type:** `Array<{ amount: string; memo?: string; recipient: string }>`

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -92,6 +92,12 @@ Escrow contract address for the payment channel. Defaults to the canonical escro
 
 Account or URL for sponsoring open and top-up transaction fees. Pass a viem `Account` to co-sign locally, a URL string to delegate to a remote [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer), or `true` when the `account` parameter doubles as the fee payer.
 
+### feePayerPolicy (optional)
+
+- **Type:** `Partial<{ maxFeePerGas: bigint; maxGas: bigint; maxPriorityFeePerGas: bigint; maxTotalFee: bigint; maxValidityWindowSeconds: number }>`
+
+Override the local fee-sponsor policy used when the server co-signs session open and top-up transactions. Remote fee payer services enforce their own policy.
+
 ### getClient (optional)
 
 - **Type:** `(parameters: { chainId: number }) => MaybePromise<Client>`

--- a/src/pages/sdk/typescript/server/Mppx.compose.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.compose.mdx
@@ -37,6 +37,7 @@ export async function handler(request: Request) {
 ## Behavior
 
 - **No Credential present:** Calls all handlers and merges their `402` challenges into a single response with multiple `WWW-Authenticate` headers.
+- **`Accept-Payment` present:** Ranks and filters the merged Challenges by the client's supported `method/intent` entries. Entries with `q=0` are excluded. If the header is invalid or filters out every Challenge, all Challenges are returned.
 - **Credential present:** Dispatches to the handler matching the Credential's `method` and `intent`.
 
 ## Return type

--- a/src/pages/sdk/typescript/server/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.create.mdx
@@ -34,7 +34,7 @@ import type { Mppx, Transport } from 'mppx/server'
 type ReturnType = Mppx<[Method.Server], Transport.Http>
 ```
 
-The returned object includes the method's intent functions (for example, `charge`) which you call to handle payment requests.
+The returned object includes the method's intent functions (for example, `charge`), `compose`, and `verifyCredential`.
 
 ## Parameters
 

--- a/src/pages/sdk/typescript/server/Mppx.verifyCredential.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.verifyCredential.mdx
@@ -1,0 +1,76 @@
+---
+description: "Verify MPP Credentials directly in custom transports and background flows."
+imageDescription: "Verify Credentials outside HTTP handlers"
+---
+
+# `Mppx.verifyCredential` [Verify a Credential directly]
+
+Verifies a serialized or parsed Credential without running a full HTTP route handler.
+
+## Usage
+
+Use `verifyCredential` when you receive a Credential through a custom transport or job boundary and need the same method verification as an `mppx` route.
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [tempo.charge()],
+})
+
+const receipt = await mppx.verifyCredential('Payment credential="..."', {
+  request: {
+    amount: '0.10',
+    currency: '0x20c0000000000000000000000000000000000000',
+    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  },
+  scope: 'GET /v1/report',
+})
+
+console.log(receipt.status)
+// @log: success
+```
+
+## Return type
+
+```ts
+type ReturnType = Promise<Receipt>
+```
+
+## Parameters
+
+### credential
+
+- **Type:** `string | Credential`
+
+Serialized `Authorization` header value or parsed Credential object.
+
+### capturedRequest (optional)
+
+- **Type:** `Method.CapturedRequest`
+
+Authoritative request snapshot used by method verification hooks.
+
+### meta (optional)
+
+- **Type:** `Record<string, string>`
+
+Expected Challenge metadata. `mppx` compares this with the metadata echoed by the Credential.
+
+### realm (optional)
+
+- **Type:** `string`
+
+Expected Challenge realm.
+
+### request (optional)
+
+- **Type:** `Record<string, unknown>`
+
+Expected method request parameters. Pass the same route options used to issue the Challenge.
+
+### scope (optional)
+
+- **Type:** `string`
+
+Expected route or resource scope. Use this when the original Challenge was issued with `scope`.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -193,16 +193,6 @@ export default defineConfig({
       destination: "/sdk/typescript",
     },
 
-    // Old Fetch.* client pages (removed)
-    {
-      source: "/sdk/typescript/client/Fetch.from",
-      destination: "/sdk/typescript",
-    },
-    {
-      source: "/sdk/typescript/client/Fetch.polyfill",
-      destination: "/sdk/typescript",
-    },
-
     // Old server page
     {
       source: "/sdk/typescript/server/Request.fromNodeListener",
@@ -513,6 +503,24 @@ export default defineConfig({
                     ],
                   },
                   {
+                    text: "Fetch",
+                    collapsed: true,
+                    items: [
+                      {
+                        text: ".from",
+                        link: "/sdk/typescript/client/Fetch.from",
+                      },
+                      {
+                        text: ".polyfill",
+                        link: "/sdk/typescript/client/Fetch.polyfill",
+                      },
+                      {
+                        text: ".restore",
+                        link: "/sdk/typescript/client/Fetch.restore",
+                      },
+                    ],
+                  },
+                  {
                     text: "Transport",
                     collapsed: true,
                     items: [
@@ -586,6 +594,10 @@ export default defineConfig({
                       {
                         text: ".toNodeListener",
                         link: "/sdk/typescript/server/Mppx.toNodeListener",
+                      },
+                      {
+                        text: ".verifyCredential",
+                        link: "/sdk/typescript/server/Mppx.verifyCredential",
                       },
                     ],
                   },


### PR DESCRIPTION
## Summary

Update the TypeScript SDK docs for mppx 0.6, including

*  Fetch helpers
* Accept-Payment policy controls
* direct Credential verification
* CLI account export
* Tempo session fee payer policy.
