### PR TITLE
Update subscriptions blog copy

### DIFF
--- a/src/pages/blog/index.mdx
+++ b/src/pages/blog/index.mdx
@@ -18,7 +18,7 @@ import { BlogPostList } from "../../components/BlogPostList";
   {
     date: "May 12, 2026",
     title: "Subscriptions",
-    description: <>Subscriptions enable recurring access for paid plans, memberships, and API tiers.</>,
+    description: <>Enabling recurring access for paid plans, memberships, and API tiers.</>,
     to: "/blog/subscriptions",
   },
   {

--- a/src/pages/blog/subscriptions.mdx
+++ b/src/pages/blog/subscriptions.mdx
@@ -4,7 +4,7 @@ outline: false
 showAskAi: false
 showFeedback: false
 showSearch: false
-description: "Subscriptions enable recurring access for paid plans, memberships, and API tiers."
+description: "Enabling recurring access for paid plans, memberships, and API tiers."
 imageDescription: "Recurring access with subscriptions"
 ---
 
@@ -16,7 +16,7 @@ import { MermaidDiagram } from "../../components/MermaidDiagram";
 
 <p className="blog-date" style={{ color: 'var(--vocs-color_text3)', fontSize: '14px' }}>May 12, 2026</p>
 
-# Subscriptions [Subscriptions enable recurring access for paid plans, memberships, and API tiers.]
+# Subscriptions [Enabling recurring access for paid plans, memberships, and API tiers.]
 
 MPP now supports subscriptions, beginning with stablecoin payments on Tempo. Subscriptions let a client authorize recurring payments once, then reuse paid access across requests.
 


### PR DESCRIPTION
## Summary

Update the subscriptions blog copy to use `Enabling recurring access for paid plans, memberships, and API tiers.`
