### PR TITLE
fix: format Tempo chain docs test

### DIFF
--- a/scripts/check-tempo-chain-docs.test.ts
+++ b/scripts/check-tempo-chain-docs.test.ts
@@ -26,7 +26,8 @@ describe("Tempo chain IDs in Sessions docs", () => {
 
       for (const [index, line] of lines.entries()) {
         for (const pattern of TESTNET_EXAMPLE_PATTERNS) {
-          if (pattern.test(line)) violations.push(`${file}:${index + 1}  ${line.trim()}`);
+          if (pattern.test(line))
+            violations.push(`${file}:${index + 1}  ${line.trim()}`);
         }
       }
     }


### PR DESCRIPTION
## Summary

- Format the Tempo chain docs test so Biome passes on main.
