### PR TITLE
Update subscriptions blog route

### DIFF
--- a/src/pages/blog/index.mdx
+++ b/src/pages/blog/index.mdx
@@ -19,7 +19,7 @@ import { BlogPostList } from "../../components/BlogPostList";
     date: "May 12, 2026",
     title: "Subscriptions",
     description: <>Subscriptions enable recurring access for paid plans, memberships, and API tiers.</>,
-    to: "/blog/subscriptions-developer-preview",
+    to: "/blog/subscriptions",
   },
   {
     date: "Apr 28, 2026",

--- a/src/pages/blog/subscriptions.mdx
+++ b/src/pages/blog/subscriptions.mdx
@@ -16,7 +16,7 @@ import { MermaidDiagram } from "../../components/MermaidDiagram";
 
 <p className="blog-date" style={{ color: 'var(--vocs-color_text3)', fontSize: '14px' }}>May 12, 2026</p>
 
-# Subscriptions [Recurring payments]
+# Subscriptions [Subscriptions enable recurring access for paid plans, memberships, and API tiers.]
 
 MPP now supports subscriptions, beginning with stablecoin payments on Tempo. Subscriptions let a client authorize recurring payments once, then reuse paid access across requests.
 


### PR DESCRIPTION
## Summary

Update the subscriptions blog slug to `/blog/subscriptions` and align the page subtitle with the recurring access copy.
