### PR TITLE
docs: add subscription intent page

### DIFF
--- a/src/components/cards.tsx
+++ b/src/components/cards.tsx
@@ -441,6 +441,18 @@ export function TempoSessionCard() {
   );
 }
 
+export function TempoSubscriptionCard() {
+  return (
+    <Card
+      description="Recurring stablecoin payments for paid API plans"
+      icon="lucide:calendar-check"
+      title="Tempo subscription"
+      to="/payment-methods/tempo/subscription"
+      topRight={<Badge variant="info">New</Badge>}
+    />
+  );
+}
+
 export function StripeChargeCard() {
   return (
     <Card

--- a/src/pages/guides/subscription-payments.mdx
+++ b/src/pages/guides/subscription-payments.mdx
@@ -5,11 +5,15 @@ imageDescription: "Build recurring paid API access"
 
 import { MermaidDiagram } from '../../components/MermaidDiagram'
 
-# Manage subscriptions [Recurring access for paid APIs]
+# Create and manage subscriptions [Recurring access for paid APIs]
 
 Build a subscription-gated API that charges $1 for access using `mppx` and Tempo subscriptions.
 
-## How it works
+## Overview
+
+Subscriptions separate access from billing. The client authorizes recurring access once, then keeps using the paid API without paying again on every request.
+
+Your server stores the subscription after the first payment succeeds. Later requests check that stored subscription and return the protected response immediately when access is active. Billing happens on its own schedule: the next request after a billing period ends can renew the subscription, or a background job can renew subscriptions before clients return. This keeps normal API requests simple while recurring payments happen asynchronously.
 
 <MermaidDiagram chart={`sequenceDiagram
     participant Client
@@ -28,9 +32,6 @@ Build a subscription-gated API that charges $1 for access using `mppx` and Tempo
     Server-->>Client: 200 OK + Receipt
 `} />
 
-Subscriptions separate access from billing. The client authorizes recurring access once, then keeps using the paid API without paying again on every request.
-
-Your server stores the subscription after the first payment succeeds. Later requests check that stored subscription and return the protected response immediately when access is active. Billing happens on its own schedule: the next request after a billing period ends can renew the subscription, or a background job can renew subscriptions before clients return. This keeps normal API requests simple while recurring payments happen asynchronously.
 
 ## Install `mppx`
 

--- a/src/pages/intents/subscription.mdx
+++ b/src/pages/intents/subscription.mdx
@@ -1,0 +1,95 @@
+---
+title: "The subscription intent for recurring payments"
+description: "The subscription intent defines recurring fixed payments in MPP. Use it when access renews across billing periods."
+imageDescription: "Collect recurring payments"
+---
+
+import { Cards } from 'vocs'
+import { MermaidDiagram } from '../../components/MermaidDiagram'
+import { TempoSubscriptionCard } from '../../components/cards'
+import { SpecCard } from '../../components/SpecCard'
+
+# Subscription [Recurring paid access]
+
+The `subscription` intent mediates recurring paid access. The client authorizes a fixed payment amount once, and the server reuses that authorization to collect at most one charge per billing period.
+
+## How it works
+
+<MermaidDiagram chart={`sequenceDiagram
+    participant Client
+    participant Server
+    participant Store
+    participant Network as Payment Network
+    Client->>Server: (1) GET /resource
+    Server->>Store: (2) Resolve subscription
+    Server-->>Client: (3) 402 + subscription Challenge
+    Note over Client: (4) Authorize recurring access
+    Client->>Server: (5) GET /resource + Credential
+    Server->>Network: (6) Activate subscription and charge first period
+    Network-->>Server: (7) Confirmed
+    Server->>Store: (8) Store subscription state
+    Server-->>Client: (9) 200 OK + Receipt
+    Client->>Server: (10) Later request
+    Server->>Store: (11) Find active subscription
+    Server-->>Client: (12) 200 OK + Receipt
+`} />
+
+1. **Client:** requests a protected resource
+2. **Server:** resolves whether the request already has an active subscription
+3. **Server:** responds with `402` and a subscription Challenge when no usable subscription exists
+4. **Client:** authorizes the recurring payment terms
+5. **Client:** retries the request with a Credential
+6. **Server:** verifies the Credential, activates the subscription, and charges the first billing period
+7. **Server:** stores durable subscription state and returns a Receipt
+8. **Server:** reuses the active subscription for later requests while the current period is paid
+
+## When to use subscription
+
+Subscription is the best intent when access renews on a fixed schedule:
+
+- **API plans**—Charge a fixed amount per day, week, or month
+- **Memberships**—Keep access active across many requests
+- **Recurring MCP access**—Bill for tool access that renews by period
+- **Usage bundles**—Renew a fixed bundle on a schedule
+
+Use `charge` when each request maps to one payment. Use `session` when usage is metered and the final cost isn't known upfront.
+
+## Request schema
+
+The subscription intent defines the following request fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `amount` | string | Required | Fixed payment amount per billing period in base units |
+| `currency` | string | Required | Currency identifier (token address, currency code) |
+| `description` | string | Optional | Human-readable subscription description |
+| `externalId` | string | Optional | Server-defined subscription reference |
+| `methodDetails` | object | Optional | Method-specific extension data |
+| `periodCount` | string | Required | Positive integer count of `periodUnit` values per billing period |
+| `periodUnit` | string | Required | Billing period unit: `day`, `week`, or `month` |
+| `recipient` | string | Optional | Recipient identifier (address, account ID) |
+| `subscriptionExpires` | string | Optional | RFC 3339 timestamp that bounds the recurring authorization |
+
+Payment methods extend this schema through `methodDetails`. They must reject subscription requests they can't represent exactly.
+
+## Lifecycle
+
+Activation starts the first billing period and collects the first charge. The server returns a Receipt with a `subscriptionId` only after activation succeeds.
+
+Renewal collects at most one charge for each later billing period. Before granting access in an unpaid period, the server must collect the renewal charge or fail the request with `402`.
+
+Reuse is application-defined. Servers use authenticated session state, account identity, resource scope, or another local selector to associate later requests with an active subscription. A `subscriptionId` alone doesn't grant access.
+
+## Method integrations
+
+Each payment method defines how subscription authorization, activation, renewal, and cancellation map to its underlying network.
+
+<Cards>
+  <TempoSubscriptionCard />
+</Cards>
+
+## Specification
+
+<Cards>
+  <SpecCard to="https://paymentauth.org/draft-payment-intent-subscription-00" />
+</Cards>

--- a/src/pages/payment-methods/tempo/index.mdx
+++ b/src/pages/payment-methods/tempo/index.mdx
@@ -8,7 +8,7 @@ import { Badge } from 'vocs'
 
 # Tempo [Stablecoin payments on the Tempo blockchain]
 
-The [Tempo](https://docs.tempo.xyz) payment method enables payments using TIP-20 stablecoins on the Tempo blockchain. Tempo supports multiple intents—**charge** for one-time payments and **session** for pay-as-you-go payment channels—covering everything from simple API access to high-frequency metered billing.
+The [Tempo](https://docs.tempo.xyz) payment method enables payments using TIP-20 stablecoins on the Tempo blockchain. Tempo supports **charge** for one-time payments, **session** for pay-as-you-go payment channels, and **subscription** for recurring access.
 
 ## Payments on Tempo
 
@@ -62,7 +62,7 @@ Tempo is purpose-built for the payment patterns MPP enables:
 
 ## Fee sponsorship
 
-Tempo supports server-paid transaction fees for both charge and session intents. When enabled, the client signs only the payment authorization and the server covers gas costs. The client doesn't need to hold gas tokens or understand fee mechanics.
+Tempo supports server-paid transaction fees for charge, session, and subscription intents. When enabled, the client signs only the payment authorization and the server covers gas costs. The client doesn't need to hold gas tokens or understand fee mechanics.
 
 Pass a `feePayer` account to `tempo()` to enable this:
 

--- a/src/pages/payment-methods/tempo/subscription.mdx
+++ b/src/pages/payment-methods/tempo/subscription.mdx
@@ -190,6 +190,7 @@ Use [`tempo.renewSubscription`](/sdk/typescript/server/Method.tempo.renewSubscri
 
 <Cards>
   <Card title="Build a subscription-gated API" description="Add recurring access to an API route" to="/guides/subscription-payments" />
+  <Card title="Subscription intent" description="Understand the method-agnostic recurring payment intent" to="/intents/subscription" />
   <Card title="Server API reference" description="Configure activation, reuse, and renewal" to="/sdk/typescript/server/Method.tempo.subscription" />
   <Card title="Client API reference" description="Sign subscription key authorizations" to="/sdk/typescript/client/Method.tempo.subscription" />
 </Cards>

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -89,6 +89,7 @@ Payment intents describe the type of payment being requested. Common intents inc
 
 - **`charge`**—One-time payment that settles immediately
 - **`session`**—Streaming payment over a payment channel
+- **`subscription`**—Recurring fixed payment for paid access across billing periods
 
 Intent Specifications define:
 
@@ -101,6 +102,7 @@ Servers can offer multiple intents in separate challenges, allowing clients to c
 ```http
 WWW-Authenticate: Payment id="abc", method="tempo", intent="charge", ...
 WWW-Authenticate: Payment id="def", method="tempo", intent="session", ...
+WWW-Authenticate: Payment id="ghi", method="tempo", intent="subscription", ...
 ```
 
 ## Request body binding
@@ -217,7 +219,7 @@ import { SpecCard } from "../../components/SpecCard";
 <Cards>
   <SpecCard to="https://paymentauth.org/draft-httpauth-payment-00" title="Payment HTTP Authentication Scheme" description="Core protocol spec (draft-httpauth-payment-00)" />
   <SpecCard to="https://paymentauth.org/draft-payment-transport-mcp-00" title="MCP Transport" description="Model Context Protocol binding" />
-  <SpecCard to="https://paymentauth.org" title="Payment Methods and Intents" description="Method and intent definitions (charge, session)" />
+  <SpecCard to="https://paymentauth.org" title="Payment Methods and Intents" description="Method and intent definitions (charge, session, subscription)" />
   <SpecCard to="https://paymentauth.org" title="All Specifications" description="Browse the full specification directory" />
 </Cards>
 

--- a/src/pages/sdk/features.mdx
+++ b/src/pages/sdk/features.mdx
@@ -31,6 +31,7 @@ Additional payment methods implement their own SDKs. Refer to the maintaining or
 |---|---|---|---|---|
 | [Charge](/intents/charge) | ✓ | ✓ | ✓ | ✓ |
 | [Session](/payment-methods/tempo/session) | ✓ | ✓ | — | — |
+| [Subscription](/intents/subscription) | ✓ | — | — | — |
 
 ## Transports
 

--- a/src/pages/sdk/typescript/client/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.mdx
@@ -4,7 +4,7 @@ description: "Register Tempo charge and session support in an MPP TypeScript cli
 imageDescription: "Handle Tempo payments in TypeScript clients"
 ---
 
-# `tempo` [Register all Tempo intents]
+# `tempo` [Register default Tempo intents]
 
 Convenience function that creates both `tempo.charge` and `tempo.session` method intents with shared configuration.
 

--- a/src/pages/sdk/typescript/server/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.mdx
@@ -4,7 +4,7 @@ description: "Register Tempo charge and session support in an MPP TypeScript ser
 imageDescription: "Accept Tempo payments in TypeScript servers"
 ---
 
-# `tempo` [Register all Tempo intents]
+# `tempo` [Register default Tempo intents]
 
 Convenience function that creates both `tempo.charge` and `tempo.session` method intents with shared configuration.
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -298,7 +298,7 @@ export default defineConfig({
             link: "/guides/streamed-payments",
           },
           {
-            text: "Manage subscriptions",
+            text: "Create and manage subscriptions",
             link: "/guides/subscription-payments",
           },
           {

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -377,7 +377,10 @@ export default defineConfig({
           {
             text: "Intents",
             collapsed: true,
-            items: [{ text: "Charge", link: "/intents/charge" }],
+            items: [
+              { text: "Charge", link: "/intents/charge" },
+              { text: "Subscription", link: "/intents/subscription" },
+            ],
           },
           {
             text: "Tempo",


### PR DESCRIPTION
## Summary

Add the subscription intent page, wire it into docs navigation and support tables, and link it from the Tempo subscription docs.