### PR TITLE
Add MPP credits support marker to service discovery

### DIFF
--- a/schemas/discovery.schema.json
+++ b/schemas/discovery.schema.json
@@ -92,6 +92,11 @@
           "$ref": "#/$defs/Docs",
           "description": "Documentation and reference links."
         },
+        "supportsCredits": {
+          "type": "boolean",
+          "const": true,
+          "description": "Whether the service can be paid with MPP Credits."
+        },
         "methods": {
           "type": "object",
           "description": "Supported payment methods, keyed by method identifier (aligns with /.well-known/payment spec).",

--- a/scripts/generate-discovery.ts
+++ b/scripts/generate-discovery.ts
@@ -10,6 +10,7 @@ import { dirname, resolve } from "node:path";
 import {
   type EndpointDef,
   HTTP_METHODS,
+  MPP_REALM,
   type HttpMethod,
   type ServiceDef,
   services,
@@ -188,6 +189,7 @@ export function buildService(svc: ServiceDef): Record<string, unknown> {
   entry.tags = svc.tags;
   entry.status = svc.status ?? "active";
   if (svc.docs) entry.docs = svc.docs;
+  if (svc.realm === MPP_REALM) entry.supportsCredits = true;
   const methods: Record<string, { intents: string[]; assets: string[] }> = {};
   for (const pm of svc.payments) {
     methods[pm.method] = {

--- a/scripts/generate-discovery.ts
+++ b/scripts/generate-discovery.ts
@@ -10,8 +10,8 @@ import { dirname, resolve } from "node:path";
 import {
   type EndpointDef,
   HTTP_METHODS,
-  MPP_REALM,
   type HttpMethod,
+  MPP_REALM,
   type ServiceDef,
   services,
 } from "../schemas/services.ts";


### PR DESCRIPTION
## Summary
- add `supportsCredits: true` to generated service discovery entries for Tempo-proxied services
- add `supportsCredits` to the public discovery JSON schema

## Verification
- `node scripts/generate-discovery.ts`
- `node - <<'NODE' ...` validated 20 credit-supported services and 0 non-Tempo-realm services marked
- Could not run `pnpm test`: `pnpm` is not installed and `corepack pnpm` timed out fetching pnpm from npm

Prompted by: @alexrisch