### PR TITLE
Match blog heading font to services page

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -1305,3 +1305,19 @@ a[href*="/payment-methods/tempo"][class*="vocs:rounded-md"]
   margin-top: 0.75rem;
   margin-bottom: 1.5rem;
 }
+
+.blog-index-title {
+  font-family: "VTC Du Bois", var(--font-sans);
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin: 0 0 0.25rem !important;
+}
+
+.blog-index-description {
+  color: var(--vocs-text-color-secondary);
+  font-size: 17px;
+  line-height: 1.4;
+  margin: 0 0 2.75rem;
+}

--- a/src/pages/blog/index.mdx
+++ b/src/pages/blog/index.mdx
@@ -8,7 +8,10 @@ description: "Updates from the MPP team on protocol development, integrations, a
 imageDescription: "Updates on the Machine Payments Protocol"
 ---
 
-# Blog [Updates on the Machine Payments Protocol]
+<h1 className="blog-index-title">Blog</h1>
+<p className="blog-index-description">
+  Updates from the MPP team on protocol development, integrations, and the future of machine payments.
+</p>
 
 {/* TODO: Replace with ::blog-posts directive when Vocs v2 adds blog support */}
 


### PR DESCRIPTION
## Summary
- updates the /blog heading markup to use a dedicated title/description pair
- styles the Blog title with the same VTC Du Bois heading stack used by Discover services

Prompted by: @funkymonk2

## Validation
- corepack pnpm check:ci
- corepack pnpm build (blocked: Vite production build stayed active without output for several minutes after search index generation; stopped manually)