### PR TITLE
feat: add Error Therapist — psychological analysis of error messages

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6657,4 +6657,41 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── Error Therapist ────────────────────────────────────────────────────────
+  {
+    id: "error-therapist",
+    name: "Error Therapist",
+    url: "https://mpp-service-one.vercel.app",
+    serviceUrl: "https://mpp-service-one.vercel.app",
+    description:
+      "Psychological analysis of error messages. Send any error message or stack trace, receive a complete personality profile, diagnosis, and reconciliation advice.",
+
+    categories: ["ai", "data"],
+    integration: "first-party",
+    tags: [
+      "errors",
+      "debugging",
+      "psychology",
+      "analysis",
+      "diagnosis",
+      "developer-tools",
+      "humor",
+    ],
+    docs: { homepage: "https://mpp-service-one.vercel.app" },
+    provider: {
+      name: "Error Therapist",
+      url: "https://mpp-service-one.vercel.app",
+    },
+    realm: "mpp-service-one.vercel.app",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /api/therapy",
+        desc: "Psychological analysis of an error message or stack trace. Returns Myers-Briggs personality type, emotional subtext, root trauma, diagnosis, and reconciliation advice.",
+        amount: "10000",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Error Therapist

First-party MPP service returning psychological profiles of error messages. Send any error message or stack trace, receive a full personality breakdown.

**Live:** https://mpp-service-one.vercel.app
**OpenAPI:** https://mpp-service-one.vercel.app/api/openapi
**Price:** 0.01 USDC per session (Tempo mainnet, chain 4217)

### Checklist
- [x] Service is live and accepting MPP payments
- [x] Entry added to `schemas/services.ts`
- [x] OpenAPI discovery at `/api/openapi`
- [x] 402 + WWW-Authenticate on unpaid requests