### PR TITLE
Add JMPR to the service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6689,4 +6689,61 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── JMPR ───────────────────────────────────────────────────────────────
+  {
+    id: "jmpr",
+    name: "JMPR",
+    url: "https://agent.jmpr.world",
+    serviceUrl: "https://agent.jmpr.world",
+    description:
+      "Luxury hotel booking for AI agents — curated 5-star, ultra-luxury, and boutique properties with live rates and real availability. Pay-per-call discovery and full-amount room booking via wallet (Tempo USDC) or end-user card checkout — no API keys, no accounts.",
+
+    categories: ["data", "web"],
+    integration: "third-party",
+    tags: ["hotels", "luxury", "travel", "booking", "5-star"],
+    status: "active",
+    docs: {
+      homepage: "https://agent.jmpr.world",
+      apiReference: "https://agent.jmpr.world/openapi.json",
+    },
+    provider: { name: "Quantum Temple", url: "https://jmpr.world" },
+    realm: "agent.jmpr.world",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/hotels/search",
+        desc: "Search luxury hotels worldwide by city + dates",
+        amount: "20000",
+      },
+      {
+        route: "POST /v1/hotels/detail",
+        desc: "Hotel record + bookable rate ladder for a stay window",
+        amount: "20000",
+      },
+      {
+        route: "POST /v1/bookings/reserve",
+        desc: "Reserve a room — returns payment_options for the end-user",
+        amount: "50000",
+      },
+      {
+        route: "GET /v1/bookings/:booking_id",
+        desc: "Booking status + lifecycle (identity-gated by the reserving wallet)",
+        amount: "10000",
+      },
+      {
+        route: "POST /v1/bookings/:booking_id/cancel",
+        desc: "Cancel a reservation before the cancel deadline",
+        amount: "50000",
+      },
+      {
+        route: "POST /v1/bookings/:booking_id/pay/tempo",
+        desc: "Settle the full room rate via wallet (Tempo USDC)",
+        dynamic: true,
+        amountHint: "Full room rate (typically $300–$20,000)",
+        unitType: "booking",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary

Adds [JMPR](https://jmpr.world) — a luxury hotel booking service for AI agents — to the registry.

JMPR exposes pay-per-call discovery and full-amount room booking. Agents pay
per request in USDC.e on Tempo (no API keys, no accounts). End-users complete
the actual room payment via wallet (Tempo USDC) or hosted card checkout —
`/v1/bookings/reserve` returns a `payment_options` array the agent presents
to the user.

## Service

- **URL**: https://agent.jmpr.world
- **Provider**: Quantum Temple (https://jmpr.world)
- **Realm**: `agent.jmpr.world`
- **Payment**: Tempo USDC.e (`0x20C0…8b50`)
- **Integration**: third-party
- **Status**: active

## Endpoints

| Route | Price | Notes |
|---|---|---|
| `POST /v1/hotels/search` | $0.02 | Search luxury hotels by city + dates |
| `POST /v1/hotels/detail` | $0.02 | Hotel record + bookable rate ladder |
| `POST /v1/bookings/reserve` | $0.05 | Reserve a room — returns `payment_options` |
| `GET /v1/bookings/:booking_id` | $0.01 | Booking status + lifecycle |
| `POST /v1/bookings/:booking_id/cancel` | $0.05 | Cancel before deadline |
| `POST /v1/bookings/:booking_id/pay/tempo` | dynamic | Settle full room rate via wallet |

API spec: https://agent.jmpr.world/openapi.json
Discovery manifest (open-402 v1.4): https://agent.jmpr.world/.well-known/agent.json

## Verification

- `pnpm check:types` — clean
- `pnpm exec biome check schemas/services.ts` — clean
- `pnpm generate:discovery` regenerates cleanly (95 → 96 services, 858 endpoints)
- Local schema-rule validator passes (uniqueness, route format, payment fields, integration enum)
- Already auto-discovered on [MPPScan](https://mppscan.com)
