### PR TITLE
Update x402 inline MPP flow docs

### DIFF
--- a/src/components/cards.tsx
+++ b/src/components/cards.tsx
@@ -58,7 +58,7 @@ export function TempoMethodCard() {
 export function EvmMethodCard() {
   return (
     <Card
-      description="Stablecoin payments on EVM chains with x402 exact compatibility"
+      description="Stablecoin payments on EVM chains with inline x402 exact compatibility"
       icon="lucide:coins"
       title="EVM"
       to="/payment-methods/evm"
@@ -69,7 +69,7 @@ export function EvmMethodCard() {
 export function EvmChargeCard() {
   return (
     <Card
-      description="One-time EVM stablecoin payments with x402 exact support"
+      description="One-time EVM stablecoin payments with inline x402 exact support"
       icon="lucide:coins"
       title="EVM charge"
       to="/payment-methods/evm/charge"

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -31,7 +31,7 @@ See [MPP vs x402](/mpp-vs-x402) for a full side-by-side comparison, or [Use MPP 
 
 ## Is MPP compatible with x402?
 
-Yes. The core x402 "exact" flows map directly onto MPP's charge intent. `mppx` can serve x402 and MPP clients from the same route. See [Use MPP with x402](/guides/use-mpp-with-x402).
+Yes. The core x402 "exact" flows map directly onto MPP's charge intent. `mppx` can run x402-compatible EVM charges inline with an MPP route, so the same endpoint can serve x402 and MPP clients. See [Use MPP with x402](/guides/use-mpp-with-x402#run-x402-inline-with-mppx).
 
 ## Why build MPP on Tempo?
 

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -9,7 +9,7 @@ import { PromptBlock } from '../../components/PromptBlock'
 
 # Use MPP with x402 [Run both payment flows together]
 
-MPP plugs into your existing x402 server. Both protocols use HTTP `402` to gate API access behind payment, and x402's "exact" charge flow maps directly onto MPP's `charge` intent. Adding MPP gives you standard `WWW-Authenticate` / `Authorization` headers, multi-method support (stablecoins, cards, Lightning), sessions for streaming payments, and an [IETF standards track](https://paymentauth.org) foundation—all without changing your business logic.
+MPP runs x402-compatible EVM charges inline with native MPP flows. Both protocols use HTTP `402` to gate API access behind payment, and x402's "exact" charge flow maps directly onto MPP's `charge` intent. Adding MPP gives you standard `WWW-Authenticate` / `Authorization` headers, multi-method support (stablecoins, cards, Lightning), sessions for streaming payments, and an [IETF standards track](https://paymentauth.org) foundation—while the same route can still serve x402 clients.
 
 ## What MPP adds
 
@@ -37,17 +37,17 @@ MPP uses three protocol objects in every payment flow—the same lifecycle x402 
 - **Credential** — The client's signed payment authorization. Sent in the `Authorization: Payment` header. Equivalent to x402's `PAYMENT-SIGNATURE`.
 - **Receipt** — The server's confirmation that payment settled. Sent in the `Payment-Receipt` header. Equivalent to x402's `PAYMENT-RESPONSE`.
 
-## Add x402 to your MPP server with `mppx`
+## Run x402 inline with `mppx`
 
-Use `evm.charge` when you want to support both MPP "charge" intents and x402 "exact" intents with a single `mppx` import.
+Use `evm.charge` when you want one MPP route to serve native MPP charge Challenges and x402 exact Challenges.
 
 :::info
-When x402 options are enabled, the server automatically handles MPP charge and x402 exact flows.
+When x402 options are enabled, `mppx` emits both `WWW-Authenticate` and `PAYMENT-REQUIRED` Challenges, accepts either `Authorization` or `PAYMENT-SIGNATURE` Credentials, and returns the matching Receipt header.
 :::
 
-### Run an x402-compatible endpoint
+### Run an inline x402 endpoint
 
-Configure `evm.charge` with a known x402 asset and a facilitator. The route returns x402-compatible Challenges in addition to MPP Challenges, and accepts both MPP and x402 Credentials.
+Configure `evm.charge` with a known x402 asset and a facilitator. The route stays an MPP flow, but also behaves as an x402-compatible server for existing clients.
 
 ```ts twoslash [server.ts]
 import { evm, Mppx } from 'mppx/server'
@@ -81,9 +81,9 @@ export async function GET(request: Request) {
 }
 ```
 
-### Add MPP to the same endpoint
+### Compose x402 with another MPP method
 
-Use `mppx.compose` when one endpoint should support x402 EVM charges and another MPP method. The same route verifies either wire format.
+Use `mppx.compose` when one endpoint should support inline x402 EVM charges and another MPP method. The same route verifies either wire format.
 
 ```ts twoslash [server.ts]
 import { evm, Mppx, tempo } from 'mppx/server'
@@ -190,13 +190,13 @@ Because MPP uses the standard `WWW-Authenticate` scheme, it works with HTTP inte
 Paste this into your coding agent to add MPP in one prompt:
 
 <PromptBlock>
-{`Use https://mpp.dev/guides/use-mpp-with-x402.md#add-x402-to-your-mpp-server-with-mppx as reference.
-Add mppx to my existing x402 server. Use the Tempo payment
-method with USDC.e. Keep the same pricing and route structure.
-Add mppx.charge to each paid endpoint. Point out areas where I could benefit from adding sessions.`}
+{`Use https://mpp.dev/guides/use-mpp-with-x402.md#run-x402-inline-with-mppx as reference.
+Run my existing x402 EVM charges inline with MPP flows. Use the Tempo
+payment method with USDC.e as an additional option. Keep the same pricing
+and route structure. Point out areas where I could benefit from adding sessions.`}
 </PromptBlock>
 
-## Advanced: Add MPP to your existing x402 server
+## Advanced: Update an existing x402 route
 
 ::::steps
 
@@ -214,25 +214,34 @@ $ bun add mppx viem
 ```
 :::
 
-### Add `mppx` alongside your existing routes
+### Move the x402 charge into `mppx`
 
-Here's a typical x402 server with MPP applied. Your business logic stays the same—you swap the payment middleware.
+Here's a typical x402 route moved into an MPP flow. Your business logic stays the same, and the route still accepts x402 exact Credentials.
 
 ```ts [server.ts]
 import express from 'express'
-import { Mppx, tempo } from 'mppx/express' // [!code hl]
+import { evm, Mppx, tempo } from 'mppx/express' // [!code hl]
 
 const app = express()
 
-const mppx = Mppx.create({ // [!code hl]
-  methods: [ // [!code hl]
-    tempo({ // [!code hl]
-      currency: '0x20c0000000000000000000000000000000000000', // [!code hl]
-      recipient: '0xYourAddress', // [!code hl]
-    }), // [!code hl]
-  ], // [!code hl]
-  secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret', // [!code hl]
-}) // [!code hl]
+// [!code hl:start]
+const mppx = Mppx.create({
+  methods: [
+    evm.charge({
+      currency: evm.assets.baseSepolia.USDC,
+      recipient: '0xYourAddress',
+      x402: {
+        facilitator: 'https://facilitator.x402.org',
+      },
+    }),
+    tempo({
+      currency: '0x20c0000000000000000000000000000000000000',
+      recipient: '0xYourAddress',
+    }),
+  ],
+  secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
+})
+// [!code hl:end]
 
 app.get(
   '/api/data',
@@ -245,22 +254,33 @@ app.get(
 
 Key differences:
 
-- **Per-route pricing.** `mppx.charge` is route middleware instead of a global config map.
+- **Inline x402.** `evm.charge` serves x402 exact Challenges from the same MPP route.
+- **Per-route pricing.** The route declares pricing where it verifies payment.
 - **Amount in dollars, not atomic units.** `'0.01'` instead of `'10000'`.
 - **No header parsing.** The SDK handles `WWW-Authenticate`, `Authorization`, and `Payment-Receipt` headers automatically.
 
 ### Simplify verification and settlement
 
-x402 servers typically call a facilitator service for `POST /verify` and `POST /settle`. The `mppx` SDK handles verification and settlement internally, so you don't need a separate facilitator client.
+x402 servers typically call a facilitator service for `POST /verify` and `POST /settle`. In an MPP flow, configure the facilitator once on `evm.charge`; `mppx` calls it while it verifies the route payment.
 
 ```ts [server.ts]
-// x402 — external facilitator
 import { createFacilitator } from '@x402/server'
+import { evm, Mppx } from 'mppx/server'
+
+// x402 — external facilitator
 const facilitator = createFacilitator('https://facilitator.x402.org')
 
-// MPP — built into the SDK
+// MPP — inline with the route payment
 const mppx = Mppx.create({
-  methods: [tempo({ /* ... */ })],
+  methods: [
+    evm.charge({
+      currency: evm.assets.baseSepolia.USDC,
+      recipient: '0xYourAddress',
+      x402: {
+        facilitator: 'https://facilitator.x402.org',
+      },
+    }),
+  ],
 })
 ```
 
@@ -317,7 +337,8 @@ $ npx mppx http://localhost:3000/api/data
 
 ## What you gain
 
-- **Multi-method payments.** Accept stablecoins, cards, and Lightning on the same endpoint—your x402 stablecoin flow continues to work, and new rails are additive.
+- **Inline x402 compatibility.** Keep x402 exact clients working while the same route serves native MPP clients.
+- **Multi-method payments.** Accept stablecoins, cards, and Lightning on the same endpoint—new rails are additive.
 - **Sessions.** Stream sub-cent payments with off-chain vouchers instead of one on-chain transaction per request.
 - **IETF standards track.** MPP's [Payment HTTP Authentication Scheme](https://paymentauth.org) follows the IETF standards process—building on a standard that browsers, proxies, and CDNs already understand.
 - **Production primitives.** Idempotency, expiration, request-body binding, and RFC 9457 error responses are built into the protocol.

--- a/src/pages/mpp-vs-x402.mdx
+++ b/src/pages/mpp-vs-x402.mdx
@@ -76,9 +76,9 @@ For low-volume one-off stablecoin payments, x402 can work. For search, inference
 
 MPP is compatible with existing x402-style charge flows.
 
-The x402 "exact" model maps cleanly onto MPP's `charge` intent, which means you can migrate incrementally instead of replacing your integration all at once. A server can also support both protocols side by side because the headers do not conflict.
+The x402 "exact" model maps cleanly onto MPP's `charge` intent. With `mppx`, you can run x402-compatible EVM charges inline with an MPP route: the server emits both MPP and x402 Challenges, accepts either Credential format, and returns the matching Receipt header.
 
-For a working server setup, see [Use MPP with x402](/guides/use-mpp-with-x402).
+For a working inline server setup, see [Use MPP with x402](/guides/use-mpp-with-x402#run-x402-inline-with-mppx).
 
 ## Which one should you choose?
 
@@ -100,7 +100,7 @@ Choose **x402** only if:
 ## Next steps
 
 <Cards>
-  <Card title="Use MPP with x402" description="Serve x402 and MPP from one route" to="/guides/use-mpp-with-x402" />
+  <Card title="Use MPP with x402" description="Run x402 inline with an MPP route" to="/guides/use-mpp-with-x402" />
   <Card title="Protocol overview" description="Learn the core Challenge-Credential-Receipt flow" to="/protocol" />
   <Card title="Accept pay-as-you-go payments" description="Use sessions for high-frequency APIs" to="/guides/pay-as-you-go" />
 </Cards>

--- a/src/pages/payment-methods/evm/charge.mdx
+++ b/src/pages/payment-methods/evm/charge.mdx
@@ -1,6 +1,6 @@
 ---
 title: "EVM charge payment method"
-description: "Accept one-time EVM stablecoin payments with MPP and x402 exact compatibility."
+description: "Accept one-time EVM stablecoin payments with MPP and inline x402 exact compatibility."
 imageDescription: "Accept one-time EVM stablecoin payments"
 ---
 
@@ -11,13 +11,13 @@ import { EvmMethodCard } from '../../../components/cards'
 
 The EVM implementation of the [charge](/intents/charge) intent.
 
-The server issues a Challenge describing the amount, currency, and recipient. The client signs an EIP-3009 authorization and returns it as a Credential. When x402 options are enabled, the server also handles x402 exact flows.
+The server issues a Challenge describing the amount, currency, and recipient. The client signs an EIP-3009 authorization and returns it as a Credential. When x402 options are enabled, the same route also handles x402 exact flows.
 
-This method is best for fixed-price API calls, paid content, and x402-compatible stablecoin payments.
+This method is best for fixed-price API calls, paid content, and inline x402-compatible stablecoin payments.
 
 ## Server
 
-Use `evm.charge` to gate an endpoint behind a one-time EVM stablecoin payment. Configure `x402.facilitator` when the endpoint also accepts x402 exact Credentials.
+Use `evm.charge` to gate an endpoint behind a one-time EVM stablecoin payment. Configure `x402.facilitator` when the same endpoint also accepts x402 exact Credentials.
 
 ```ts twoslash [server.ts]
 import { Mppx, evm } from 'mppx/server'
@@ -51,7 +51,7 @@ export async function handler(request: Request) {
 
 ## Client
 
-Use `evm.charge` with `Fetch.from` to automatically handle `402` responses. The client signs native MPP EVM charge Challenges and x402 exact Challenges for compatible assets.
+Use `evm.charge` with `Fetch.from` to automatically handle `402` responses. The client signs native MPP EVM charge Challenges and inline x402 exact Challenges for compatible assets.
 
 ```ts twoslash [client.ts]
 import { Fetch, evm } from 'mppx/client'
@@ -112,7 +112,7 @@ const method = evm.charge({
 
 ## x402 compatibility
 
-When `x402.facilitator` is configured, the server returns MPP and x402 Challenges and accepts both MPP and x402 Credentials. See [running x402 servers with mppx](/guides/use-mpp-with-x402#add-x402-to-your-mpp-server-with-mppx) for the full guide.
+When `x402.facilitator` is configured, the server returns MPP and x402 Challenges and accepts both MPP and x402 Credentials inline. See [running x402 inline with mppx](/guides/use-mpp-with-x402#run-x402-inline-with-mppx) for the full guide.
 
 ## Related resources
 

--- a/src/pages/payment-methods/evm/index.mdx
+++ b/src/pages/payment-methods/evm/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "EVM payment method"
-description: "Use EVM payment methods in MPP to accept stablecoin payments and x402 exact flows."
+description: "Use EVM payment methods in MPP to accept stablecoin payments and run x402 exact flows inline."
 imageDescription: "Accept stablecoin payments on EVM chains"
 ---
 
@@ -9,9 +9,9 @@ import { EvmChargeCard } from '../../../components/cards'
 
 # EVM [Stablecoin payments on EVM chains]
 
-The EVM payment method enables MPP payments using EIP-3009 token authorizations. It supports the **charge** intent for one-time stablecoin payments and can accept x402 exact flows when x402 options are enabled.
+The EVM payment method enables MPP payments using EIP-3009 token authorizations. It supports the **charge** intent for one-time stablecoin payments and can run x402 exact flows inline when x402 options are enabled.
 
-Use `evm.charge` when you want one payment method that handles native MPP EVM charge Challenges and existing x402 exact Challenges. Read the [EVM charge protocol spec](https://paymentauth.org/draft-evm-charge-00) for the wire format.
+Use `evm.charge` when you want one payment method that handles native MPP EVM charge Challenges and x402 exact Challenges on the same route. Read the [EVM charge protocol spec](https://paymentauth.org/draft-evm-charge-00) for the wire format.
 
 ## Installation
 
@@ -35,4 +35,4 @@ $ bun add mppx viem
 
 ## x402 compatibility
 
-Configure `x402.facilitator` on the server to return x402-compatible Challenges and accept x402 exact Credentials. See [running x402 servers with mppx](/guides/use-mpp-with-x402#add-x402-to-your-mpp-server-with-mppx) for more details.
+Configure `x402.facilitator` on the server to return x402-compatible Challenges and accept x402 exact Credentials inline with the MPP flow. See [running x402 inline with mppx](/guides/use-mpp-with-x402#run-x402-inline-with-mppx) for more details.

--- a/src/pages/sdk/typescript/client/Method.evm.charge.mdx
+++ b/src/pages/sdk/typescript/client/Method.evm.charge.mdx
@@ -31,7 +31,7 @@ console.log(response.status)
 // @log: 200
 ```
 
-The client signs native MPP EVM charge Challenges and x402 exact Challenges for compatible assets.
+The client signs native MPP EVM charge Challenges and inline x402 exact Challenges for compatible assets.
 
 ## Return type
 

--- a/src/pages/sdk/typescript/server/Method.evm.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.evm.charge.mdx
@@ -4,7 +4,7 @@ title: "evm.charge server method"
 
 # `Method.evm.charge` [One-time EVM payments]
 
-Creates an EVM charge payment method for native MPP and x402 exact payment flows.
+Creates an EVM charge payment method for native MPP and inline x402 exact payment flows.
 
 ## Usage
 
@@ -37,7 +37,7 @@ export async function handler(request: Request) {
 }
 ```
 
-Use `x402.facilitator` for x402 exact settlement. Use `settle` when you want to verify and settle Credentials yourself.
+Use `x402.facilitator` to run x402 exact settlement inline with the MPP route. Use `settle` when you want to verify and settle Credentials yourself.
 
 ## Return type
 
@@ -106,7 +106,7 @@ Custom settlement callback. Use this instead of `x402.facilitator` when you sett
 
 - **Type:** `{ facilitator: string | Facilitator }`
 
-x402 compatibility options. Pass a facilitator URL to verify and settle x402 exact payments.
+x402 compatibility options. Pass a facilitator URL to verify and settle x402 exact payments inline.
 
 ## Request parameters
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -55,8 +55,7 @@ export default defineConfig({
     { source: "/402", destination: "/protocol/http-402" },
     {
       source: "/x402",
-      destination:
-        "/guides/use-mpp-with-x402#add-x402-to-your-mpp-server-with-mppx",
+      destination: "/guides/use-mpp-with-x402#run-x402-inline-with-mppx",
     },
     {
       source: "/guides/upgrade-x402",


### PR DESCRIPTION
## Summary

- Update x402 compatibility docs to describe running x402 EVM charges inline with MPP flows
- Point x402 guide links and redirect anchors at the inline mppx flow
- Refresh EVM payment method and TypeScript SDK reference copy for inline x402 support