### PR TITLE
Add Sayer & Stone to service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -4002,6 +4002,61 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Sayer & Stone ───────────────────────────────────────────────────────
+  {
+    id: "sayer-and-stone",
+    name: "Sayer & Stone",
+    url: "https://www.sayerandstone.com",
+    serviceUrl: "https://agents.sayerandstone.com",
+    description:
+      "Lab-grown diamond fine jewelry, made to order. AI agents can browse and purchase pieces.",
+
+    categories: ["web"],
+    integration: "first-party",
+    tags: [
+      "jewelry",
+      "commerce",
+      "physical-goods",
+      "lab-grown-diamond",
+      "made-to-order",
+      "luxury",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://www.sayerandstone.com",
+      llmsTxt: "https://agents.sayerandstone.com/llms.txt",
+      apiReference: "https://agents.sayerandstone.com/openapi.json",
+    },
+    provider: { name: "Sayer & Stone", url: "https://www.sayerandstone.com" },
+    realm: "agents.sayerandstone.com",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT, STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /catalog",
+        desc: "List products with embedded variants",
+      },
+      {
+        route: "GET /catalog/:slug",
+        desc: "Get product detail by slug, including all variants",
+      },
+      {
+        route: "POST /purchase",
+        desc: "Purchase a jewelry piece",
+        dynamic: true,
+        amountHint: "Variable",
+      },
+      {
+        route: "GET /orders/:id",
+        desc: "Retrieve order details",
+      },
+      {
+        route: "GET /orders/:id/status",
+        desc: "Check payment status",
+      },
+    ],
+  },
+
   // ── Megapot ─────────────────────────────────────────────────────────────
   {
     id: "megapot",


### PR DESCRIPTION
## Summary

Adds Sayer & Stone to the service directory — lab-grown diamond fine jewelry, made to order. AI agents can browse the catalog and purchase pieces. Accepts Tempo USDC and Stripe.

- Live service: https://agents.sayerandstone.com
- OpenAPI: https://agents.sayerandstone.com/openapi.json
- llms.txt: https://agents.sayerandstone.com/llms.txt
- Homepage: https://www.sayerandstone.com
- MPPScan: https://www.mppscan.com/server/06907d680c2aeff96553e87e7fcf4fe8ed890ee71ba0857a389bce95fb111328

## Required checklist

- [x] Service is **live and accepting payments** via MPP (not a placeholder)
- [x] Entry added to `schemas/services.ts`
- [x] Types pass: `pnpm check:types`
- [x] Build succeeds: `pnpm build`
- [x] Tests pass: `pnpm test` (`schemas/services.test.ts`, 5670/5670)
- [x] Biome clean on changed file: `pnpm check schemas/services.ts`

## Recommended

- [x] Registered on MPPScan

## Endpoints

All 5 endpoints match the live `openapi.json`. Paths are written in the repo's `:param` convention (matching AgentMail, DripStack, Martin Estate, etc.) — the live OpenAPI spec uses the equivalent `{param}` form.

- `GET /catalog` — list products with embedded variants
- `GET /catalog/:slug` — product detail
- `POST /purchase` — dynamic price
- `GET /orders/:id` — order detail
- `GET /orders/:id/status` — payment status