### PR TITLE
Add Link CLI to wallet and Stripe docs

### DIFF
--- a/src/pages/payment-methods/stripe/charge.mdx
+++ b/src/pages/payment-methods/stripe/charge.mdx
@@ -170,6 +170,10 @@ See the [payment links guide](/guides/payment-links) for a full walkthrough and 
 
 ## Client
 
+::::tip[For agents]
+The [Link CLI](/tools/wallet#link-cli) handles `stripe.charge` end-to-end—`link-cli mpp pay` parses the 402 Challenge, creates an SPT from the user's Link wallet, and retries the request with the Credential. No code required.
+::::
+
 Use `stripe` with `Mppx.create` to automatically handle `402` responses. The client parses the Challenge, creates an SPT through the `createToken` callback, and retries with the Credential.
 
 SPT creation requires a Stripe secret key, so the client accepts a `createToken` callback that proxies through a server endpoint. You can optionally pass a `client` (a Stripe.js instance from `@stripe/stripe-js`) which is forwarded to the `createToken` callback for use with Elements.

--- a/src/pages/payment-methods/stripe/index.mdx
+++ b/src/pages/payment-methods/stripe/index.mdx
@@ -20,6 +20,10 @@ Machine payments must be enabled on your Stripe account before you can accept MP
 
 To learn more, read the [Stripe documentation](https://docs.stripe.com/payments/machine/mpp) on accepting MPP.
 
+::::tip[For agents]
+Use the [Link CLI](/tools/wallet#link-cli) to pay for `stripe.charge` services from a Link wallet without writing integration code. `link-cli mpp pay` handles the full 402 → SPT → retry flow automatically.
+::::
+
 ## How it works
 
 <MermaidDiagram chart={`sequenceDiagram

--- a/src/pages/tools/wallet.mdx
+++ b/src/pages/tools/wallet.mdx
@@ -14,6 +14,7 @@ Agents need a wallet to pay for MPP-enabled services. Choose the wallet that fit
 | [Tempo Wallet](#tempo-wallet) | Tempo MPP services with spend controls and service discovery | `tempo` | `tempo wallet login` |
 | [Privy Agent CLI](#privy-agent-cli) | Multi-chain agent wallets with browser-based funding | `tempo`, `solana` | `privy-agent-wallets login` |
 | [AgentCash](#agentcash) | Discover and use 300+ premium APIs via MPP | `tempo` | `npx agentcash onboard` |
+| [Link CLI](#link-cli) | Stripe payments via Link wallet | `stripe` | `link-cli auth login` |
 | [`mppx` CLI](#mppx) | Development and debugging | All | `mppx account create` |
 
 ## Tempo Wallet 
@@ -198,6 +199,66 @@ $ claude mcp add agentcash --scope user -- npx -y agentcash@latest
 - **No human required** - pay per request with USDC.e, no subscriptions or manual sign-up flows
 - **API and tool discovery** - any service that implements MPP is automatically discoverable and usable
 - **MPPScan integration** — easily discover and use services via [mppscan.com](https://www.mppscan.com/)
+
+## Link CLI
+
+[Link CLI](https://github.com/stripe/link-cli) lets agents pay for MPP services using a [Link](https://link.co) wallet. The agent authenticates with Link, then `link-cli mpp pay` handles the full `402` → SPT → retry flow automatically—no Stripe integration code required.
+
+The user approves each purchase via the Link app, and credentials are one-time-use tokens scoped to a specific merchant and amount.
+
+<Tabs>
+<Tab title="Agent">
+
+Paste this into your agent:
+
+```
+Read https://github.com/stripe/link-cli/blob/main/SKILL.md and set up link-cli
+```
+
+</Tab>
+<Tab title="Human">
+::::steps
+
+### Install
+
+```bash [terminal]
+$ npm install -g @stripe/link-cli
+```
+
+### Log in
+
+```bash [terminal]
+$ link-cli auth login --client-name "My Agent"
+```
+
+This displays a verification URL and phrase. Approve in the Link app to complete authentication.
+
+### List payment methods
+
+```bash [terminal]
+$ link-cli payment-methods list
+```
+
+### Make a paid request
+
+```bash [terminal]
+$ link-cli mpp pay https://api.example.com/resource \
+  --method POST \
+  --data '{"prompt": "hello"}'
+```
+
+::::
+</Tab>
+</Tabs>
+
+**Supported methods:** <Badge variant="info">stripe.charge</Badge>
+
+**Key features:**
+
+- **End-to-end 402 handling**—`link-cli mpp pay` parses the Challenge, creates an SPT, and retries with the Credential
+- **User approval**—each purchase requires explicit approval in the Link app
+- **One-time-use credentials**—SPTs are scoped to a specific merchant, amount, and context
+- **MCP server mode**—run as `link-cli --mcp` for integration with Claude Code and other MCP-compatible agents
 
 ## `mppx`
 


### PR DESCRIPTION
Adds Link CLI as a wallet option and references it on the Stripe payment method pages.