### PR TITLE
Add researcher-now (first-party): article/video analysis + deep research

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1709,6 +1709,55 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── researcher-now ────────────────────────────────────────────────────────
+  {
+    id: "researcher-now",
+    name: "researcher-now",
+    url: "https://researcher.now",
+    serviceUrl: "https://researcher.now",
+    description:
+      "Article and video analysis plus deep research for agents — formatted content with structured claims, facts, and quotes; multi-source cited Research Reports. Pay per call, no signup.",
+
+    categories: ["ai", "search", "data"],
+    integration: "first-party",
+    tags: [
+      "research",
+      "deep-research",
+      "youtube-transcript",
+      "article-analysis",
+      "video-analysis",
+      "reports",
+      "evidence",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://researcher.now/agent/",
+      llmsTxt: "https://researcher.now/llms.txt",
+      apiReference: "https://researcher.now/openapi.json",
+    },
+    provider: { name: "Researcher", url: "https://researcher.now" },
+    realm: "researcher.now",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/analyze",
+        desc: "Article or video analysis — formatted content plus structured claims, facts, and quotes",
+        amount: "50000",
+        unitType: "request",
+      },
+      {
+        route: "POST /v1/runs",
+        desc: "Deep research — cited Research Report from a multi-source corpus",
+        intent: "session",
+        dynamic: true,
+        amountHint: "$1 – $25 by depth",
+      },
+      { route: "GET /v1/library/search", desc: "Recall prior research — claims and evidence with citations" },
+      { route: "POST /v1/keys/trial", desc: "Free trial key — 10 analyze calls" },
+    ],
+  },
+
   // ── StableEmail ────────────────────────────────────────────────────────
   {
     id: "stableemail",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1742,7 +1742,7 @@ export const services: ServiceDef[] = [
     endpoints: [
       {
         route: "POST /v1/analyze",
-        desc: "Article or video analysis — formatted content plus structured claims, facts, and quotes",
+        desc: "Article or video analysis — formatted content plus structured claims, facts, and quotes. Also accepts session payments for repeat callers (deposit once, $0.05 deducted per call).",
         amount: "50000",
         unitType: "request",
       },


### PR DESCRIPTION
Adds **researcher-now** (https://researcher.now) — article and video analysis plus deep multi-source research for agents. First-party MPP integration (direct, no proxy).

**Live verification:**
- Discovery doc: https://researcher.now/openapi.json (`x-service-info` + `x-payment-info`, validated with `mppx/discovery`)
- Anonymous `POST /v1/analyze` answers 402 with a `WWW-Authenticate: Payment` challenge — realm `researcher.now`, method `tempo`, USDC.e (`0x20c0…8b50`), 50000 base units ($0.05/request):
  ```
  curl -i -X POST https://researcher.now/v1/analyze -H 'Content-Type: application/json' -d '{"url":"https://example.com"}'
  ```
- `POST /v1/runs` (deep research → cited Research Report) is session-intent, $1–$25 by depth
- Free trial path for keyless agents: `POST /v1/keys/trial`
- llms.txt: https://researcher.now/llms.txt

Happy to adjust entry format/pricing fields as preferred.