### PR TITLE
Add Weftly to service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6657,4 +6657,62 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── Weftly ─────────────────────────────────────────────────────────────
+  {
+    id: "weftly",
+    name: "Weftly",
+    url: "https://weftly.ai",
+    serviceUrl: "https://api.weftly.ai",
+    description:
+      "Pay-per-job audio/video processing: transcribe, summarize, find clips, and cut horizontal or 9:16 vertical clips for short-form social. Per-call MPP payment — no API keys or accounts.",
+
+    categories: ["media", "ai"],
+    integration: "first-party",
+    tags: [
+      "transcription",
+      "video",
+      "audio",
+      "clips",
+      "summarization",
+      "subtitles",
+      "mcp",
+    ],
+    docs: {
+      homepage: "https://weftly.ai",
+      apiReference: "https://api.weftly.ai/openapi.json",
+    },
+    provider: { name: "Woven Record Media", url: "https://weftly.ai" },
+    realm: "api.weftly.ai",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT, STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /api/v1/jobs",
+        desc: "Create a transcribe, summarize, find_clips, extract_clip, or extract_vertical_clip job",
+        dynamic: true,
+        amountHint: "$0.50 – $2.00 depending on job type",
+      },
+      {
+        route: "POST /api/v1/jobs/:job_id/complete-upload",
+        desc: "Confirm upload and start processing — upload-based jobs (transcribe, summarize, find_clips)",
+        dynamic: true,
+        amountHint: "$0.50 – $2.00 depending on job type",
+      },
+      {
+        route: "POST /api/v1/jobs/:job_id/process",
+        desc: "Verify payment and start processing — derivative jobs (extract_clip, extract_vertical_clip)",
+        amount: "500000",
+      },
+      {
+        route: "GET /api/v1/jobs/:job_id",
+        desc: "Get job status and output download URLs",
+      },
+      {
+        route: "GET /api/test",
+        desc: "MPP smoke test endpoint",
+        amount: "10000",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary

Adds [Weftly](https://weftly.ai) — pay-per-job audio/video processing — to the curated services list.

- **What it does:** transcribe, summarize, find clips, extract horizontal clips, and extract 9:16 vertical clips for short-form social
- **Payment:** MPP-paid via Tempo USDC.e (primary) or Stripe SPT
- **Live at:** `https://api.weftly.ai` — production endpoints accepting MPP payments today
- **Discovery:** [`https://api.weftly.ai/.well-known/mpp.json`](https://api.weftly.ai/.well-known/mpp.json)

## Checklist

- [x] Service is **live and accepting payments** via MPP (production endpoints behind 402 + WWW-Authenticate)
- [x] Added entry to `schemas/services.ts`
- [x] `pnpm check:types` passes
- [x] `pnpm build` succeeds
- [x] Already registered on MPPScan

## Test plan

- [ ] CI passes on this PR
- [ ] Maintainer reviews the entry and confirms category/tag fit