### PR TITLE
docs: keep Sessions chain examples consistent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,8 @@ Always use these chain IDs when referencing Tempo networks:
 
 Never use `98865`—that is a deprecated chain ID.
 
+Keep code examples within a single page on one Tempo network unless the section is explicitly comparing networks. For Sessions docs, default runnable examples to Tempo mainnet (`4217`, `tempo` from `viem/chains`, and `https://rpc.tempo.xyz`) and reserve Moderato (`42431`) for parameter descriptions, network reference tables, or pages that are specifically about testnet setup.
+
 When showing token or contract addresses in code examples, add a short inline comment naming the currency or contract whenever the name is not obvious from surrounding text:
 
 ```ts

--- a/scripts/check-tempo-chain-docs.test.ts
+++ b/scripts/check-tempo-chain-docs.test.ts
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..");
+
+const SESSION_DOCS = [
+  "src/pages/payment-methods/tempo/session.mdx",
+  "src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx",
+  "src/pages/sdk/typescript/server/Method.tempo.session.mdx",
+] as const;
+
+const TESTNET_EXAMPLE_PATTERNS = [
+  /\bchainId:\s*42431\b/,
+  /\btempoModerato\b/,
+  /https:\/\/rpc\.moderato\.tempo\.xyz/,
+] as const;
+
+describe("Tempo chain IDs in Sessions docs", () => {
+  it("keeps runnable Sessions examples on Tempo mainnet", async () => {
+    const violations: string[] = [];
+
+    for (const file of SESSION_DOCS) {
+      const content = await readFile(resolve(ROOT, file), "utf-8");
+      const lines = content.split("\n");
+
+      for (const [index, line] of lines.entries()) {
+        for (const pattern of TESTNET_EXAMPLE_PATTERNS) {
+          if (pattern.test(line)) violations.push(`${file}:${index + 1}  ${line.trim()}`);
+        }
+      }
+    }
+
+    expect(
+      violations,
+      `Sessions runnable examples should use Tempo mainnet; keep Moderato references to prose or network reference tables.\n${violations.join("\n")}`,
+    ).toHaveLength(0);
+  });
+});

--- a/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
@@ -172,7 +172,7 @@ Legacy Sessions clients used `tempo.sessionLegacy()` or `tempo.sessionLegacy.met
 import { Mppx, tempo } from 'mppx/client'
 import { createClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempoModerato } from 'viem/chains'
+import { tempo as tempoMainnet } from 'viem/chains'
 
 const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
@@ -182,8 +182,8 @@ const { fetch: mppxFetch } = Mppx.create({
       account,
       getClient: () =>
         createClient({
-          chain: tempoModerato,
-          transport: http('https://rpc.moderato.tempo.xyz'),
+          chain: tempoMainnet,
+          transport: http('https://rpc.tempo.xyz'),
         }),
       maxDeposit: '1',
     }),

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -87,7 +87,7 @@ const mppx = Mppx.create({
   methods: [
     tempo.session({
       account,
-      chainId: 42431,
+      chainId: 4217,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       store: Store.memory(),
     }),


### PR DESCRIPTION
## Summary
- make Sessions migration examples consistently use Tempo mainnet
- add an AGENTS.md rule to keep runnable Sessions examples on one Tempo network per page
- add a Vitest guard for Sessions docs so Moderato example tokens do not reappear in runnable examples

## Verification
- rg: no chainId: 42431, tempoModerato, or rpc.moderato.tempo.xyz remains in the guarded Sessions docs
- npx vitest run with an empty config: scripts/check-tempo-chain-docs.test.ts and scripts/check-addresses.test.ts passed

Note: repo dependency install was not run; direct vitest against the repo config failed because dependencies were not installed locally, so I reran with a minimal temporary config to execute only the script tests.