### PR TITLE
feat(services): add JustaName ENS Resolver

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -74,6 +74,13 @@ export const STRIPE_PAYMENT: PaymentDefaults = {
   decimals: 2,
 };
 
+/** EVM payment defaults — USDC on Base mainnet (per `draft-evm-charge-00`) */
+export const EVM_USDC_BASE_PAYMENT: PaymentDefaults = {
+  method: "evm",
+  currency: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  decimals: 6,
+};
+
 export interface EndpointDef {
   /** Route string: "METHOD /path" (without service slug prefix) */
   route: string;
@@ -6599,6 +6606,49 @@ export const services: ServiceDef[] = [
         desc: "Write and send an agent-penned postcard",
         dynamic: true,
         amountHint: "$1 digital, $3 physical",
+      },
+    ],
+  },
+
+  // ── JustaName ───────────────────────────────────────────────────────────
+  {
+    id: "justaname",
+    name: "JustaName ENS Resolver",
+    url: "https://api.justaname.id",
+    serviceUrl: "https://api.justaname.id",
+    description:
+      "ENS forward and reverse resolution with on-chain CCIP-Read. Batch up to 50 names or addresses per call with per-name chain scoping via interop addresses. Optional BYO-RPC bypass (caller pays upstream RPC compute, request becomes free).",
+
+    categories: ["blockchain", "web"],
+    integration: "third-party",
+    tags: [
+      "ens",
+      "resolver",
+      "ccip-read",
+      "ensip-19",
+      "base",
+      "reverse-resolution",
+      "subnames",
+      "x402",
+      "evm",
+    ],
+    docs: { homepage: "https://docs.justaname.id" },
+    provider: { name: "JustaName", url: "https://www.justaname.id" },
+    realm: "api.justaname.id",
+    intent: "charge",
+    payments: [EVM_USDC_BASE_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /ens/v2/resolve",
+        desc: "Resolve ENS name(s) into addresses, text records, and content hash. Repeat ?ens=a.eth&ens=b.eth to batch up to 50 names.",
+        amount: "1000",
+        unitType: "request",
+      },
+      {
+        route: "GET /ens/v2/reverse",
+        desc: "ENSIP-19 reverse resolution with a 3-step fallback chain (on-chain primary name → ENSIP-19 default coinType → offchain primary-name store). Batch up to 50 addresses.",
+        amount: "1000",
+        unitType: "request",
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Adds **JustaName ENS Resolver** to the MPP service registry — ENS forward + reverse resolution with on-chain CCIP-Read.
- Two paid endpoints: `GET /ens/v2/resolve` and `GET /ens/v2/reverse` (1000 base units = 0.001 USDC per request, batch up to 50).
- First entry using `method: "evm"` — adds an `EVM_USDC_BASE_PAYMENT` preset (USDC on Base mainnet) alongside the existing `TEMPO_PAYMENT` and `STRIPE_PAYMENT` presets.

## Why a new preset

The `evm` payment method is formally specified in [`mpp-specs/specs/methods/evm/draft-evm-charge-00.md`](https://github.com/tempoxyz/mpp-specs/blob/main/specs/methods/evm/draft-evm-charge-00.md) (DiNovi / Swenberg / Scott, 2026) but the schema in this repo didn't yet have a preset for it. `EVM_USDC_BASE_PAYMENT` mirrors the existing `TEMPO_PAYMENT` / `STRIPE_PAYMENT` shape:

```ts
export const EVM_USDC_BASE_PAYMENT: PaymentDefaults = {
  method: "evm",
  currency: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // USDC on Base mainnet
  decimals: 6,
};
```

Happy to rename / restructure if the maintainers prefer a different shape (e.g. a generic `EVM_PAYMENT` parametrised by chain + token, or per-chain constants `EVM_USDC_BASE_PAYMENT` / `EVM_USDC_OPTIMISM_PAYMENT` / etc.).

## Live and accepting payments

Two real settlements on Base mainnet today via MPP-charge (`draft-evm-charge-00`, `type="authorization"` / EIP-3009 `transferWithAuthorization`), settled through the Coinbase CDP facilitator:

| Endpoint | Settlement tx |
|---|---|
| `GET /ens/v2/resolve?ens=vitalik.eth` | [0xc56fecf6…f909c](https://basescan.org/tx/0xc56fecf633daafae6d52a80b0f78f16ee3dfc97d7ce7dc067ced19c28b5f909c) |
| `GET /ens/v2/reverse?address=0xd8dA…6045&coinType=60` | [0x254bac08…a089e](https://basescan.org/tx/0x254bac08f86db59aa666a2409d9915d941fd88d11139ac28d2ce3596feda089e) |

Both transferred 0.001 USDC to `0xC529EDD6D47C60923902514C7C0B3993ae42C2ec`. The pricing endpoint advertises both `x402` and `mpp-charge` schemes per route:

```bash
curl -s https://api.justaname.id/ens/v2/pricing | jq
# { "routes": [
#   { "path": "/ens/v2/resolve", "schemes": ["x402","mpp-charge"], "amount": "1000",
#     "asset": "USDC", "network": "eip155:8453", ... },
#   { "path": "/ens/v2/reverse", "schemes": ["x402","mpp-charge"], ... }
# ]}
```

Also registered on [MPPScan](https://www.mppscan.com/server/614e588405cd8b6e280ec37e30cbdb823349b865ea28f97cef3557fcb13609f0).

## Discovery surfaces already live

- [Coinbase Bazaar](https://api.cdp.coinbase.com/platform/v2/x402/discovery/merchant?payTo=0xC529EDD6D47C60923902514C7C0B3993ae42C2ec) — both resources indexed.
- [x402scan](https://www.x402scan.com/server/4a86b269-e674-4d07-b43e-b501cb62d245) — indexed via their own crawler.
- [agentcash CLI](https://www.npmjs.com/package/@agentcash/discovery) — `discover` returns the full route list.

## Checklist

- [x] Service is live and accepting payments via MPP
- [x] Entry added to `schemas/services.ts`
- [x] `pnpm check:types` passes
- [x] `pnpm build` passes
- [x] `pnpm exec vitest run --mode production schemas/services.test.ts scripts/generate-discovery.test.ts` — **5683/5683 passing**
- [x] `pnpm exec biome check schemas/services.ts` clean
- [x] `pnpm generate:discovery` regenerates correctly (94 services, 848 endpoints, +2 from before)

## Notes for reviewers

- `serviceUrl === url` (no proxy host) — same pattern as Papercut (#600 precedent: molty.cash also lists x402-on-Base as a settlement rail).
- `payments: [EVM_USDC_BASE_PAYMENT]` reflects the actual `/ens/v2/pricing` declaration; we don't accept Tempo today, so we don't claim it.