### PR TITLE
add bluerails402 publisher registry

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6573,6 +6573,35 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── bluerails402 ───────────────────────────────────────────────────────
+  {
+    id: "bluerails402",
+    name: "bluerails402 Publisher Registry",
+    url: "https://bluerails402.com",
+    serviceUrl: "https://bluerails402.com/mcp",
+    description:
+      "EU news and media publisher registry for AI agents. Discover publishers accepting agentic payments via MCP — EU-first, MiCA-aligned, x402-native.",
+
+    categories: ["media", "data"],
+    integration: "third-party",
+    tags: ["publishers", "news", "media", "mcp", "x402", "eu", "mica"],
+    docs: {
+      homepage: "https://bluerails402.com",
+      llmsTxt: "https://bluerails402.com/llms.txt",
+    },
+    provider: { name: "Bluerails", url: "https://bluerails402.com" },
+    realm: "bluerails402.com",
+    intent: "charge",
+    payments: [],
+    endpoints: [
+      {
+        route: "POST /mcp",
+        desc: "MCP JSON-RPC — list_publishers, get_publisher (public); get_fx_quote, fetch_content (X-API-Key required)",
+        docs: "https://bluerails402.com/openapi.json",
+      },
+    ],
+  },
+
   // ── Papercut ───────────────────────────────────────────────────────────
   {
     id: "papercut",


### PR DESCRIPTION
## What

Adds bluerails402.com — an EU news and media publisher registry for AI agents — to the MPP service directory.

## Service

- **Site:** https://bluerails402.com
- **MCP endpoint:** https://bluerails402.com/mcp (HTTP Streamable transport)
- **Public tools:** `list_publishers`, `get_publisher` (no auth required)
- **Authenticated tools:** `get_fx_quote`, `fetch_content` (X-API-Key required)
- **Coverage:** EU news/media publishers accepting agentic payments (x402-native, MiCA-aligned)
- **Discovery endpoints:** `/llms.txt`, `/openapi.json`, `/.well-known/agent.json`, `/.well-known/mcp.json`

## Notes

- `payments: []` — x402 payment integration is in progress; listing is informational for now
- 158+ EU publishers seeded (Bild, Spiegel, Zeit, Le Monde, Le Figaro, etc.)