### PR TITLE
Align docs with v2 Sessions SDK

### DIFF
--- a/scripts/check-tempo-chain-docs.test.ts
+++ b/scripts/check-tempo-chain-docs.test.ts
@@ -5,8 +5,15 @@ import { describe, expect, it } from "vitest";
 const ROOT = resolve(import.meta.dirname, "..");
 
 const SESSION_DOCS = [
+  "src/pages/guides/pay-as-you-go.mdx",
+  "src/pages/guides/streamed-payments.mdx",
   "src/pages/payment-methods/tempo/session.mdx",
   "src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx",
+  "src/pages/sdk/typescript/middlewares/elysia.mdx",
+  "src/pages/sdk/typescript/middlewares/express.mdx",
+  "src/pages/sdk/typescript/middlewares/hono.mdx",
+  "src/pages/sdk/typescript/middlewares/nextjs.mdx",
+  "src/pages/sdk/typescript/server/Method.tempo.mdx",
   "src/pages/sdk/typescript/server/Method.tempo.session.mdx",
 ] as const;
 
@@ -26,7 +33,8 @@ describe("Tempo chain IDs in Sessions docs", () => {
 
       for (const [index, line] of lines.entries()) {
         for (const pattern of TESTNET_EXAMPLE_PATTERNS) {
-          if (pattern.test(line)) violations.push(`${file}:${index + 1}  ${line.trim()}`);
+          if (pattern.test(line))
+            violations.push(`${file}:${index + 1}  ${line.trim()}`);
         }
       }
     }

--- a/skills/mppx/SKILL.md
+++ b/skills/mppx/SKILL.md
@@ -34,10 +34,21 @@ const res = await mppx.fetch('https://api.example.com/resource')
 ## Server
 
 ```ts
-import { Mppx, tempo } from 'mppx/server'
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
 
 const mppx = Mppx.create({
-  methods: [tempo({ currency: '0x...', recipient: '0x...' })],
+  methods: [
+    tempo.charge({ currency: '0x...', recipient: '0x...' }),
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x...',
+      store: Store.memory(),
+    }),
+  ],
   secretKey: process.env.MPP_SECRET_KEY,
 })
 
@@ -56,7 +67,7 @@ async function handler(request: Request): Promise<Response> {
 | `tempo.session` | `session` | Streaming payments via payment channels on Tempo |
 | `stripe.charge` | `charge` | One-time payment via Stripe |
 
-`tempo()` returns `[tempo.charge, tempo.session]` as a tuple. Use `tempo.charge()` or `tempo.session()` individually if you only need one intent.
+`tempo()` returns `[tempo.charge, tempo.session]` as a tuple using the current v2 Sessions implementation. Use `tempo.charge()` or `tempo.session()` individually if you only need one intent. Use `tempo.sessionLegacy` only for Legacy Sessions v1 compatibility.
 
 ## Exports
 

--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -1,139 +1,182 @@
 // deno-fmt-ignore-file
 // biome-ignore format: generated types do not need formatting
 // prettier-ignore
-import type { PathsForPages, GetConfigResponse } from 'waku/router';
-
+import type { PathsForPages } from 'waku/router'
 
 // prettier-ignore
 type Page =
-| { path: '/404'; render: 'static' }
-| { path: '/brand'; render: 'static' }
-| { path: '/extensions'; render: 'static' }
-| { path: '/faq'; render: 'static' }
-| { path: '/'; render: 'static' }
-| { path: '/overview'; render: 'static' }
-| { path: '/services'; render: 'static' }
-| { path: '/sdk/features'; render: 'static' }
-| { path: '/sdk'; render: 'static' }
-| { path: '/sdk/typescript/Html.init'; render: 'static' }
-| { path: '/sdk/typescript/Method.from'; render: 'static' }
-| { path: '/sdk/typescript/cli'; render: 'static' }
-| { path: '/sdk/typescript'; render: 'static' }
-| { path: '/sdk/typescript/proxy'; render: 'static' }
-| { path: '/sdk/typescript/server/Method.stripe.charge'; render: 'static' }
-| { path: '/sdk/typescript/server/Method.stripe'; render: 'static' }
-| { path: '/sdk/typescript/server/Method.tempo.charge'; render: 'static' }
-| { path: '/sdk/typescript/server/Method.tempo'; render: 'static' }
-| { path: '/sdk/typescript/server/Method.tempo.session'; render: 'static' }
-| { path: '/sdk/typescript/server/Mppx.compose'; render: 'static' }
-| { path: '/sdk/typescript/server/Mppx.create'; render: 'static' }
-| { path: '/sdk/typescript/server/Mppx.toNodeListener'; render: 'static' }
-| { path: '/sdk/typescript/server/Request.toNodeListener'; render: 'static' }
-| { path: '/sdk/typescript/server/Response.requirePayment'; render: 'static' }
-| { path: '/sdk/typescript/server/Transport.from'; render: 'static' }
-| { path: '/sdk/typescript/server/Transport.http'; render: 'static' }
-| { path: '/sdk/typescript/server/Transport.mcp'; render: 'static' }
-| { path: '/sdk/typescript/server/Transport.mcpSdk'; render: 'static' }
-| { path: '/sdk/typescript/middlewares/elysia'; render: 'static' }
-| { path: '/sdk/typescript/middlewares/express'; render: 'static' }
-| { path: '/sdk/typescript/middlewares/hono'; render: 'static' }
-| { path: '/sdk/typescript/middlewares/nextjs'; render: 'static' }
-| { path: '/sdk/typescript/html/custom'; render: 'static' }
-| { path: '/sdk/typescript/core/BodyDigest.compute'; render: 'static' }
-| { path: '/sdk/typescript/core/BodyDigest.verify'; render: 'static' }
-| { path: '/sdk/typescript/core/Challenge.deserialize'; render: 'static' }
-| { path: '/sdk/typescript/core/Challenge.from'; render: 'static' }
-| { path: '/sdk/typescript/core/Challenge.fromHeaders'; render: 'static' }
-| { path: '/sdk/typescript/core/Challenge.fromMethod'; render: 'static' }
-| { path: '/sdk/typescript/core/Challenge.fromResponse'; render: 'static' }
-| { path: '/sdk/typescript/core/Challenge.meta'; render: 'static' }
-| { path: '/sdk/typescript/core/Challenge.serialize'; render: 'static' }
-| { path: '/sdk/typescript/core/Challenge.verify'; render: 'static' }
-| { path: '/sdk/typescript/core/Credential.deserialize'; render: 'static' }
-| { path: '/sdk/typescript/core/Credential.from'; render: 'static' }
-| { path: '/sdk/typescript/core/Credential.fromRequest'; render: 'static' }
-| { path: '/sdk/typescript/core/Credential.serialize'; render: 'static' }
-| { path: '/sdk/typescript/core/Expires'; render: 'static' }
-| { path: '/sdk/typescript/core/Method.from'; render: 'static' }
-| { path: '/sdk/typescript/core/Method.toClient'; render: 'static' }
-| { path: '/sdk/typescript/core/Method.toServer'; render: 'static' }
-| { path: '/sdk/typescript/core/PaymentRequest.deserialize'; render: 'static' }
-| { path: '/sdk/typescript/core/PaymentRequest.from'; render: 'static' }
-| { path: '/sdk/typescript/core/PaymentRequest.serialize'; render: 'static' }
-| { path: '/sdk/typescript/core/Receipt.deserialize'; render: 'static' }
-| { path: '/sdk/typescript/core/Receipt.from'; render: 'static' }
-| { path: '/sdk/typescript/core/Receipt.fromResponse'; render: 'static' }
-| { path: '/sdk/typescript/core/Receipt.serialize'; render: 'static' }
-| { path: '/sdk/typescript/client/McpClient.wrap'; render: 'static' }
-| { path: '/sdk/typescript/client/Method.stripe.charge'; render: 'static' }
-| { path: '/sdk/typescript/client/Method.stripe'; render: 'static' }
-| { path: '/sdk/typescript/client/Method.tempo.charge'; render: 'static' }
-| { path: '/sdk/typescript/client/Method.tempo'; render: 'static' }
-| { path: '/sdk/typescript/client/Method.tempo.session-manager'; render: 'static' }
-| { path: '/sdk/typescript/client/Method.tempo.session'; render: 'static' }
-| { path: '/sdk/typescript/client/Mppx.create'; render: 'static' }
-| { path: '/sdk/typescript/client/Mppx.restore'; render: 'static' }
-| { path: '/sdk/typescript/client/Transport.from'; render: 'static' }
-| { path: '/sdk/typescript/client/Transport.http'; render: 'static' }
-| { path: '/sdk/typescript/client/Transport.mcp'; render: 'static' }
-| { path: '/sdk/rust/client'; render: 'static' }
-| { path: '/sdk/rust/core'; render: 'static' }
-| { path: '/sdk/rust'; render: 'static' }
-| { path: '/sdk/rust/server'; render: 'static' }
-| { path: '/sdk/python/client'; render: 'static' }
-| { path: '/sdk/python/core'; render: 'static' }
-| { path: '/sdk/python'; render: 'static' }
-| { path: '/sdk/python/server'; render: 'static' }
-| { path: '/quickstart/agent'; render: 'static' }
-| { path: '/quickstart/client'; render: 'static' }
-| { path: '/quickstart'; render: 'static' }
-| { path: '/quickstart/server'; render: 'static' }
-| { path: '/protocol/challenges'; render: 'static' }
-| { path: '/protocol/credentials'; render: 'static' }
-| { path: '/protocol/http-402'; render: 'static' }
-| { path: '/protocol'; render: 'static' }
-| { path: '/protocol/receipts'; render: 'static' }
-| { path: '/protocol/transports/http'; render: 'static' }
-| { path: '/protocol/transports'; render: 'static' }
-| { path: '/protocol/transports/mcp'; render: 'static' }
-| { path: '/payment-methods/custom'; render: 'static' }
-| { path: '/payment-methods'; render: 'static' }
-| { path: '/payment-methods/tempo/charge'; render: 'static' }
-| { path: '/payment-methods/tempo'; render: 'static' }
-| { path: '/payment-methods/tempo/session'; render: 'static' }
-| { path: '/payment-methods/stripe/charge'; render: 'static' }
-| { path: '/payment-methods/stripe'; render: 'static' }
-| { path: '/payment-methods/stellar/charge'; render: 'static' }
-| { path: '/payment-methods/stellar'; render: 'static' }
-| { path: '/payment-methods/stellar/session'; render: 'static' }
-| { path: '/payment-methods/solana/charge'; render: 'static' }
-| { path: '/payment-methods/solana'; render: 'static' }
-| { path: '/payment-methods/lightning/charge'; render: 'static' }
-| { path: '/payment-methods/lightning'; render: 'static' }
-| { path: '/payment-methods/lightning/session'; render: 'static' }
-| { path: '/payment-methods/card/charge'; render: 'static' }
-| { path: '/payment-methods/card'; render: 'static' }
-| { path: '/intents/charge'; render: 'static' }
-| { path: '/guides/building-with-an-llm'; render: 'static' }
-| { path: '/guides/multiple-payment-methods'; render: 'static' }
-| { path: '/guides/one-time-payments'; render: 'static' }
-| { path: '/guides/pay-as-you-go'; render: 'static' }
-| { path: '/guides/payment-links'; render: 'static' }
-| { path: '/guides/proxy-existing-service'; render: 'static' }
-| { path: '/guides/split-payments'; render: 'static' }
-| { path: '/guides/streamed-payments'; render: 'static' }
-| { path: '/guides/upgrade-x402'; render: 'static' }
-| { path: '/advanced/discovery'; render: 'static' }
-| { path: '/advanced/identity'; render: 'static' }
-| { path: '/advanced/refunds'; render: 'static' }
-| { path: '/_api/api/og'; render: 'static' };
+  | { path: '/404'; render: 'static' }
+  | { path: '/_api/api/og'; render: 'static' }
+  | { path: '/advanced/discovery'; render: 'static' }
+  | { path: '/advanced/identity'; render: 'static' }
+  | { path: '/advanced/refunds'; render: 'static' }
+  | { path: '/advanced/security'; render: 'static' }
+  | { path: '/blog/evm-x402-support'; render: 'static' }
+  | { path: '/blog/go-and-ruby-sdks'; render: 'static' }
+  | { path: '/blog'; render: 'static' }
+  | { path: '/blog/multi-method-discovery'; render: 'static' }
+  | { path: '/blog/payment-hooks'; render: 'static' }
+  | { path: '/blog/subscriptions'; render: 'static' }
+  | { path: '/brand'; render: 'static' }
+  | { path: '/extensions'; render: 'static' }
+  | { path: '/faq'; render: 'static' }
+  | { path: '/guides/accept-card-payments'; render: 'static' }
+  | { path: '/guides/building-with-an-llm'; render: 'static' }
+  | { path: '/guides/monetize-mcp-server'; render: 'static' }
+  | { path: '/guides/multiple-payment-methods'; render: 'static' }
+  | { path: '/guides/one-time-payments'; render: 'static' }
+  | { path: '/guides/pay-as-you-go'; render: 'static' }
+  | { path: '/guides/payment-links'; render: 'static' }
+  | { path: '/guides/proxy-existing-service'; render: 'static' }
+  | { path: '/guides/split-payments'; render: 'static' }
+  | { path: '/guides/streamed-payments'; render: 'static' }
+  | { path: '/guides/subscription-payments'; render: 'static' }
+  | { path: '/guides/use-mpp-with-x402'; render: 'static' }
+  | { path: '/'; render: 'static' }
+  | { path: '/intents/charge'; render: 'static' }
+  | { path: '/intents/subscription'; render: 'static' }
+  | { path: '/mpp-vs-x402'; render: 'static' }
+  | { path: '/overview'; render: 'static' }
+  | { path: '/payment-methods/card/charge'; render: 'static' }
+  | { path: '/payment-methods/card'; render: 'static' }
+  | { path: '/payment-methods/custom'; render: 'static' }
+  | { path: '/payment-methods/evm/charge'; render: 'static' }
+  | { path: '/payment-methods/evm'; render: 'static' }
+  | { path: '/payment-methods'; render: 'static' }
+  | { path: '/payment-methods/lightning/charge'; render: 'static' }
+  | { path: '/payment-methods/lightning'; render: 'static' }
+  | { path: '/payment-methods/lightning/session'; render: 'static' }
+  | { path: '/payment-methods/monad/charge'; render: 'static' }
+  | { path: '/payment-methods/monad'; render: 'static' }
+  | { path: '/payment-methods/redotpay/charge'; render: 'static' }
+  | { path: '/payment-methods/redotpay'; render: 'static' }
+  | { path: '/payment-methods/solana/charge'; render: 'static' }
+  | { path: '/payment-methods/solana'; render: 'static' }
+  | { path: '/payment-methods/stellar/charge'; render: 'static' }
+  | { path: '/payment-methods/stellar'; render: 'static' }
+  | { path: '/payment-methods/stellar/session'; render: 'static' }
+  | { path: '/payment-methods/stripe/charge'; render: 'static' }
+  | { path: '/payment-methods/stripe'; render: 'static' }
+  | { path: '/payment-methods/tempo/charge'; render: 'static' }
+  | { path: '/payment-methods/tempo'; render: 'static' }
+  | { path: '/payment-methods/tempo/session'; render: 'static' }
+  | { path: '/payment-methods/tempo/subscription'; render: 'static' }
+  | { path: '/protocol/challenges'; render: 'static' }
+  | { path: '/protocol/credentials'; render: 'static' }
+  | { path: '/protocol/http-402'; render: 'static' }
+  | { path: '/protocol'; render: 'static' }
+  | { path: '/protocol/receipts'; render: 'static' }
+  | { path: '/protocol/transports/http'; render: 'static' }
+  | { path: '/protocol/transports'; render: 'static' }
+  | { path: '/protocol/transports/mcp'; render: 'static' }
+  | { path: '/protocol/transports/websocket'; render: 'static' }
+  | { path: '/quickstart/agent'; render: 'static' }
+  | { path: '/quickstart/client'; render: 'static' }
+  | { path: '/quickstart'; render: 'static' }
+  | { path: '/quickstart/server'; render: 'static' }
+  | { path: '/sdk/features'; render: 'static' }
+  | { path: '/sdk/go/client'; render: 'static' }
+  | { path: '/sdk/go/core'; render: 'static' }
+  | { path: '/sdk/go'; render: 'static' }
+  | { path: '/sdk/go/server'; render: 'static' }
+  | { path: '/sdk'; render: 'static' }
+  | { path: '/sdk/python/client'; render: 'static' }
+  | { path: '/sdk/python/core'; render: 'static' }
+  | { path: '/sdk/python'; render: 'static' }
+  | { path: '/sdk/python/server'; render: 'static' }
+  | { path: '/sdk/ruby/client'; render: 'static' }
+  | { path: '/sdk/ruby/core'; render: 'static' }
+  | { path: '/sdk/ruby'; render: 'static' }
+  | { path: '/sdk/ruby/server'; render: 'static' }
+  | { path: '/sdk/rust/client'; render: 'static' }
+  | { path: '/sdk/rust/core'; render: 'static' }
+  | { path: '/sdk/rust'; render: 'static' }
+  | { path: '/sdk/rust/server'; render: 'static' }
+  | { path: '/sdk/typescript/Html.init'; render: 'static' }
+  | { path: '/sdk/typescript/Method.from'; render: 'static' }
+  | { path: '/sdk/typescript/cli'; render: 'static' }
+  | { path: '/sdk/typescript/client/Fetch.from'; render: 'static' }
+  | { path: '/sdk/typescript/client/Fetch.polyfill'; render: 'static' }
+  | { path: '/sdk/typescript/client/Fetch.restore'; render: 'static' }
+  | { path: '/sdk/typescript/client/McpClient.wrap'; render: 'static' }
+  | { path: '/sdk/typescript/client/Method.evm.charge'; render: 'static' }
+  | { path: '/sdk/typescript/client/Method.evm'; render: 'static' }
+  | { path: '/sdk/typescript/client/Method.stripe.charge'; render: 'static' }
+  | { path: '/sdk/typescript/client/Method.stripe'; render: 'static' }
+  | { path: '/sdk/typescript/client/Method.tempo.charge'; render: 'static' }
+  | { path: '/sdk/typescript/client/Method.tempo'; render: 'static' }
+  | { path: '/sdk/typescript/client/Method.tempo.session-manager'; render: 'static' }
+  | { path: '/sdk/typescript/client/Method.tempo.session'; render: 'static' }
+  | { path: '/sdk/typescript/client/Method.tempo.subscription'; render: 'static' }
+  | { path: '/sdk/typescript/client/Mppx.create'; render: 'static' }
+  | { path: '/sdk/typescript/client/Mppx.restore'; render: 'static' }
+  | { path: '/sdk/typescript/client/Transport.from'; render: 'static' }
+  | { path: '/sdk/typescript/client/Transport.http'; render: 'static' }
+  | { path: '/sdk/typescript/client/Transport.mcp'; render: 'static' }
+  | { path: '/sdk/typescript/core/BodyDigest.compute'; render: 'static' }
+  | { path: '/sdk/typescript/core/BodyDigest.verify'; render: 'static' }
+  | { path: '/sdk/typescript/core/Challenge.deserialize'; render: 'static' }
+  | { path: '/sdk/typescript/core/Challenge.from'; render: 'static' }
+  | { path: '/sdk/typescript/core/Challenge.fromHeaders'; render: 'static' }
+  | { path: '/sdk/typescript/core/Challenge.fromMethod'; render: 'static' }
+  | { path: '/sdk/typescript/core/Challenge.fromResponse'; render: 'static' }
+  | { path: '/sdk/typescript/core/Challenge.meta'; render: 'static' }
+  | { path: '/sdk/typescript/core/Challenge.serialize'; render: 'static' }
+  | { path: '/sdk/typescript/core/Challenge.verify'; render: 'static' }
+  | { path: '/sdk/typescript/core/Credential.deserialize'; render: 'static' }
+  | { path: '/sdk/typescript/core/Credential.from'; render: 'static' }
+  | { path: '/sdk/typescript/core/Credential.fromRequest'; render: 'static' }
+  | { path: '/sdk/typescript/core/Credential.serialize'; render: 'static' }
+  | { path: '/sdk/typescript/core/Expires'; render: 'static' }
+  | { path: '/sdk/typescript/core/Method.from'; render: 'static' }
+  | { path: '/sdk/typescript/core/Method.toClient'; render: 'static' }
+  | { path: '/sdk/typescript/core/Method.toServer'; render: 'static' }
+  | { path: '/sdk/typescript/core/PaymentRequest.deserialize'; render: 'static' }
+  | { path: '/sdk/typescript/core/PaymentRequest.from'; render: 'static' }
+  | { path: '/sdk/typescript/core/PaymentRequest.serialize'; render: 'static' }
+  | { path: '/sdk/typescript/core/Receipt.deserialize'; render: 'static' }
+  | { path: '/sdk/typescript/core/Receipt.from'; render: 'static' }
+  | { path: '/sdk/typescript/core/Receipt.fromResponse'; render: 'static' }
+  | { path: '/sdk/typescript/core/Receipt.serialize'; render: 'static' }
+  | { path: '/sdk/typescript/html/custom'; render: 'static' }
+  | { path: '/sdk/typescript'; render: 'static' }
+  | { path: '/sdk/typescript/middlewares/elysia'; render: 'static' }
+  | { path: '/sdk/typescript/middlewares/express'; render: 'static' }
+  | { path: '/sdk/typescript/middlewares/hono'; render: 'static' }
+  | { path: '/sdk/typescript/middlewares/nextjs'; render: 'static' }
+  | { path: '/sdk/typescript/proxy'; render: 'static' }
+  | { path: '/sdk/typescript/server/Method.evm.charge'; render: 'static' }
+  | { path: '/sdk/typescript/server/Method.evm'; render: 'static' }
+  | { path: '/sdk/typescript/server/Method.stripe.charge'; render: 'static' }
+  | { path: '/sdk/typescript/server/Method.stripe'; render: 'static' }
+  | { path: '/sdk/typescript/server/Method.tempo.charge'; render: 'static' }
+  | { path: '/sdk/typescript/server/Method.tempo'; render: 'static' }
+  | { path: '/sdk/typescript/server/Method.tempo.renewSubscription'; render: 'static' }
+  | { path: '/sdk/typescript/server/Method.tempo.session'; render: 'static' }
+  | { path: '/sdk/typescript/server/Method.tempo.subscription'; render: 'static' }
+  | { path: '/sdk/typescript/server/Mppx.compose'; render: 'static' }
+  | { path: '/sdk/typescript/server/Mppx.create'; render: 'static' }
+  | { path: '/sdk/typescript/server/Mppx.toNodeListener'; render: 'static' }
+  | { path: '/sdk/typescript/server/Mppx.verifyCredential'; render: 'static' }
+  | { path: '/sdk/typescript/server/Request.toNodeListener'; render: 'static' }
+  | { path: '/sdk/typescript/server/Response.requirePayment'; render: 'static' }
+  | { path: '/sdk/typescript/server/Transport.from'; render: 'static' }
+  | { path: '/sdk/typescript/server/Transport.http'; render: 'static' }
+  | { path: '/sdk/typescript/server/Transport.mcp'; render: 'static' }
+  | { path: '/sdk/typescript/server/Transport.mcpSdk'; render: 'static' }
+  | { path: '/sdk/typescript/server/Ws.serve'; render: 'static' }
+  | { path: '/services'; render: 'static' }
+  | { path: '/tools/wallet'; render: 'static' }
+  | { path: '/use-cases/agentic-payments'; render: 'static' }
+  | { path: '/use-cases/api-monetization'; render: 'static' }
+  | { path: '/use-cases/micropayments'; render: 'static' }
 
 // prettier-ignore
 declare module 'waku/router' {
   interface RouteConfig {
-    paths: PathsForPages<Page>;
+    paths: PathsForPages<Page>
   }
   interface CreatePagesConfig {
-    pages: Page;
+    pages: Page
   }
 }

--- a/src/pages/_api/api/demo/poem.ts
+++ b/src/pages/_api/api/demo/poem.ts
@@ -46,7 +46,7 @@ const poems = [
     "A stream of data onward drifts.",
     "No human hand to slow the pace,",
     "Just math and trust in empty space.",
-    "The escrow holds, the channel clears,",
+    "The reserve holds, the channel clears,",
     "A settlement in milliseconds, not years.",
   ],
   [

--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -41,7 +41,7 @@ const app = new Hono()
 
 const mppx = Mppx.create({
   methods: [
-    tempo({
+    tempo.charge({
       currency: '0x20c0000000000000000000000000000000000000',
       recipient: '0x...',
       testnet: true,
@@ -73,7 +73,7 @@ const app = express()
 
 const mppx = Mppx.create({
   methods: [
-    tempo({
+    tempo.charge({
       currency: '0x20c0000000000000000000000000000000000000',
       recipient: '0x...',
       testnet: true,

--- a/src/pages/advanced/refunds.mdx
+++ b/src/pages/advanced/refunds.mdx
@@ -46,7 +46,7 @@ Refund decisions are up to your service. Common triggers include failed processi
 
 ## Session flow
 
-In the session flow, funds are locked but not immediately claimed. If the server never claims the locked funds, they automatically return to the client after the session expires.
+In the v2 session flow, funds are reserved in a Tempo channel but not immediately claimed. If the server never claims the reserved funds, they return to the client after the session expires or closes.
 
 This gives sessions a **built-in refund mechanism**—unclaimed funds are refunded by default.
 
@@ -76,25 +76,22 @@ This gives sessions a **built-in refund mechanism**—unclaimed funds are refund
 
 ### Refunding via channel close
 
-To refund a session, close the channel with the last settled voucher. Any unclaimed deposit returns to the client automatically.
+To refund a session, close the channel with the last accepted voucher. Any unclaimed deposit returns to the client automatically.
 
-```ts twoslash [server.ts]
-// @noEmit
-declare const session: { close(): Promise<{ txHash: string; refundedToPayer: string }> }
-// ---cut---
+```ts [client.ts]
+import { tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const session = tempo.session.manager({
+  account: privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'),
+  maxDeposit: '10',
+})
+
+await session.fetch('https://api.example.com/resource')
+
 const receipt = await session.close()
-// @log: { txHash: "0xabc...", refundedToPayer: "8500000" }
-```
-
-On the client side, calling `requestClose` followed by `withdraw` after the grace period achieves the same result if the server is unresponsive:
-
-```ts twoslash [client.ts]
-// @noEmit
-declare const escrow: { write: { requestClose(args: [`0x${string}`]): Promise<void>; withdraw(args: [`0x${string}`]): Promise<void> } }
-declare const channelId: `0x${string}`
-// ---cut---
-await escrow.write.requestClose([channelId])
-await escrow.write.withdraw([channelId])
+console.log(receipt?.txHash)
+// @log: 0x...
 ```
 
 ## Best practices

--- a/src/pages/blog/multi-method-discovery.mdx
+++ b/src/pages/blog/multi-method-discovery.mdx
@@ -99,7 +99,7 @@ const app = new Hono()
 
 const mppx = Mppx.create({
   methods: [
-    tempo({
+    tempo.charge({
       currency: '0x20c0000000000000000000000000000000000000',
       recipient: '0x...',
       testnet: true,

--- a/src/pages/guides/monetize-mcp-server.mdx
+++ b/src/pages/guides/monetize-mcp-server.mdx
@@ -106,7 +106,7 @@ import { Mppx, tempo, Transport } from 'mppx/server' // [!code ++]
 
 // [!code focus:start]
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -139,7 +139,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio'
 import { Mppx, tempo, Transport } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -200,7 +200,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio'
 import { Mppx, tempo, Transport } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',

--- a/src/pages/guides/multiple-payment-methods.mdx
+++ b/src/pages/guides/multiple-payment-methods.mdx
@@ -71,7 +71,7 @@ const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
+    tempo.charge({
       testnet: true,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -103,7 +103,7 @@ const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
+    tempo.charge({
       testnet: true,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -170,7 +170,7 @@ const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
+    tempo.charge({
       testnet: true,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -208,7 +208,7 @@ const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
+    tempo.charge({
       testnet: true,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -244,7 +244,7 @@ const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
+    tempo.charge({
       testnet: true,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',

--- a/src/pages/guides/one-time-payments.mdx
+++ b/src/pages/guides/one-time-payments.mdx
@@ -68,7 +68,7 @@ import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -86,7 +86,7 @@ import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -112,7 +112,7 @@ import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -173,7 +173,7 @@ const app = new Hono()
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -194,7 +194,7 @@ const app = new Hono()
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -223,7 +223,7 @@ const app = new Hono()
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -283,7 +283,7 @@ import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -301,7 +301,7 @@ import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -328,7 +328,7 @@ import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -396,7 +396,7 @@ const app = express()
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -417,7 +417,7 @@ const app = express()
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -446,7 +446,7 @@ const app = express()
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -511,7 +511,7 @@ import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -529,7 +529,7 @@ import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -556,7 +556,7 @@ import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
+  methods: [tempo.charge({
     testnet: true,
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',

--- a/src/pages/guides/pay-as-you-go.mdx
+++ b/src/pages/guides/pay-as-you-go.mdx
@@ -63,22 +63,28 @@ $ bun add mppx viem
 
 ### Set up `Mppx` instance
 
-Set up an `Mppx` instance with the `tempo` method.
+Set up an `Mppx` instance with the current `tempo.session` method.
 
-- `recipient` is the address where you receive payments.
-- `currency` is the token address for payments (in this case, `pathUSD`).
+- `account` signs server-side session settlement and close transactions.
+- `currency` is the token address for payments, in this case `pathUSD`.
+- `store` keeps v2 Session channel state; use a durable atomic store in production.
 
 ```ts [app/api/sessions/photo/route.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import { Mppx, tempo } from 'mppx/nextjs'
+import { privateKeyToAccount } from 'viem/accounts'
 
-export const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 ```
 
@@ -87,16 +93,21 @@ export const mppx = Mppx.create({
 Create the gallery route. This route is **currently unpaid**.
 
 ```ts [app/api/sessions/photo/route.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import { Mppx, tempo } from 'mppx/nextjs'
+import { privateKeyToAccount } from 'viem/accounts'
 
-export const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 
 // [!code focus:start]
@@ -113,16 +124,21 @@ Add payment verification using `mppx.session` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [app/api/sessions/photo/route.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import { Mppx, tempo } from 'mppx/nextjs'
+import { privateKeyToAccount } from 'viem/accounts'
 
-export const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 
 // [!code focus:start]
@@ -166,25 +182,31 @@ $ bun add mppx hono viem
 
 ### Set up `Mppx` instance
 
-Set up an `Mppx` instance with the `tempo` method.
+Set up an `Mppx` instance with the current `tempo.session` method.
 
-- `recipient` is the address where you receive payments.
-- `currency` is the token address for payments (in this case, `pathUSD`).
+- `account` signs server-side session settlement and close transactions.
+- `currency` is the token address for payments, in this case `pathUSD`.
+- `store` keeps v2 Session channel state; use a durable atomic store in production.
 
 ```ts [server.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = new Hono()
 
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 ```
 
@@ -193,19 +215,24 @@ const mppx = Mppx.create({
 Create the gallery route. This route is **currently unpaid**.
 
 ```ts [server.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = new Hono()
 
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 
 // [!code focus:start]
@@ -222,19 +249,24 @@ Add payment verification using `mppx.session` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [server.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = new Hono()
 
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 
 // [!code focus:start]
@@ -280,22 +312,27 @@ $ bun add mppx viem
 
 ### Set up `Mppx` instance
 
-Set up an `Mppx` instance with the `tempo` method.
+Set up an `Mppx` instance with the current `tempo.session` method.
 
-- `recipient` is the address where you receive payments.
-- `currency` is the token address for payments (in this case, `pathUSD`).
+- `account` signs server-side session settlement and close transactions.
+- `currency` is the token address for payments, in this case `pathUSD`.
+- `store` keeps v2 Session channel state; use a durable atomic store in production.
 
 ```ts [src/index.ts]
-import crypto from 'crypto'
-import { Mppx, tempo } from 'mppx/server'
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 ```
 
@@ -304,16 +341,20 @@ const mppx = Mppx.create({
 Create the gallery route. This route is **currently unpaid**.
 
 ```ts [src/index.ts]
-import crypto from 'crypto'
-import { Mppx, tempo } from 'mppx/server'
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 
 // [!code focus:start]
@@ -331,16 +372,20 @@ export default {
 Add payment verification using `mppx.session`. If the status is `402`, return the Challenge. Otherwise, fetch the photo and attach a Receipt to the response.
 
 ```ts [src/index.ts]
-import crypto from 'crypto'
-import { Mppx, tempo } from 'mppx/server'
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 
 // [!code focus:start]
@@ -391,25 +436,31 @@ $ bun add mppx express viem
 
 ### Set up `Mppx` instance
 
-Set up an `Mppx` instance with the `tempo` method.
+Set up an `Mppx` instance with the current `tempo.session` method.
 
-- `recipient` is the address where you receive payments.
-- `currency` is the token address for payments (in this case, `pathUSD`).
+- `account` signs server-side session settlement and close transactions.
+- `currency` is the token address for payments, in this case `pathUSD`.
+- `store` keeps v2 Session channel state; use a durable atomic store in production.
 
 ```ts [server.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import express from 'express'
 import { Mppx, tempo } from 'mppx/express'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = express()
 
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 ```
 
@@ -418,19 +469,24 @@ const mppx = Mppx.create({
 Create the gallery route. This route is **currently unpaid**.
 
 ```ts [server.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import express from 'express'
 import { Mppx, tempo } from 'mppx/express'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = express()
 
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 
 // [!code focus:start]
@@ -447,19 +503,24 @@ Add payment verification using `mppx.session` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [server.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import express from 'express'
 import { Mppx, tempo } from 'mppx/express'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = express()
 
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 
 // [!code focus:start]
@@ -510,21 +571,27 @@ $ bun add mppx viem
 
 ### Set up `Mppx` instance
 
-Set up an `Mppx` instance with the `tempo` method.
+Set up an `Mppx` instance with the current `tempo.session` method.
 
-- `recipient` is the address where you receive payments.
-- `currency` is the token address for payments (in this case, `pathUSD`).
+- `account` signs server-side session settlement and close transactions.
+- `currency` is the token address for payments, in this case `pathUSD`.
+- `store` keeps v2 Session channel state; use a durable atomic store in production.
 
 ```ts [server.ts]
-import { Mppx, tempo } from 'mppx/server'
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 ```
 
@@ -533,16 +600,20 @@ const mppx = Mppx.create({
 Create the gallery route. This route is **currently unpaid**.
 
 ```ts [server.ts]
-import crypto from 'crypto'
-import { Mppx, tempo } from 'mppx/server'
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 
 // [!code focus:start]
@@ -560,16 +631,20 @@ Bun.serve({
 Add payment verification using `mppx.session`. If the status is `402`, return the Challenge. Otherwise, fetch the photo and attach a Receipt to the response.
 
 ```ts [server.ts]
-import crypto from 'crypto'
-import { Mppx, tempo } from 'mppx/server'
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
-  methods: [tempo({
-    testnet: true,
-    currency: '0x20c0000000000000000000000000000000000000',
-    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-  })],
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
 })
 
 // [!code focus:start]

--- a/src/pages/guides/payment-links.mdx
+++ b/src/pages/guides/payment-links.mdx
@@ -37,7 +37,7 @@ Paste this into your coding agent to create a payment link in one prompt:
 Add mppx to my app with a payment-gated photo endpoint
 that charges $0.01 per request using the Tempo payment method with
 PathUSD. Enable payment links so browsers can pay directly
-from the page by setting html: true on the tempo() method config.
+from the page by setting html: true on the tempo.charge() method config.
 When payment is verified, fetch a random photo from
 https://picsum.photos/1024/1024 and return the URL as JSON.`}
 </PromptBlock>
@@ -71,7 +71,7 @@ import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     html: true, // [!code hl]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -90,7 +90,7 @@ import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/nextjs'
 
 export const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     html: true,
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -148,7 +148,7 @@ import { Mppx, tempo } from 'mppx/hono'
 const app = new Hono()
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     html: true, // [!code hl]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -168,7 +168,7 @@ import { Mppx, tempo } from 'mppx/hono'
 const app = new Hono()
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     html: true,
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -226,7 +226,7 @@ import { Mppx, tempo } from 'mppx/express'
 const app = express()
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     html: true, // [!code hl]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -246,7 +246,7 @@ import { Mppx, tempo } from 'mppx/express'
 const app = express()
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     html: true,
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -306,7 +306,7 @@ import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     html: true, // [!code hl]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -325,7 +325,7 @@ import crypto from 'crypto'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     html: true,
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',

--- a/src/pages/guides/proxy-existing-service.mdx
+++ b/src/pages/guides/proxy-existing-service.mdx
@@ -67,7 +67,7 @@ Use `Service.from` to describe the API you want to proxy. The proxy injects upst
 import { Proxy, Service } from 'mppx/proxy'
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 const proxy = Proxy.create({
   services: [
@@ -98,7 +98,7 @@ Each route maps a `"METHOD /pattern"` to a payment intent or `true` for free pas
 import { Proxy, Service } from 'mppx/proxy'
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 const proxy = Proxy.create({
   services: [
@@ -127,7 +127,7 @@ The proxy returns two handlers for different runtimes.
 import { Proxy, Service } from 'mppx/proxy'
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 const proxy = Proxy.create({
   description: 'Payment-gated weather data', // [!code hl]
@@ -182,7 +182,7 @@ Gate several APIs behind a single proxy by passing multiple services. Each mount
 import { Proxy, Service, openai } from 'mppx/proxy'
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 const proxy = Proxy.create({
   description: 'Multi-service paid API proxy',

--- a/src/pages/guides/split-payments.mdx
+++ b/src/pages/guides/split-payments.mdx
@@ -35,7 +35,7 @@ Add a `splits` array to any `mppx.charge` call. Each entry specifies a `recipien
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 // ---cut---
 export async function handler(request: Request) {
   const result = await mppx.charge({
@@ -63,7 +63,7 @@ Each split can carry its own on-chain memo for reconciliation:
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 declare const request: Request
 // ---cut---
@@ -89,7 +89,7 @@ Split payments work with [fee sponsorship](/payment-methods/tempo#fee-sponsorshi
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 declare const request: Request
 // ---cut---

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -67,20 +67,23 @@ $ bun add mppx viem
 
 ### Set up `Mppx` instance with streaming
 
-Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
+Set up an `Mppx` instance with the current `tempo.session` method and `sse: true`.
 
 ```ts [app/api/sessions/poem/route.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import { Mppx, tempo } from "mppx/nextjs";
+import { privateKeyToAccount } from 'viem/accounts'
 
-export const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
   methods: [
-    tempo({
-      testnet: true,
-      currency: "0x20c0000000000000000000000000000000000000",
-      recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: "0x20c0000000000000000000000000000000000000", // pathUSD on Tempo
       sse: true,
+      store: Store.memory(),
     }),
   ],
 });
@@ -91,17 +94,20 @@ export const mppx = Mppx.create({
 Create the poem route. The `withReceipt` method accepts an async generator—each yielded value is one SSE event and one charged word.
 
 ```ts [app/api/sessions/poem/route.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import { Mppx, tempo } from "mppx/nextjs";
+import { privateKeyToAccount } from 'viem/accounts'
 
-export const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
   methods: [
-    tempo({
-      testnet: true,
-      currency: "0x20c0000000000000000000000000000000000000",
-      recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: "0x20c0000000000000000000000000000000000000", // pathUSD on Tempo
       sse: true,
+      store: Store.memory(),
     }),
   ],
 });
@@ -170,23 +176,26 @@ $ bun add mppx hono viem
 
 ### Set up `Mppx` instance with streaming
 
-Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
+Set up an `Mppx` instance with the current `tempo.session` method and `sse: true`.
 
 ```ts [server.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import { Hono } from "hono";
 import { Mppx, tempo } from "mppx/hono";
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = new Hono();
 
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
-      testnet: true,
-      currency: "0x20c0000000000000000000000000000000000000",
-      recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: "0x20c0000000000000000000000000000000000000", // pathUSD on Tempo
       sse: true,
+      store: Store.memory(),
     }),
   ],
 });
@@ -197,20 +206,23 @@ const mppx = Mppx.create({
 Create the poem route with the session middleware. The handler returns an async generator—each yielded value is one SSE event and one charged word.
 
 ```ts [server.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import { Hono } from "hono";
 import { Mppx, tempo } from "mppx/hono";
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = new Hono();
 
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
-      testnet: true,
-      currency: "0x20c0000000000000000000000000000000000000",
-      recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: "0x20c0000000000000000000000000000000000000", // pathUSD on Tempo
       sse: true,
+      store: Store.memory(),
     }),
   ],
 });
@@ -281,20 +293,22 @@ $ bun add mppx viem
 
 ### Set up `Mppx` instance with streaming
 
-Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
+Set up an `Mppx` instance with the current `tempo.session` method and `sse: true`.
 
 ```ts [src/index.ts]
-import crypto from 'crypto'
-import { Mppx, tempo } from "mppx/server";
+import { Mppx, Store, tempo } from "mppx/server";
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
-      testnet: true,
-      currency: "0x20c0000000000000000000000000000000000000",
-      recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: "0x20c0000000000000000000000000000000000000", // pathUSD on Tempo
       sse: true,
+      store: Store.memory(),
     }),
   ],
 });
@@ -305,17 +319,19 @@ const mppx = Mppx.create({
 Create the poem route. The `withReceipt` method accepts an async generator—each yielded value is one SSE event and one charged word.
 
 ```ts [src/index.ts]
-import crypto from 'crypto'
-import { Mppx, tempo } from "mppx/server";
+import { Mppx, Store, tempo } from "mppx/server";
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
-      testnet: true,
-      currency: "0x20c0000000000000000000000000000000000000",
-      recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: "0x20c0000000000000000000000000000000000000", // pathUSD on Tempo
       sse: true,
+      store: Store.memory(),
     }),
   ],
 });
@@ -391,23 +407,26 @@ $ bun add mppx express viem
 
 ### Set up `Mppx` instance with streaming
 
-Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
+Set up an `Mppx` instance with the current `tempo.session` method and `sse: true`.
 
 ```ts [server.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import express from "express";
 import { Mppx, tempo } from "mppx/express";
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = express();
 
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
-      testnet: true,
-      currency: "0x20c0000000000000000000000000000000000000",
-      recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: "0x20c0000000000000000000000000000000000000", // pathUSD on Tempo
       sse: true,
+      store: Store.memory(),
     }),
   ],
 });
@@ -418,20 +437,23 @@ const mppx = Mppx.create({
 Create the poem route with the session middleware. The handler returns an async generator—each yielded value is one SSE event and one charged word.
 
 ```ts [server.ts]
-import crypto from 'crypto'
+import { Store } from 'mppx'
 import express from "express";
 import { Mppx, tempo } from "mppx/express";
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = express();
 
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
-      testnet: true,
-      currency: "0x20c0000000000000000000000000000000000000",
-      recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: "0x20c0000000000000000000000000000000000000", // pathUSD on Tempo
       sse: true,
+      store: Store.memory(),
     }),
   ],
 });
@@ -507,20 +529,22 @@ $ bun add mppx viem
 
 ### Set up `Mppx` instance with streaming
 
-Set up an `Mppx` instance with `sse: true` to enable SSE support on the session method.
+Set up an `Mppx` instance with the current `tempo.session` method and `sse: true`.
 
 ```ts [server.ts]
-import crypto from 'crypto'
-import { Mppx, tempo } from "mppx/server";
+import { Mppx, Store, tempo } from "mppx/server";
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
-      testnet: true,
-      currency: "0x20c0000000000000000000000000000000000000",
-      recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: "0x20c0000000000000000000000000000000000000", // pathUSD on Tempo
       sse: true,
+      store: Store.memory(),
     }),
   ],
 });
@@ -531,17 +555,19 @@ const mppx = Mppx.create({
 Create the route handler. `withReceipt` accepts an async generator—each yielded value becomes one SSE `event: message` and is charged one tick (`$0.001`). If the channel balance runs out mid-stream, the server emits `event: payment-need-voucher` and pauses until the client sends a new voucher.
 
 ```ts [server.ts]
-import crypto from 'crypto'
-import { Mppx, tempo } from "mppx/server";
+import { Mppx, Store, tempo } from "mppx/server";
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY || crypto.randomBytes(32).toString('base64'),
   methods: [
-    tempo({
-      testnet: true,
-      currency: "0x20c0000000000000000000000000000000000000",
-      recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: "0x20c0000000000000000000000000000000000000", // pathUSD on Tempo
       sse: true,
+      store: Store.memory(),
     }),
   ],
 });

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -234,7 +234,7 @@ const mppx = Mppx.create({
         facilitator: 'https://facilitator.x402.org',
       },
     }),
-    tempo({
+    tempo.charge({
       currency: '0x20c0000000000000000000000000000000000000',
       recipient: '0xYourAddress',
     }),
@@ -298,7 +298,7 @@ const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 
 const mppx = Mppx.create({
   methods: [
-    tempo({
+    tempo.charge({
       currency: '0x20c0000000000000000000000000000000000000',
       recipient: '0xYourAddress',
       testnet: true,

--- a/src/pages/payment-methods/solana/index.mdx
+++ b/src/pages/payment-methods/solana/index.mdx
@@ -5,7 +5,7 @@ imageDescription: "Accept SOL and SPL token payments on Solana"
 
 # Solana [Native SOL and SPL token payments]
 
-The Solana payment method enables MPP payments on Solana using native SOL, SPL tokens, and Token-2022 assets. Solana supports two intents: **charge** for one-time payments and **session** for escrowed, pay-as-you-go billing.
+The Solana payment method enables MPP payments on Solana using native SOL, SPL tokens, and Token-2022 assets. Solana supports two intents: **charge** for one-time payments and **session** for reserved, pay-as-you-go billing.
 
 The reference implementation is provided by [`@solana/mpp`](https://github.com/solana-foundation/mpp-sdk), which extends [`mppx`](https://github.com/tempoxyz/mpp) with Solana-native client and server handlers.
 

--- a/src/pages/payment-methods/stellar/index.mdx
+++ b/src/pages/payment-methods/stellar/index.mdx
@@ -33,7 +33,7 @@ Stellar enables several useful capabilities for MPP:
 - **5-second finality**: Transactions settle with deterministic confirmation, no probabilistic waiting
 - **Sub-cent fees**: Transaction costs low enough for micropayments and per-request billing
 - **Fee sponsorship**: Servers can pay transaction fees on behalf of clients, removing wallet friction entirely
-- **Stellar smart contracts**: Payment channels run as auditable on-chain contracts for secure escrow and settlement
+- **Stellar smart contracts**: Payment channels run as auditable on-chain contracts for secure reserve and settlement
 - **Flexible token support**: Any SEP-41 compliant token is supported, which includes smart contract transfers and classic assets (via SAC).
 - **Payment channels**: Off-chain cumulative commitments enable high-frequency metered billing without per-request on-chain cost
 

--- a/src/pages/payment-methods/stellar/session.mdx
+++ b/src/pages/payment-methods/stellar/session.mdx
@@ -16,7 +16,7 @@ Stellar uses the term "channel" for its streaming payment intent. This correspon
 The formal specification for the Stellar channel intent is still being drafted. An initial implementation is available in [`@stellar/mpp`](https://github.com/stellar/stellar-mpp-sdk) and this documentation reflects that implementation. Details may change as the spec is finalized.
 :::
 
-The `channel` intent enables high-frequency, pay-as-you-go payments over unidirectional payment channels on Stellar. Clients deposit tokens into an on-chain smart contract escrow and sign off-chain cumulative commitments as they consume resources. The server verifies commitments via contract simulation–no per-request on-chain transactions–and closes the channel to settle the final balance.
+The `channel` intent enables high-frequency, pay-as-you-go payments over unidirectional payment channels on Stellar. Clients deposit tokens into an on-chain contract reserve and sign off-chain cumulative commitments as they consume resources. The server verifies commitments via contract simulation–no per-request on-chain transactions–and closes the channel to settle the final balance.
 
 Payment channels reduce payment verification to a single contract simulation per request, making it possible to meter and bill at the granularity of individual LLM tokens, API calls, or bytes transferred.
 

--- a/src/pages/payment-methods/tempo/charge.mdx
+++ b/src/pages/payment-methods/tempo/charge.mdx
@@ -24,7 +24,7 @@ Use [`mppx.charge`](/sdk/typescript/server/Method.tempo.charge) to gate any endp
 import { Mppx, tempo } from "mppx/server";
 
 const mppx = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
 });
 
 export async function handler(request: Request) {
@@ -45,7 +45,7 @@ export async function handler(request: Request) {
 ```ts twoslash
 import { Mppx, tempo } from "mppx/server";
 
-const mppx = Mppx.create({ methods: [tempo()] });
+const mppx = Mppx.create({ methods: [tempo.charge()] });
 // ---cut---
 import { Expires } from "mppx";
 
@@ -67,7 +67,7 @@ export async function handler(request: Request) {
 ```ts twoslash
 import { Mppx, tempo } from "mppx/server";
 
-const mppx = Mppx.create({ methods: [tempo()] });
+const mppx = Mppx.create({ methods: [tempo.charge()] });
 
 declare const request: Request;
 // ---cut---
@@ -88,7 +88,7 @@ Set `amount: "0"` to issue an identity-only Challenge. The client returns a `pro
 ```ts twoslash
 import { Mppx, tempo } from "mppx/server";
 
-const mppx = Mppx.create({ methods: [tempo()] });
+const mppx = Mppx.create({ methods: [tempo.charge()] });
 
 declare const request: Request;
 // ---cut---
@@ -110,7 +110,7 @@ Split a charge across multiple recipients in a single transaction. The primary `
 ```ts twoslash
 import { Mppx, tempo } from "mppx/server";
 
-const mppx = Mppx.create({ methods: [tempo()] });
+const mppx = Mppx.create({ methods: [tempo.charge()] });
 
 declare const request: Request;
 // ---cut---

--- a/src/pages/payment-methods/tempo/index.mdx
+++ b/src/pages/payment-methods/tempo/index.mdx
@@ -64,14 +64,14 @@ Tempo is purpose-built for the payment patterns MPP enables:
 
 Tempo supports server-paid transaction fees for charge, session, and subscription intents. When enabled, the client signs only the payment authorization and the server covers gas costs. The client doesn't need to hold gas tokens or understand fee mechanics.
 
-Pass a `feePayer` account to `tempo()` to enable this:
+Pass a `feePayer` account to a Tempo server method to enable this. For one-time charges, configure `tempo.charge`:
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'
 import { privateKeyToAccount } from 'viem/accounts'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     feePayer: privateKeyToAccount('0x…'), // [!code hl]
   })],
 })
@@ -83,8 +83,10 @@ It is also possible to point the `feePayer` to a fee service that supports the [
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     feePayer: 'https://sponsor.example.com', // [!code hl]
   })],
 })
 ```
+
+For Sessions, pass the same `feePayer` parameter to [`tempo.session`](/sdk/typescript/server/Method.tempo.session) alongside `account` and `store`.

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -38,7 +38,7 @@ import { Mppx, tempo } from 'mppx/nextjs'
 
 // [!code hl:start]
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -58,7 +58,7 @@ const app = new Hono()
 
 // [!code hl:start]
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -78,7 +78,7 @@ import { Mppx, tempo } from 'mppx/elysia'
 
 // [!code hl:start]
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -100,7 +100,7 @@ const app = express()
 
 // [!code hl:start]
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -139,7 +139,7 @@ If you prefer full control over the payment flow, use `mppx/server` directly wit
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -189,7 +189,7 @@ Use the `Mppx.toNodeListener` helper to transform the handler into a Node.js-com
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -227,7 +227,7 @@ If you would like to force a specific mode, you can set the `mode` parameter to 
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     mode: 'push', // [!code focus]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -239,14 +239,14 @@ The `mode` parameter only affects non-zero charges. When `amount` is `0`, the cl
 
 ### Fee sponsorship
 
-To sponsor gas fees for pull-mode clients, pass a `feePayer` account to `tempo()`:
+To sponsor gas fees for pull-mode clients, pass a `feePayer` account to `tempo.charge()`:
 
 ```ts
 import { Mppx, tempo } from 'mppx/server'
 import { privateKeyToAccount } from 'viem/accounts'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     feePayer: privateKeyToAccount('0x…'), // [!code focus]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -260,7 +260,7 @@ It is possible to pass a [fee payer service](https://docs.tempo.xyz/sdk/typescri
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     feePayer: 'https://sponsor.example.com', // [!code focus]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -276,7 +276,7 @@ By default, the server waits for onchain confirmation before returning a Receipt
 
 ```ts
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     waitForConfirmation: false, // [!code focus]
@@ -300,7 +300,7 @@ import { tempo } from 'mppx/server'
 const app = new Hono()
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -131,7 +131,7 @@ import { Mppx, tempo } from 'mppx/nextjs'
 
 // [!code hl:start]
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -151,7 +151,7 @@ const app = new Hono()
 
 // [!code hl:start]
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -171,7 +171,7 @@ import { Mppx, tempo } from 'mppx/elysia'
 
 // [!code hl:start]
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -193,7 +193,7 @@ const app = express()
 
 // [!code hl:start]
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -238,7 +238,7 @@ If you prefer full control over the payment flow, use `mppx/server` directly wit
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
@@ -294,7 +294,7 @@ Use the `Mppx.toNodeListener` helper to transform the handler into a Node.js-com
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo({
+  methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],

--- a/src/pages/sdk/typescript/middlewares/elysia.mdx
+++ b/src/pages/sdk/typescript/middlewares/elysia.mdx
@@ -34,7 +34,7 @@ Import `Mppx` and `tempo` from `mppx/elysia` to create an Elysia-aware payment h
 import { Elysia } from 'elysia'
 import { Mppx, tempo } from 'mppx/elysia'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 const app = new Elysia()
   .guard(
@@ -51,7 +51,7 @@ Use `.onBeforeHandle()` to apply payment to all routes.
 import { Elysia } from 'elysia'
 import { Mppx, tempo } from 'mppx/elysia'
 
-const mppx = Mppx.create({ methods: [tempo()] }) // [!code hl]
+const mppx = Mppx.create({ methods: [tempo.charge()] }) // [!code hl]
 
 const app = new Elysia()
   .onBeforeHandle(mppx.charge({ amount: '1' })) // [!code hl]
@@ -61,13 +61,26 @@ const app = new Elysia()
 
 ### Session payments
 
-Use `mppx.session()` to gate routes behind session-based payment intents.
+Use `mppx.session()` with `tempo.session()` to gate routes behind current v2 Sessions.
 
 ```ts [server.ts]
+import { Store } from 'mppx'
 import { Elysia } from 'elysia'
 import { Mppx, tempo } from 'mppx/elysia'
+import { privateKeyToAccount } from 'viem/accounts'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
+})
 
 const app = new Elysia()
   .guard(

--- a/src/pages/sdk/typescript/middlewares/express.mdx
+++ b/src/pages/sdk/typescript/middlewares/express.mdx
@@ -35,7 +35,7 @@ import express from 'express'
 import { Mppx, tempo } from 'mppx/express'
 
 const app = express()
-const mppx = Mppx.create({ methods: [tempo()] }) // [!code hl]
+const mppx = Mppx.create({ methods: [tempo.charge()] }) // [!code hl]
 
 app.get(
   '/premium', 
@@ -46,14 +46,27 @@ app.get(
 
 ### Session payments
 
-Use `mppx.session()` to gate routes behind session-based payment intents.
+Use `mppx.session()` with `tempo.session()` to gate routes behind current v2 Sessions.
 
 ```ts [server.ts]
+import { Store } from 'mppx'
 import express from 'express'
 import { Mppx, tempo } from 'mppx/express'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = express()
-const mppx = Mppx.create({ methods: [tempo()] })
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
+})
 
 app.get(
   '/content',
@@ -72,7 +85,7 @@ import { Credential } from 'mppx'
 import { Mppx, tempo } from 'mppx/express'
 
 const app = express()
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 app.get(
   '/premium',

--- a/src/pages/sdk/typescript/middlewares/hono.mdx
+++ b/src/pages/sdk/typescript/middlewares/hono.mdx
@@ -35,7 +35,7 @@ import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
 
 const app = new Hono()
-const mppx = Mppx.create({ methods: [tempo()] }) // [!code hl]
+const mppx = Mppx.create({ methods: [tempo.charge()] }) // [!code hl]
 
 app.get(
   '/premium', 
@@ -46,14 +46,27 @@ app.get(
 
 ### Session payments
 
-Use `mppx.session()` to gate routes behind session-based payment intents.
+Use `mppx.session()` with `tempo.session()` to gate routes behind current v2 Sessions.
 
 ```ts [server.ts]
+import { Store } from 'mppx'
 import { Hono } from 'hono'
 import { Mppx, tempo } from 'mppx/hono'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const app = new Hono()
-const mppx = Mppx.create({ methods: [tempo()] })
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
+})
 
 app.get(
   '/content',
@@ -72,7 +85,7 @@ import { Credential } from 'mppx'
 import { Mppx, tempo } from 'mppx/hono'
 
 const app = new Hono()
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 app.get(
   '/premium',

--- a/src/pages/sdk/typescript/middlewares/nextjs.mdx
+++ b/src/pages/sdk/typescript/middlewares/nextjs.mdx
@@ -33,7 +33,7 @@ Import `Mppx` and `tempo` from `mppx/nextjs` to create a Next.js-aware payment h
 ```ts twoslash [app/api/premium/route.ts]
 import { Mppx, tempo } from 'mppx/nextjs'
 
-const mppx = Mppx.create({ methods: [tempo()] }) // [!code hl]
+const mppx = Mppx.create({ methods: [tempo.charge()] }) // [!code hl]
 
 export const GET = 
   mppx.charge({ amount: '1' }) // [!code hl]
@@ -42,12 +42,25 @@ export const GET =
 
 ### Session payments
 
-Use `mppx.session()` to gate routes behind session-based payment intents.
+Use `mppx.session()` with `tempo.session()` to gate routes behind current v2 Sessions.
 
 ```ts twoslash [app/api/content/route.ts]
+import { Store } from 'mppx'
 import { Mppx, tempo } from 'mppx/nextjs'
+import { privateKeyToAccount } from 'viem/accounts'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
+  ],
+})
 
 export const GET =
   mppx.session({ amount: '1', unitType: 'token' })
@@ -62,7 +75,7 @@ After the handler verifies payment, the `Authorization` header is still on the r
 import { Credential } from 'mppx'
 import { Mppx, tempo } from 'mppx/nextjs'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 export const GET =
   mppx.charge({ amount: '1' })

--- a/src/pages/sdk/typescript/proxy.mdx
+++ b/src/pages/sdk/typescript/proxy.mdx
@@ -34,7 +34,7 @@ Import `Proxy` and a service preset from `mppx/proxy`, then create an `Mppx` ser
 import { Proxy, openai } from 'mppx/proxy'
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 const proxy = Proxy.create({
   services: [
@@ -69,7 +69,7 @@ Pass multiple services to gate several upstream APIs behind a single proxy.
 import { Proxy, anthropic, openai, stripe } from 'mppx/proxy'
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 const proxy = Proxy.create({
   description: 'Multi-service paid API proxy',
@@ -186,7 +186,7 @@ Use `Service.from` (or its alias `custom`) to define a service for any upstream 
 import { Proxy, Service } from 'mppx/proxy'
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 const proxy = Proxy.create({
   services: [

--- a/src/pages/sdk/typescript/server/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.mdx
@@ -17,12 +17,21 @@ Register [`tempo.subscription`](/sdk/typescript/server/Method.tempo.subscription
 ## Usage
 
 ```ts twoslash
-import { Mppx, tempo } from 'mppx/server'
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 Mppx.create({
   methods: [
     // [!code focus:start]
-    tempo(),
+    tempo({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      store: Store.memory(),
+    }),
     // [!code focus:end]
   ],
 })
@@ -31,12 +40,23 @@ Mppx.create({
 This is equivalent to:
 
 ```ts twoslash
-import { Mppx, tempo } from 'mppx/server'
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
 
 Mppx.create({
   methods: [
-    tempo.charge(),
-    tempo.session(),
+    tempo.charge({
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    }),
+    tempo.session({
+      account,
+      chainId: 4217,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store: Store.memory(),
+    }),
   ],
 })
 ```

--- a/src/pages/sdk/typescript/server/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.create.mdx
@@ -8,7 +8,7 @@ Creates a server-side payment handler from a method.
 import { Mppx, tempo } from 'mppx/server'
 
 const payment = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
 })
 ```
 
@@ -20,7 +20,7 @@ Use a custom transport for non-HTTP environments like MCP servers.
 import { Mppx, tempo, Transport } from 'mppx/server'
 
 const payment = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
   transport: Transport.mcpSdk(),
 })
 ```
@@ -66,14 +66,14 @@ The returned object includes the method's intent functions (for example, `charge
 
 - **Type:** `readonly Method.Server[]`
 
-Array of payment methods (for example, `[tempo()]`).
+Array of payment methods (for example, `[tempo.charge()]`).
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'
 
 const payment = Mppx.create({
   // [!code focus:start]
-  methods: [tempo()],
+  methods: [tempo.charge()],
   // [!code focus:end]
 })
 ```
@@ -89,7 +89,7 @@ Server realm (for example, hostname). Auto-detected from common platform environ
 import { Mppx, tempo } from 'mppx/server'
 
 const payment = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
   realm: 'mpp.dev', // [!code focus]
 })
 ```
@@ -105,7 +105,7 @@ Secret key for HMAC-bound challenge IDs. Enables stateless verification—the se
 import { Mppx, tempo } from 'mppx/server'
 
 const payment = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
   secretKey: process.env.MPP_SECRET_KEY!, // [!code focus]
 })
 ```
@@ -121,7 +121,7 @@ Transport to use for handling payment requests.
 import { Mppx, tempo, Transport } from 'mppx/server'
 
 const payment = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
   transport: Transport.mcp(), // [!code focus]
 })
 ```

--- a/src/pages/sdk/typescript/server/Mppx.toNodeListener.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.toNodeListener.mdx
@@ -9,7 +9,7 @@ import * as http from 'node:http'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
 })
 
 http.createServer(async (req, res) => {
@@ -54,7 +54,7 @@ import * as http from 'node:http'
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
 })
 
 http.createServer(async (req, res) => {

--- a/src/pages/sdk/typescript/server/Request.toNodeListener.mdx
+++ b/src/pages/sdk/typescript/server/Request.toNodeListener.mdx
@@ -8,7 +8,7 @@ Converts a Fetch API handler into a Node.js HTTP request listener. Useful for ru
 import http from 'node:http'
 import { Mppx, Request, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 const server = http.createServer(
   Request.toNodeListener(mppx.request),

--- a/src/pages/sdk/typescript/server/Transport.http.mdx
+++ b/src/pages/sdk/typescript/server/Transport.http.mdx
@@ -8,7 +8,7 @@ HTTP transport for server-side payment handling.
 import { Mppx, tempo, Transport } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
   transport: Transport.http(),
 })
 ```

--- a/src/pages/sdk/typescript/server/Transport.mcp.mdx
+++ b/src/pages/sdk/typescript/server/Transport.mcp.mdx
@@ -8,7 +8,7 @@ MCP transport for server-side payment handling with raw JSON-RPC.
 import { Mppx, tempo, Transport } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
   transport: Transport.mcp(),
 })
 ```

--- a/src/pages/sdk/typescript/server/Transport.mcpSdk.mdx
+++ b/src/pages/sdk/typescript/server/Transport.mcpSdk.mdx
@@ -9,7 +9,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
 import { Mppx, tempo, Transport } from 'mppx/server'
 
 const mppx = Mppx.create({
-  methods: [tempo()],
+  methods: [tempo.charge()],
   transport: Transport.mcpSdk(),
 })
 


### PR DESCRIPTION
## Summary

- Update Sessions guides and middleware examples to use current v2 `tempo.session` setup
- Make charge-only Tempo examples use `tempo.charge()` instead of the combined helper
- Keep legacy Sessions references scoped to migration and compatibility docs
- Expand the Sessions chain ID guard across audited docs
