### PR TITLE
Add agentfax to the service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -122,6 +122,37 @@ export interface ServiceDef {
 
 // prettier-ignore
 export const services: ServiceDef[] = [
+  // ── agentfax ───────────────────────────────────────────────────────────
+  {
+    id: "agentfax",
+    name: "agentfax",
+    url: "https://agentfax.val.run",
+    serviceUrl: "https://agentfax.val.run",
+    description: "Send a fax to any phone number, priced per page. Pay-per-fax for AI agents — no signup, no API key; documents are never stored.",
+
+    categories: ["social"],
+    integration: "third-party",
+    tags: ["fax", "documents", "pdf", "communication"],
+    status: "active",
+    docs: {
+      homepage: "https://agentfax.val.run",
+      llmsTxt: "https://agentfax.val.run/llms.txt",
+      apiReference: "https://agentfax.val.run/v1/info",
+    },
+    provider: { name: "agentfax", url: "https://agentfax.val.run" },
+    realm: "agentfax.val.run",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/fax",
+        desc: "Send a fax to any phone number — priced per page",
+        dynamic: true,
+        amountHint: "$0.20/page",
+        unitType: "page",
+      },
+    ],
+  },
   // ── AgentMail ──────────────────────────────────────────────────────────
   {
     id: "agentmail",


### PR DESCRIPTION
Adds **agentfax** — a pay-per-fax HTTP API for AI agents.

- Send a fax to any phone number; priced **per page** in **USDC.e on Tempo** over MPP.
- No signup, no API key. Documents are never stored (only minimal send metadata).
- Live: https://agentfax.val.run
- MPP discovery: https://agentfax.val.run/openapi.json (passes `mppx discover validate`)
- Manifest: https://agentfax.val.run/v1/info

Verified end-to-end — a real fax was paid via `tempo request` and delivered to a public test line. It's the first fax service in the directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)