### PR TITLE
fix: handle session voucher update responses

### DIFF
--- a/src/pages/_api/api/demo/chat.ts
+++ b/src/pages/_api/api/demo/chat.ts
@@ -1,5 +1,6 @@
 import { mppx } from "../../../../mppx.server";
 import { getProxyFetch } from "../../../../mppx-proxy-client";
+import { sessionUpdateResponse } from "../../../../session-response";
 
 const responses = [
   [
@@ -82,7 +83,7 @@ export default async function handler(request: Request) {
   if (result.status === 402) return result.challenge;
 
   // POST = voucher update (no body needed)
-  if (request.method === "POST") return result.withReceipt();
+  if (request.method === "POST") return sessionUpdateResponse(result);
 
   // GET = stream a chat response
   const proxyFetch = getProxyFetch();

--- a/src/pages/_api/api/demo/poem.ts
+++ b/src/pages/_api/api/demo/poem.ts
@@ -1,4 +1,5 @@
 import { mppx } from "../../../../mppx.server";
+import { sessionUpdateResponse } from "../../../../session-response";
 
 const poems = [
   [
@@ -116,7 +117,7 @@ export default async function handler(request: Request) {
   if (result.status === 402) return result.challenge;
 
   // POST = voucher update (no body needed)
-  if (request.method === "POST") return result.withReceipt();
+  if (request.method === "POST") return sessionUpdateResponse(result);
 
   // GET = stream a poem
   const poem = poems[Math.floor(Math.random() * poems.length)];

--- a/src/pages/_api/api/sessions/poem.ts
+++ b/src/pages/_api/api/sessions/poem.ts
@@ -1,4 +1,5 @@
 import { mppx } from "../../../../mppx.server";
+import { sessionUpdateResponse } from "../../../../session-response";
 
 const poems = [
   {
@@ -75,7 +76,7 @@ export default async function handler(request: Request) {
   if (result.status === 402) return result.challenge;
 
   // POST = voucher update (no body needed)
-  if (request.method === "POST") return result.withReceipt();
+  if (request.method === "POST") return sessionUpdateResponse(result);
 
   // GET = stream a poem
   const poem = poems[Math.floor(Math.random() * poems.length)];

--- a/src/session-response.test.ts
+++ b/src/session-response.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { sessionUpdateResponse } from "./session-response";
+
+describe("sessionUpdateResponse", () => {
+  it("passes an explicit empty response to withReceipt", () => {
+    const response = sessionUpdateResponse({
+      withReceipt(inner) {
+        expect(inner.status).toBe(204);
+        return new Response(null, { status: inner.status });
+      },
+    });
+
+    expect(response.status).toBe(204);
+  });
+});

--- a/src/session-response.ts
+++ b/src/session-response.ts
@@ -1,0 +1,7 @@
+type ReceiptResult = {
+  withReceipt(response: Response): Response;
+};
+
+export function sessionUpdateResponse(result: ReceiptResult): Response {
+  return result.withReceipt(new Response(null, { status: 204 }));
+}


### PR DESCRIPTION
## Summary

- Return an explicit empty receipt response for session voucher update requests.
- Apply the helper to streamed chat and poem demo endpoints.