### PR TITLE
Add fal image-to-image service endpoint

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -990,6 +990,11 @@ export const services: ServiceDef[] = [
         amount: "25000",
       },
       {
+        route: "POST /fal-ai/flux/dev/image-to-image",
+        desc: "FLUX.1 [dev] - Image-to-image editing and transformations",
+        amount: "25000",
+      },
+      {
         route: "POST /fal-ai/flux/schnell",
         desc: "FLUX.1 [schnell] - Fast text-to-image (1-4 steps)",
         amount: "3000",


### PR DESCRIPTION
## Summary
- Add the fal.ai FLUX dev image-to-image endpoint to the MPP services registry
- Use the current fixed FLUX dev one-image price ($0.025 / 25000 base units); true request-aware pricing needs a proxy-runtime handler that parses the request body before issuing the 402 challenge

## Testing
- node scripts/generate-discovery.ts
- corepack pnpm exec vitest run --mode production schemas/services.test.ts scripts/generate-discovery.test.ts
- corepack pnpm exec biome check --write schemas/services.ts
- corepack pnpm exec tsc --noEmit