### PR TITLE
Add Swift (mpp-swift) to the Other languages SDK list

### DIFF
--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -42,5 +42,6 @@ Community-maintained SDKs extend MPP to more language ecosystems.
 |---|---|---|---|---|
 | Elixir | `mpp` | ZenHive | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/ZenHive/mpp) · [hex.pm](https://hex.pm/packages/mpp) · [Docs](https://hexdocs.pm/mpp/) |
 | Go | `mppx` | cp0x | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/cp0x-org/mppx) · [Docs](https://pkg.go.dev/github.com/cp0x-org/mppx) |
+| Swift | `mpp-swift` | Amit Acharya | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/amitach/mpp-swift) · [DeepWiki](https://deepwiki.com/amitach/mpp-swift) |
 
 Want to add another SDK? Open a PR and we can list it here.


### PR DESCRIPTION
Lists `mpp-swift` as a community SDK in the `sdk/index` **Other languages** table, alongside the Elixir and Go entries.

Reworked per @brendanjryan's review — the original PR added a full first-class `/sdk/swift` section; this is now a single-row addition to the community table instead.

mpp-swift is a Swift implementation of MPP (client + server, both independent; macOS/iOS/Linux; Apache-2.0 / MIT; 1.0.0). Every rail and transport with a reference peer is conformance-checked against mppx in both directions, offline and live on the Moderato testnet.