### PR TITLE
docs: add evm x402 support blog post

### DIFF
--- a/src/pages/blog/evm-x402-support.mdx
+++ b/src/pages/blog/evm-x402-support.mdx
@@ -14,9 +14,9 @@ imageDescription: "Accept MPP payments on any EVM compatible network"
 
 <p className="blog-date" style={{ color: 'var(--vocs-color_text3)', fontSize: '14px' }}>Monday, June 8, 2026</p>
 
-# EVM and x402 support [Use one SDK for MPP and x402 payments]
+# EVM and x402 support [Use one SDK for MPP and x402 payments on any EVM blockchain]
 
-Today, MPP supports generic EVM payments, including x402 [`exact`](https://docs.x402.org/schemes/exact) flows.
+Today, MPP supports `charge` payments on any EVM network including Ethereum, Base, and Polygon. In addition, `mppx` now supports x402 [`exact`](https://docs.x402.org/schemes/exact) flows, using the same primtives and security model as the rest of the `mppx` sdk.
 
 Many MPP-enabled APIs and services support x402 in addition to MPP, serving similar requests and responses for the limited subset of stablecoin payment methods supported by x402.
 

--- a/src/pages/blog/evm-x402-support.mdx
+++ b/src/pages/blog/evm-x402-support.mdx
@@ -16,15 +16,15 @@ imageDescription: "Accept MPP payments on any EVM compatible network"
 
 # EVM and x402 support [Use one SDK for MPP and x402 payments]
 
-Today, MPP supports generic EVM payments, including x402 exact flows.
+Today, MPP supports generic EVM payments, including x402 [`exact`](https://docs.x402.org/schemes/exact) flows.
 
-Many paid APIs already expose x402 while adding MPP for standard HTTP auth, Receipts, sessions, cards, and other payment methods. `evm.charge` keeps that migration additive: one SDK config, one paid route, two compatible `402` flows.
+Many MPP-enabled APIs and services support x402 in addition to MPP, serving similar requests and responses for the limited subset of stablecoin payment methods supported by x402.
 
-Use `evm.charge` when you want one SDK surface for native MPP Challenges and existing x402 payment clients. The server can advertise both protocols, then verify whichever Credential the client returns.
+Building on the [`evm.charge`](https://paymentauth.org/draft-evm-charge-00.html) payment method, `mppx` now supports rendering both MPP and x402 payment requests under a single integration. The server can advertise both protocols, then verify whichever Credential the client returns. 
 
 ## Server
 
-Configure an EVM charge method once. Add `x402.facilitator` when the same endpoint accepts x402 exact payments.
+Configure an EVM charge method once. Add `x402.facilitator` when the same endpoint accepts x402 `exact` payments.
 
 ```ts [server.ts]
 import { Mppx, evm } from 'mppx/server'
@@ -76,6 +76,7 @@ console.log(response.status)
 // @log: 200
 ```
 
-Start with [Use MPP with x402](/guides/use-mpp-with-x402).
+## Learn more
 
-</div>
+* [Use MPP with x402](/guides/use-mpp-with-x402).
+* [`evm.charge` payment method](payment-methods/evm/charge#evm-charge)

--- a/src/pages/blog/evm-x402-support.mdx
+++ b/src/pages/blog/evm-x402-support.mdx
@@ -16,7 +16,7 @@ imageDescription: "Accept MPP payments on any EVM compatible network"
 
 # EVM and x402 support [Use one SDK for MPP and x402 payments on any EVM blockchain]
 
-Today, MPP supports `charge` payments on any EVM network including Ethereum, Base, and Polygon. In addition, `mppx` now supports x402 [`exact`](https://docs.x402.org/schemes/exact) flows, using the same primtives and security model as the rest of the `mppx` sdk.
+Today, MPP supports `charge` payments on any EVM network including Ethereum, Base, and Polygon. In addition, `mppx` now supports x402 [`exact`](https://docs.x402.org/schemes/exact) flows, using the same primitives and security model as the rest of the `mppx` SDK.
 
 Many MPP-enabled APIs and services support x402 in addition to MPP, serving similar requests and responses for the limited subset of stablecoin payment methods supported by x402.
 
@@ -78,5 +78,7 @@ console.log(response.status)
 
 ## Learn more
 
-* [Use MPP with x402](/guides/use-mpp-with-x402).
-* [`evm.charge` payment method](payment-methods/evm/charge#evm-charge)
+- [Use MPP with x402](/guides/use-mpp-with-x402)
+- [`evm.charge` payment method](/payment-methods/evm/charge#evm-charge)
+
+</div>

--- a/src/pages/blog/evm-x402-support.mdx
+++ b/src/pages/blog/evm-x402-support.mdx
@@ -14,17 +14,15 @@ imageDescription: "Accept MPP payments on any EVM compatible network"
 
 <p className="blog-date" style={{ color: 'var(--vocs-color_text3)', fontSize: '14px' }}>Monday, June 8, 2026</p>
 
-# EVM and x402 support [Use one SDK for MPP and x402 payments on any EVM blockchain]
+# EVM and x402 support [Use one SDK for EVM and x402 payments]
 
-Today, MPP supports `charge` payments on any EVM network including Ethereum, Base, and Polygon. In addition, `mppx` now supports x402 [`exact`](https://docs.x402.org/schemes/exact) flows, using the same primitives and security model as the rest of the `mppx` SDK.
+MPP now supports `charge` payments on any EVM network, including Ethereum, Base, and Polygon. `mppx` also supports x402 [`exact`](https://docs.x402.org/schemes/exact) flows through the same payment-method interface.
 
-Many MPP-enabled APIs and services support x402 in addition to MPP, serving similar requests and responses for the limited subset of stablecoin payment methods supported by x402.
-
-Building on the [`evm.charge`](https://paymentauth.org/draft-evm-charge-00.html) payment method, `mppx` now supports rendering both MPP and x402 payment requests under a single integration. The server can advertise both protocols, then verify whichever Credential the client returns. 
+Use `evm.charge` when you want one integration for MPP Challenges and compatible x402 payment requests. The server advertises both protocols, then verifies whichever Credential the client returns.
 
 ## Server
 
-Configure an EVM charge method once. Add `x402.facilitator` when the same endpoint accepts x402 `exact` payments.
+Configure one EVM charge method. Add `x402.facilitator` when the endpoint accepts x402 `exact` payments.
 
 ```ts [server.ts]
 import { Mppx, evm } from 'mppx/server'
@@ -51,7 +49,7 @@ const paid = mppx.evm.charge({
 
 ## Client
 
-The client signs MPP Challenges and compatible x402 Challenges. Clients automatically select which protocol to use based on the payment methods they have available.
+The client signs MPP Challenges and compatible x402 Challenges. It selects a protocol from the payment methods available to the request.
 
 ```ts [client.ts]
 import { Fetch, evm } from 'mppx/client'

--- a/src/pages/blog/evm-x402-support.mdx
+++ b/src/pages/blog/evm-x402-support.mdx
@@ -14,7 +14,7 @@ imageDescription: "Accept MPP payments on any EVM compatible network"
 
 <p className="blog-date" style={{ color: 'var(--vocs-color_text3)', fontSize: '14px' }}>Monday, June 8, 2026</p>
 
-# EVM and x402 support [Use one SDK for EVM and x402 payments]
+# EVM and x402 support [Use one SDK for MPP and x402 payments on any EVM blockchain]
 
 MPP now supports `charge` payments on any EVM network, including Ethereum, Base, and Polygon. `mppx` also supports x402 [`exact`](https://docs.x402.org/schemes/exact) flows through the same payment-method interface.
 

--- a/src/pages/blog/evm-x402-support.mdx
+++ b/src/pages/blog/evm-x402-support.mdx
@@ -1,0 +1,81 @@
+---
+layout: minimal
+outline: false
+showAskAi: false
+showFeedback: false
+showSearch: false
+description: "MPP now supports generic EVM payments and x402 exact flows from one SDK."
+imageDescription: "Accept MPP payments on any EVM compatible network"
+---
+
+<div className="blog-narrow">
+
+<a href="/blog" className="blog-back">Blog</a>
+
+<p className="blog-date" style={{ color: 'var(--vocs-color_text3)', fontSize: '14px' }}>Monday, June 8, 2026</p>
+
+# EVM and x402 support [Use one SDK for MPP and x402 payments]
+
+Today, MPP supports generic EVM payments, including x402 exact flows.
+
+Many paid APIs already expose x402 while adding MPP for standard HTTP auth, Receipts, sessions, cards, and other payment methods. `evm.charge` keeps that migration additive: one SDK config, one paid route, two compatible `402` flows.
+
+Use `evm.charge` when you want one SDK surface for native MPP Challenges and existing x402 payment clients. The server can advertise both protocols, then verify whichever Credential the client returns.
+
+## Server
+
+Configure an EVM charge method once. Add `x402.facilitator` when the same endpoint accepts x402 exact payments.
+
+```ts [server.ts]
+import { Mppx, evm } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    // [!code hl:start]
+    evm.charge({
+      currency: evm.assets.baseSepolia.USDC,
+      recipient: '0xYourAddress',
+      x402: {
+        facilitator: 'https://example.com/facilitator',
+      },
+    }),
+    // [!code hl:end]
+  ],
+})
+
+const paid = mppx.evm.charge({
+  amount: '0.01',
+  description: 'Premium API access',
+})
+```
+
+## Client
+
+The client signs MPP Challenges and compatible x402 Challenges. Clients automatically select which protocol to use based on the payment methods they have available.
+
+```ts [client.ts]
+import { Fetch, evm } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const fetch = Fetch.from({
+  methods: [
+    // [!code hl:start]
+    evm.charge({
+      account: privateKeyToAccount(
+        '0x0123456789012345678901234567890123456789012345678901234567890123',
+      ),
+      currencies: [evm.assets.baseSepolia.USDC],
+      maxAmount: '1.00',
+    }),
+    // [!code hl:end]
+  ],
+})
+
+const response = await fetch('https://api.example.com/paid')
+console.log(response.status)
+// @log: 200
+```
+
+Start with [Use MPP with x402](/guides/use-mpp-with-x402).
+
+</div>

--- a/src/pages/blog/index.mdx
+++ b/src/pages/blog/index.mdx
@@ -19,6 +19,12 @@ import { BlogPostList } from "../../components/BlogPostList";
 
 <BlogPostList posts={[
   {
+    date: "Monday, June 8, 2026",
+    title: "EVM and x402 support",
+    description: <>MPP now supports generic EVM payments and x402 exact flows from one SDK.</>,
+    to: "/blog/evm-x402-support",
+  },
+  {
     date: "Thursday, May 21, 2026",
     title: "Payment hooks",
     description: <>Core SDKs now expose typed payment hooks for logging, monitoring, and request context.</>,


### PR DESCRIPTION
## Summary

- Add a concise blog post announcing generic EVM and x402 support in MPP
- Add the new post to the blog index