### PR TITLE
feat: add honeypot service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -5348,6 +5348,81 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── honeypot ─────────────────────────────────────────────────────────
+  {
+    id: "honeypot",
+    name: "honeypot",
+    url: "https://honeypot.ivan-tempo.xyz",
+    serviceUrl: "https://honeypot.ivan-tempo.xyz",
+    description:
+      "Multi-chain token honeypot and security checker. Detects honeypots, taxes, owner privileges, blacklist functions, contract vulnerabilities, and wallet risk scores via GoPlus Security across 8 EVM chains (Ethereum, BSC, Polygon, Avalanche, Arbitrum, Optimism, Base, Fantom).",
+    categories: ["blockchain", "data"],
+    integration: "third-party",
+    tags: [
+      "honeypot",
+      "security",
+      "token-safety",
+      "goplus",
+      "rugcheck",
+      "wallet-risk",
+      "ethereum",
+      "bsc",
+      "polygon",
+      "evm",
+      "multichain",
+      "defi",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://honeypot.ivan-tempo.xyz",
+      apiReference: "https://honeypot.ivan-tempo.xyz/openapi.json",
+    },
+    provider: { name: "honeypot", url: "https://honeypot.ivan-tempo.xyz" },
+    realm: "honeypot.ivan-tempo.xyz",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /api/check?token=0x...&chain=1",
+        desc: "Basic honeypot check: isHoneypot, buy/sellTax, isOpenSource, isProxy, isMintable, ownerCanChangeBalance, hasBlacklist, antiWhale, transferPausable. Supports 8 EVM chains. Results cached 5 min.",
+        amount: "20000",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/check/deep?token=0x...&chain=1",
+        desc: "Deep analysis: all basic fields plus LP analysis (lockedPercent, dex list, pair addresses), top 10 token holders, creator and owner info, cannotSellAll, tradingCooldown, hiddenOwner. Results cached 5 min.",
+        amount: "40000",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/check/batch?tokens=0x...,0x...&chain=1",
+        desc: "Batch basic honeypot check for up to 20 tokens in one request. Price is dynamic: N tokens × $0.01. Results cached 5 min per token.",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/wallet-risk?address=0x...&chain=1",
+        desc: "Address security check via GoPlus: cybercrime, money_laundering, sanctioned, phishing, blackmail, darkweb_transactions flags. Returns riskScore 0–100 and riskLevel (clean/low/medium/high). Results cached 5 min.",
+        amount: "20000",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/lp?token=0x...&chain=1",
+        desc: "Liquidity pool details: dex list, pair addresses, liquidity amounts, LP holders, and locked LP percentage. Results cached 5 min.",
+        amount: "20000",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/info",
+        desc: "Service metadata — payment details, supported chains, endpoint list (free)",
+      },
+      {
+        route: "GET /openapi.json",
+        desc: "OpenAPI 3.1 spec for agent discovery (free)",
+      },
+    ],
+  },
+
   // ── Hunter ───────────────────────────────────────────────────────────
   {
     id: "hunter",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -5771,6 +5771,30 @@ export const services: ServiceDef[] = [
         unitType: "request",
       },
       {
+        route: "GET /api/gas/deep",
+        desc: "EIP-1559 breakdown: baseFee, priorityFee (slow/standard/fast), maxFeePerGas recommendations, block number and timestamp. Falls back to legacy gasPrice for non-EIP-1559 chains.",
+        amount: "20000",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/gas/forecast",
+        desc: "30-min linear trend forecast based on rolling 10-min sample buffer. Returns now / in15min / in30min gwei per chain. Falls back to 'insufficient data' on cold start.",
+        amount: "20000",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/gas/spike?chain=ethereum",
+        desc: "Spike detector. Compares current standard gwei against rolling 1h average. Returns isSpike=true if current > avg + 2*stddev. Supports all 7 chains via query param.",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/gas/best-time?chain=ethereum",
+        desc: "Finds cheapest UTC hour from 24h rolling buffer. Returns currentVsCheapest percentage and recommendation 'send now' or 'wait'.",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
         route: "GET /api/info",
         desc: "Service metadata — payment details, gas-abstraction status (free)",
       },

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -5734,8 +5734,8 @@ export const services: ServiceDef[] = [
   {
     id: "mppgas",
     name: "mppgas",
-    url: "https://mppgas.vercel.app",
-    serviceUrl: "https://mppgas.vercel.app",
+    url: "https://gas.ivan-tempo.xyz",
+    serviceUrl: "https://gas.ivan-tempo.xyz",
     description:
       "Multi-chain gas tracker. Returns current slow/standard/fast gas prices in gwei, native token USD price, and estimated 21k-gas transfer cost in USD for Ethereum, Base, Arbitrum, Optimism, Polygon, BSC, and Tempo.",
     categories: ["blockchain", "data"],
@@ -5756,11 +5756,11 @@ export const services: ServiceDef[] = [
     ],
     status: "active",
     docs: {
-      homepage: "https://mppgas.vercel.app",
-      apiReference: "https://mppgas.vercel.app/openapi.json",
+      homepage: "https://gas.ivan-tempo.xyz",
+      apiReference: "https://gas.ivan-tempo.xyz/openapi.json",
     },
-    provider: { name: "mppgas", url: "https://mppgas.vercel.app" },
-    realm: "mppgas.vercel.app",
+    provider: { name: "mppgas", url: "https://gas.ivan-tempo.xyz" },
+    realm: "gas.ivan-tempo.xyz",
     intent: "charge",
     payments: [TEMPO_PAYMENT],
     endpoints: [

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -5730,6 +5730,53 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── mppgas ───────────────────────────────────────────────────────────
+  {
+    id: "mppgas",
+    name: "mppgas",
+    url: "https://mppgas.vercel.app",
+    serviceUrl: "https://mppgas.vercel.app",
+    description:
+      "Multi-chain gas tracker. Returns current slow/standard/fast gas prices in gwei, native token USD price, and estimated 21k-gas transfer cost in USD for Ethereum, Base, Arbitrum, Optimism, Polygon, BSC, and Tempo.",
+    categories: ["blockchain", "data"],
+    integration: "third-party",
+    tags: [
+      "gas",
+      "gas-price",
+      "ethereum",
+      "base",
+      "arbitrum",
+      "optimism",
+      "polygon",
+      "bsc",
+      "tempo",
+      "multichain",
+      "defi",
+      "evm",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://mppgas.vercel.app",
+      apiReference: "https://mppgas.vercel.app/openapi.json",
+    },
+    provider: { name: "mppgas", url: "https://mppgas.vercel.app" },
+    realm: "mppgas.vercel.app",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /api/gas",
+        desc: "Gas prices (slow/standard/fast gwei), native token USD price, and 21k-gas transfer cost for all 7 chains. Cached 10s per chain.",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/info",
+        desc: "Service metadata — payment details, gas-abstraction status (free)",
+      },
+    ],
+  },
+
   // ── OpenWeather ──────────────────────────────────────────────────────
   {
     id: "openweather",


### PR DESCRIPTION
## Summary

- Adds **honeypot** — multi-chain token honeypot and security checker via GoPlus Security API
- 5 paid endpoints + 2 free, 8 EVM chains (Ethereum, BSC, Polygon, Avalanche, Arbitrum, Optimism, Base, Fantom)
- Alphabetically inserted between Holidays and Hunter

## Endpoints

| Route | Price |
|---|---|
| `GET /api/check?token=0x...&chain=1` | $0.02 |
| `GET /api/check/deep?token=0x...&chain=1` | $0.04 |
| `GET /api/check/batch?tokens=0x...,0x...&chain=1` | $0.01/token |
| `GET /api/wallet-risk?address=0x...&chain=1` | $0.02 |
| `GET /api/lp?token=0x...&chain=1` | $0.02 |
| `GET /api/info` | free |
| `GET /openapi.json` | free |

## Links

- Service: https://honeypot.ivan-tempo.xyz
- OpenAPI: https://honeypot.ivan-tempo.xyz/openapi.json