### PR TITLE
docs: clarify Sessions client APIs and migration

### DIFF
--- a/src/pages/payment-methods/tempo/session.mdx
+++ b/src/pages/payment-methods/tempo/session.mdx
@@ -17,6 +17,17 @@ Payment sessions reduce payment verification to near constant time, making it po
 `tempo.session` is the current Sessions implementation in `mppx`. The previous contract-backed implementation is Legacy Sessions, also called Sessions v1, and is available as `tempo.sessionLegacy`.
 :::
 
+## Which client API should I use?
+
+There are two current Sessions client APIs:
+
+| API | Use it when |
+|---|---|
+| `tempo({ account, maxDeposit })` | You want a fetch wrapper that handles both one-time charges and Sessions. This expands to `tempo.charge()` plus the current `tempo.session()` client method. |
+| `tempo.session({ account, maxDeposit })` | You want to register only the current Sessions client method in `Mppx.create`. |
+| `tempo.session.manager({ account, maxDeposit })` | You want direct lifecycle control with `.fetch()`, `.topUp()`, `.close()`, `.sse()`, or `.ws()`. Use this when your code must explicitly close or top up a channel. |
+| `tempo.sessionLegacy` / `tempo.sessionLegacy.method()` | You still need compatibility with contract-backed Sessions v1. Do not use this for new integrations. |
+
 ## Why Sessions matter in MPP
 
 Traditional payment rails target human purchase flows: a buyer decides, pays, and receives goods. Usage-based billing—the model that powers cloud infrastructure, LLM APIs, and metered services—requires something fundamentally different. It needs payment verification that can keep pace with the service itself.
@@ -378,6 +389,18 @@ Legacy Sessions, also called Sessions v1, is the contract-backed session flow. U
 - Keep `tempo.sessionLegacy` registered beside `tempo.session` during migration so existing clients keep working.
 - Use `tempo()` on the client when the same fetch wrapper should handle charges and Sessions.
 - Register `tempo.session()` and `tempo.sessionLegacy.method()` explicitly when the client must support both Sessions implementations.
+
+### Compatibility matrix
+
+| Server methods | Client methods | Result |
+|---|---|---|
+| `tempo.session()` only | `tempo.session()` or `tempo()` | Current Sessions flow. New integrations should target this. |
+| `tempo.sessionLegacy()` only | `tempo.sessionLegacy()` or `tempo.sessionLegacy.method()` | Legacy Sessions v1 flow. Use only until the server migrates. |
+| `tempo.session()` only | `tempo.sessionLegacy()` or `tempo.sessionLegacy.method()` | Not compatible. The client cannot answer current Sessions Challenges. |
+| `tempo.sessionLegacy()` only | `tempo.session()` or `tempo()` | Not compatible for Sessions. The client cannot answer Legacy Sessions Challenges unless `tempo.sessionLegacy.method()` is also registered. |
+| `tempo.session()` and `tempo.sessionLegacy()` | `tempo.session()` and `tempo.sessionLegacy.method()` | Migration mode. Both current and Legacy Sessions Challenges can be handled while clients roll forward. |
+
+Current Sessions Challenges advertise `sessionProtocol: "v2"` in method details and use TIP-1034 reserve channels. Legacy Sessions Challenges use the contract-backed Sessions v1 flow. Channel state is not reusable across implementations; let old channels close or settle under `tempo.sessionLegacy`, and open new channels with `tempo.session`.
 
 ### Server
 

--- a/src/pages/sdk/typescript/client/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.mdx
@@ -10,6 +10,8 @@ Convenience function that creates both `tempo.charge` and Sessions method intent
 
 Register [`tempo.subscription`](/sdk/typescript/client/Method.tempo.subscription) separately for recurring payments.
 
+Use this helper when you want `Mppx.create` to handle both one-time charges and current Sessions through the same fetch wrapper. If you need to close, top up, or stream a single channel explicitly, use [`tempo.session.manager()`](/sdk/typescript/client/Method.tempo.session-manager) instead.
+
 :::warning[Legacy Sessions]
 `tempo.session` is the current Sessions implementation. The previous contract-backed flow is Legacy Sessions, also called Sessions v1, and is available as `tempo.sessionLegacy`.
 :::
@@ -49,7 +51,7 @@ Mppx.create({
 
 ### Standalone session manager
 
-`tempo.session.manager()` creates the recommended standalone Sessions manager with explicit `.fetch()`, `.topUp()`, `.close()`, `.sse()`, and `.ws()` methods—no `Mppx.create` required:
+`tempo.session.manager()` creates a standalone Sessions manager with explicit `.fetch()`, `.topUp()`, `.close()`, `.sse()`, and `.ws()` methods. It does not register a method in `Mppx.create`; it owns one channel lifecycle directly.
 
 ```ts twoslash
 import { tempo } from 'mppx/client'

--- a/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
@@ -2,7 +2,9 @@
 
 Creates a Sessions manager that handles channel open, paid fetches, streaming, top-ups, and close.
 
-Use this for client-side pay-as-you-go flows. The manager opens a TIP-1034 channel lazily after the first `402` Challenge, signs cumulative vouchers, tops up when needed, and closes the channel when you call `.close()`.
+Use this when application code needs direct lifecycle control for one channel. The manager opens a TIP-1034 channel lazily after the first `402` Challenge, signs cumulative vouchers, tops up when needed, and closes the channel when you call `.close()`.
+
+Use `tempo.session()` instead when you only need to register the current Sessions method inside `Mppx.create`. Use `tempo()` when the same fetch wrapper should handle both one-time charges and current Sessions.
 
 :::warning[Legacy Sessions]
 `tempo.session.manager` is the current Sessions manager. The previous contract-backed manager is Legacy Sessions, also called Sessions v1, and is available as `tempo.sessionLegacy`.
@@ -167,6 +169,8 @@ const session = tempo.session.manager({
 ## Migrate from Legacy Sessions
 
 Legacy Sessions clients used `tempo.sessionLegacy()` or `tempo.sessionLegacy.method()`. Use `tempo.session.manager()` for a standalone manager, or `tempo()` when you want the same fetch wrapper to handle one-time charges and Sessions.
+
+Current Sessions and Legacy Sessions do not share channel state. Existing Legacy channels should be closed or settled through `tempo.sessionLegacy`; new channels should be opened through `tempo.session` or `tempo.session.manager()`. During a rolling migration, register both `tempo.session()` and `tempo.sessionLegacy.method()` if the client may talk to both server versions.
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'

--- a/src/pages/sdk/typescript/client/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session.mdx
@@ -3,7 +3,7 @@
 Creates the low-level Tempo Sessions client method for `Mppx.create`.
 
 :::info
-Use [`tempo.session.manager()`](/sdk/typescript/client/Method.tempo.session-manager) for the recommended standalone session manager. Use `tempo.session()` when you need to register the session intent directly in `Mppx.create`.
+Use `tempo.session()` when you need to register only the current Sessions intent in `Mppx.create`. Use [`tempo.session.manager()`](/sdk/typescript/client/Method.tempo.session-manager) when you need a standalone object with `.fetch()`, `.topUp()`, `.close()`, `.sse()`, or `.ws()`.
 :::
 
 :::warning[Legacy Sessions]
@@ -45,6 +45,22 @@ Mppx.create({
 ### With Legacy Sessions
 
 Use `tempo.sessionLegacy.method()` only for servers that still issue Legacy Sessions Challenges.
+
+If a client must support both current and Legacy Sessions during migration, register both methods:
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+Mppx.create({
+  methods: [
+    tempo.session({ account, maxDeposit: '1' }),
+    tempo.sessionLegacy.method({ account, maxDeposit: '1' }),
+  ],
+})
+```
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -77,6 +77,14 @@ const mppx = Mppx.create({
 
 Register `tempo.session()` beside `tempo.sessionLegacy()` during migration so existing clients keep working while new clients use Sessions.
 
+| Server methods | Compatible client methods |
+|---|---|
+| `tempo.session()` only | `tempo.session()` or `tempo()` |
+| `tempo.sessionLegacy()` only | `tempo.sessionLegacy()` or `tempo.sessionLegacy.method()` |
+| `tempo.session()` and `tempo.sessionLegacy()` | `tempo.session()` plus `tempo.sessionLegacy.method()` when clients may see both Challenge types |
+
+Current Sessions Challenges include `sessionProtocol: "v2"` and use TIP-1034 reserve channels. Legacy Sessions use the contract-backed Sessions v1 flow. Channel state is not portable between them, so close or settle Legacy channels with `tempo.sessionLegacy` and open new channels with `tempo.session`.
+
 ```ts twoslash
 import { Mppx, Store, tempo } from 'mppx/server'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -283,7 +291,5 @@ Settles multiple precompile-backed channels on-chain.
 ```ts
 import { tempo } from 'mppx/server'
 
-const receipts = await tempo.session.settleBatch(store, client, {
-  limit: 100,
-})
+const txHashes = await tempo.session.settleBatch(store, client, channelIds)
 ```


### PR DESCRIPTION
## Summary
- clarify when to use tempo(), tempo.session(), tempo.session.manager(), and legacy APIs
- add current/legacy Sessions migration compatibility guidance
- correct settleBatch docs to match the upstream mppx signature: settleBatch(store, client, channelIds, options?)

## Verification
- checked upstream wevm/mppx source for settleBatch signature
- rg confirmed the edited docs no longer contain the stale settleBatch object-form sample or old manager wording

Note: package install/typecheck was not run because pnpm is not installed and corepack/npm access to the package spec failed in this sandbox.