### PR TITLE
feat(og): add Blog category to OG image generator

### DIFF
--- a/src/pages/_api/api/og.tsx
+++ b/src/pages/_api/api/og.tsx
@@ -17,6 +17,7 @@ const sidebarCategories: Record<string, string> = {
   "/sdk": "SDKs",
   "/brand": "Resources",
   "/services": "Services",
+  "/blog": "Blog",
 };
 
 const sidebarSubcategories: Record<string, string> = {


### PR DESCRIPTION
Blog posts at `/blog/*` now show a **BLOG** category label in the top-left of generated OG images, matching how docs sections already display their category.

Fixes the missing category on blog post OG images (e.g. `/blog/subscriptions`).