### PR TITLE
Add Accounts SDK tabs to Tempo client examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@resvg/resvg-wasm": "^2.6.2",
     "@stripe/stripe-js": "^9.7.0",
     "@vercel/blob": "^2.4.0",
+    "accounts": "^0.14.9",
     "hono": "^4.12.23",
     "mermaid": "^11.15.0",
     "mppx": "https://pkg.pr.new/mppx@530",
@@ -33,7 +34,7 @@
     "react-dom": "^19",
     "stripe": "^22.2.0",
     "tailwindcss": "^4.3.0",
-    "viem": "^2.52.0",
+    "viem": "^2.52.2",
     "vocs": "^2.0.10",
     "wagmi": "^3.6.16",
     "waku": "1.0.0-beta.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@vercel/blob':
         specifier: ^2.4.0
         version: 2.4.0
+      accounts:
+        specifier: ^0.14.9
+        version: 0.14.9(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.16)(@wagmi/core@3.5.0)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.16)
       hono:
         specifier: ^4.12.23
         version: 4.12.23
@@ -28,7 +31,7 @@ importers:
         version: 11.15.0
       mppx:
         specifier: https://pkg.pr.new/mppx@530
-        version: https://pkg.pr.new/mppx@530(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.23)(typescript@6.0.3)(viem@2.52.0(typescript@6.0.3)(zod@4.4.3))
+        version: https://pkg.pr.new/mppx@530(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.23)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))
       react:
         specifier: ^19
         version: 19.2.7
@@ -42,14 +45,14 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       viem:
-        specifier: ^2.52.0
-        version: 2.52.0(typescript@6.0.3)(zod@4.4.3)
+        specifier: ^2.52.2
+        version: 2.52.2(typescript@6.0.3)(zod@4.4.3)
       vocs:
         specifier: ^2.0.10
         version: 2.0.10(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.1.0)(mermaid@11.15.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.7)(rollup@4.60.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(waku@1.0.0-beta.1(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       wagmi:
         specifier: ^3.6.16
-        version: 3.6.16(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.7))(@types/react@19.2.16)(react@19.2.7)(typescript@6.0.3)(viem@2.52.0(typescript@6.0.3)(zod@4.4.3))
+        version: 3.6.16(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.7))(@types/react@19.2.16)(accounts@0.14.9)(react@19.2.7)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))
       waku:
         specifier: 1.0.0-beta.1
         version: 1.0.0-beta.1(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.27.7)))(react@19.2.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -649,6 +652,10 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/curves@1.9.1':
     resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
@@ -656,6 +663,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -1685,6 +1696,35 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  accounts@0.14.9:
+    resolution: {integrity: sha512-wrDFGs2eiko4qbfyc9/OY7IbQ5wyRncbHTp56fGbOSC1BWsxhyayXvI8BWBRIkc5HZwwfyJ/EWPT/yUSlp15Ww==}
+    peerDependencies:
+      '@privy-io/react-auth': '>=3.25.0'
+      '@react-native-async-storage/async-storage': ^3.0.2
+      '@wagmi/core': '>=3.4.3'
+      expo-secure-store: ^55.0.12
+      expo-web-browser: ^55.0.13
+      react: '>=18'
+      viem: '>=2.50.4'
+      wagmi: '>=0.0.0'
+    peerDependenciesMeta:
+      '@privy-io/react-auth':
+        optional: true
+      '@react-native-async-storage/async-storage':
+        optional: true
+      '@wagmi/core':
+        optional: true
+      expo-secure-store:
+        optional: true
+      expo-web-browser:
+        optional: true
+      react:
+        optional: true
+      viem:
+        optional: true
+      wagmi:
+        optional: true
+
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -2452,6 +2492,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  idb-keyval@6.2.5:
+    resolution: {integrity: sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -2544,6 +2587,9 @@ packages:
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2919,6 +2965,25 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
+  mppx@0.6.31:
+    resolution: {integrity: sha512-euHHDLjNa9DQdPSzpayRBhUb3YVGSNZhVAzoOPmjzqxcEb77ry59uaeSBsWr3IjSxqmpR45cB6aR0uiNSgO6kA==}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.25.0'
+      elysia: '>=1'
+      express: '>=5'
+      hono: '>=4.12.18'
+      viem: '>=2.51.0'
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+      elysia:
+        optional: true
+      express:
+        optional: true
+      hono:
+        optional: true
+
   mppx@https://pkg.pr.new/mppx@530:
     resolution: {tarball: https://pkg.pr.new/mppx@530}
     version: 0.6.31
@@ -3020,6 +3085,14 @@ packages:
 
   ox@0.14.27:
     resolution: {integrity: sha512-+xhLHo/f+f4BH121/1Pomm/1vgBBda1wYiFpTvjSo8o5OcEj76Pf1hGPJiepoYMTQoTm2SKdSBvWkFWk5l07PA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -3235,6 +3308,9 @@ packages:
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
+
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
@@ -3675,8 +3751,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  viem@2.52.0:
-    resolution: {integrity: sha512-py2QPYe9e1f4DmPJCsXF7zHmyZ0PkJrBxdQZ5dvNXvzy3UzWkUn7dNfC0TMeNm6Qv1tKw3b6qXXExpx6L0oMbw==}
+  viem@2.52.2:
+    resolution: {integrity: sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -3832,9 +3908,15 @@ packages:
       react-dom: ~19.2.4
       react-server-dom-webpack: ~19.2.4
 
+  wata@0.0.1:
+    resolution: {integrity: sha512-cJ8lN48Tgabj5mUnpCXDrEOhCHxXi5NlR9vTleQedn5EpSXwHmuQ9SXxLuQMdq4qjsToKd/gw0p5uftyp+LInA==}
+
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
+
+  webauthx@0.1.2:
+    resolution: {integrity: sha512-J0H9/BOW/aRtWa/rKsGjf1+YQ5xkfgycTT455fsHyqG4+hYJ5dPDrNcIXrjGnjBKGru/qxY75m68iHg27rHoUg==}
 
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
@@ -3912,6 +3994,24 @@ packages:
 
   zustand@5.0.0:
     resolution: {integrity: sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -4522,11 +4622,15 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/ciphers@2.2.0': {}
+
   '@noble/curves@1.9.1':
     dependencies:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@open-draft/deferred-promise@2.2.0': {}
 
@@ -5333,21 +5437,23 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@wagmi/connectors@8.0.15(@wagmi/core@3.5.0(@tanstack/query-core@5.90.20)(@types/react@19.2.16)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.0(typescript@6.0.3)(zod@4.4.3)))(typescript@6.0.3)(viem@2.52.0(typescript@6.0.3)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.15(@wagmi/core@3.5.0)(accounts@0.14.9)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))':
     dependencies:
-      '@wagmi/core': 3.5.0(@tanstack/query-core@5.90.20)(@types/react@19.2.16)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.0(typescript@6.0.3)(zod@4.4.3))
-      viem: 2.52.0(typescript@6.0.3)(zod@4.4.3)
+      '@wagmi/core': 3.5.0(@tanstack/query-core@5.90.20)(@types/react@19.2.16)(accounts@0.14.9)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))
+      viem: 2.52.2(typescript@6.0.3)(zod@4.4.3)
     optionalDependencies:
+      accounts: 0.14.9(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.16)(@wagmi/core@3.5.0)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.16)
       typescript: 6.0.3
 
-  '@wagmi/core@3.5.0(@tanstack/query-core@5.90.20)(@types/react@19.2.16)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.0(typescript@6.0.3)(zod@4.4.3))':
+  '@wagmi/core@3.5.0(@tanstack/query-core@5.90.20)(@types/react@19.2.16)(accounts@0.14.9)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@6.0.3)
-      viem: 2.52.0(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.52.2(typescript@6.0.3)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
     optionalDependencies:
       '@tanstack/query-core': 5.90.20
+      accounts: 0.14.9(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.16)(@wagmi/core@3.5.0)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.16)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/react'
@@ -5449,6 +5555,32 @@ snapshots:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
+
+  accounts@0.14.9(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.16)(@wagmi/core@3.5.0)(express@5.2.1)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))(wagmi@3.6.16):
+    dependencies:
+      hono: 4.12.23
+      idb-keyval: 6.2.5
+      jose: 6.2.3
+      mipd: 0.0.7(typescript@6.0.3)
+      mppx: 0.6.31(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.23)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))
+      ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
+      wata: 0.0.1(typescript@6.0.3)
+      webauthx: 0.1.2(typescript@6.0.3)(zod@4.4.3)
+      zod: 4.4.3
+      zustand: 5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
+    optionalDependencies:
+      '@wagmi/core': 3.5.0(@tanstack/query-core@5.90.20)(@types/react@19.2.16)(accounts@0.14.9)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))
+      react: 19.2.7
+      viem: 2.52.2(typescript@6.0.3)(zod@4.4.3)
+      wagmi: 3.6.16(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.7))(@types/react@19.2.16)(accounts@0.14.9)(react@19.2.7)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@types/react'
+      - elysia
+      - express
+      - immer
+      - typescript
+      - use-sync-external-store
 
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
@@ -6293,6 +6425,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  idb-keyval@6.2.5: {}
+
   ieee754@1.2.1: {}
 
   image-size@2.0.2: {}
@@ -6364,6 +6498,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.1.3: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -7009,11 +7145,24 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@https://pkg.pr.new/mppx@530(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.23)(typescript@6.0.3)(viem@2.52.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.6.31(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.23)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       incur: 0.4.8
       ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
-      viem: 2.52.0(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.52.2(typescript@6.0.3)(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      express: 5.2.1
+      hono: 4.12.23
+    transitivePeerDependencies:
+      - typescript
+
+  mppx@https://pkg.pr.new/mppx@530(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.23)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3)):
+    dependencies:
+      incur: 0.4.8
+      ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.52.2(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -7077,6 +7226,21 @@ snapshots:
   outvariant@1.4.0: {}
 
   ox@0.14.27(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@6.0.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.29(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -7370,6 +7534,8 @@ snapshots:
   resolve-pkg-maps@1.0.0: {}
 
   retry@0.13.1: {}
+
+  rettime@0.11.11: {}
 
   robust-predicates@3.0.3: {}
 
@@ -7844,7 +8010,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.52.0(typescript@6.0.3)(zod@4.4.3):
+  viem@2.52.2(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -7852,7 +8018,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
       isows: 1.0.7(ws@8.20.1)
-      ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
+      ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
       ws: 8.20.1
     optionalDependencies:
       typescript: 6.0.3
@@ -8027,14 +8193,14 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
-  wagmi@3.6.16(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.7))(@types/react@19.2.16)(react@19.2.7)(typescript@6.0.3)(viem@2.52.0(typescript@6.0.3)(zod@4.4.3)):
+  wagmi@3.6.16(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.7))(@types/react@19.2.16)(accounts@0.14.9)(react@19.2.7)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.90.21(react@19.2.7)
-      '@wagmi/connectors': 8.0.15(@wagmi/core@3.5.0(@tanstack/query-core@5.90.20)(@types/react@19.2.16)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.0(typescript@6.0.3)(zod@4.4.3)))(typescript@6.0.3)(viem@2.52.0(typescript@6.0.3)(zod@4.4.3))
-      '@wagmi/core': 3.5.0(@tanstack/query-core@5.90.20)(@types/react@19.2.16)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.0(typescript@6.0.3)(zod@4.4.3))
+      '@wagmi/connectors': 8.0.15(@wagmi/core@3.5.0)(accounts@0.14.9)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))
+      '@wagmi/core': 3.5.0(@tanstack/query-core@5.90.20)(@types/react@19.2.16)(accounts@0.14.9)(react@19.2.7)(typescript@6.0.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))
       react: 19.2.7
       use-sync-external-store: 1.4.0(react@19.2.7)
-      viem: 2.52.0(typescript@6.0.3)(zod@4.4.3)
+      viem: 2.52.2(typescript@6.0.3)(zod@4.4.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -8080,10 +8246,29 @@ snapshots:
       - tsx
       - yaml
 
+  wata@0.0.1(typescript@6.0.3):
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      hono: 4.12.23
+      ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
+      rettime: 0.11.11
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - typescript
+
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+
+  webauthx@0.1.2(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
+    transitivePeerDependencies:
+      - typescript
+      - zod
 
   webpack-sources@3.5.0: {}
 
@@ -8158,6 +8343,12 @@ snapshots:
   zod@4.4.3: {}
 
   zustand@5.0.0(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7)):
+    optionalDependencies:
+      '@types/react': 19.2.16
+      react: 19.2.7
+      use-sync-external-store: 1.4.0(react@19.2.7)
+
+  zustand@5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7)):
     optionalDependencies:
       '@types/react': 19.2.16
       react: 19.2.7

--- a/src/pages/advanced/refunds.mdx
+++ b/src/pages/advanced/refunds.mdx
@@ -3,6 +3,8 @@ description: "Return funds to clients after a charge, or let sessions refund unu
 imageDescription: "Return funds to clients in charge and session flows"
 ---
 
+import { Tab, Tabs } from 'vocs'
+
 import { MermaidDiagram } from '../../components/MermaidDiagram'
 
 # Refunds [Return funds to clients]
@@ -78,6 +80,32 @@ This gives sessions a **built-in refund mechanism**—unclaimed funds are refund
 
 To refund a session, close the channel with the last accepted voucher. Any unclaimed deposit returns to the client automatically.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts [client.ts]
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '10',
+})
+
+await session.fetch('https://api.example.com/resource')
+
+const receipt = await session.close()
+console.log(receipt?.txHash)
+// @log: 0x...
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts [client.ts]
 import { tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -93,6 +121,9 @@ const receipt = await session.close()
 console.log(receipt?.txHash)
 // @log: 0x...
 ```
+
+</Tab>
+</Tabs>
 
 ## Best practices
 

--- a/src/pages/guides/multiple-payment-methods.mdx
+++ b/src/pages/guides/multiple-payment-methods.mdx
@@ -3,7 +3,7 @@ description: "Accept Tempo stablecoins, Stripe cards, and Lightning Bitcoin on a
 imageDescription: "Accept stablecoins, cards, and Lightning on one endpoint"
 ---
 
-import { Cards } from 'vocs'
+import { Cards, Tab, Tabs } from 'vocs'
 import { OneTimePaymentsCard, PayAsYouGoCard, PaymentMethodsCard } from '../../components/cards'
 import { PromptBlock } from '../../components/PromptBlock'
 
@@ -273,6 +273,47 @@ Each payment method has its own parameters. Refer to the individual method docs 
 
 Clients can declare which payment methods they prefer by passing `paymentPreferences` to `Mppx.create`. This sends an `Accept-Payment` header on every request, and the server uses it to filter Challenges down to the methods the client supports.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Mppx, stripe, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+    stripe.charge({
+      createToken: async (opts) => {
+        const res = await fetch('/api/create-spt', {
+          body: JSON.stringify(opts),
+          headers: { 'Content-Type': 'application/json' },
+          method: 'POST',
+        })
+        const { spt } = await res.json() as { spt: string }
+        return spt
+      },
+    }),
+  ],
+  // [!code hl:start]
+  paymentPreferences: ({ tempo, stripe }) => ({
+    [tempo.charge]: 1,
+    [stripe.charge]: 0.5,
+    [tempo.session]: 0.2,
+  }),
+  // [!code hl:end]
+})
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, stripe, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -303,6 +344,9 @@ Mppx.create({
   // [!code hl:end]
 })
 ```
+
+</Tab>
+</Tabs>
 
 See the [`paymentPreferences` parameter reference](/sdk/typescript/client/Mppx.create#paymentpreferences-optional) for the full configuration options.
 

--- a/src/pages/guides/pay-as-you-go.mdx
+++ b/src/pages/guides/pay-as-you-go.mdx
@@ -683,6 +683,33 @@ $ npx mppx http://localhost:3000
 
 When using sessions from a client, set `maxDeposit` to enable automatic channel management. This is the maximum amount of tokens the client reserves in the payment channel. Any unspent deposit is refunded when the channel closes.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts [client.ts]
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+    maxDeposit: '1', // Reserve up to 1 pathUSD per channel
+  })],
+})
+
+// Each fetch automatically manages the session lifecycle:
+// 1st request: opens channel on-chain, sends initial voucher
+// 2nd+ requests: sends off-chain vouchers (no on-chain tx)
+const res = await fetch('http://localhost:3000/api/sessions/photo')
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts [client.ts]
 import { Mppx, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -700,6 +727,9 @@ const mppx = Mppx.create({
 const res = await fetch('http://localhost:3000/api/sessions/photo')
 ```
 
+</Tab>
+</Tabs>
+
 - **`maxDeposit: '1'`**: Reserves up to 1 pathUSD in the payment channel. At $0.01/photo, this covers up to 100 requests before the channel runs out.
 - The client handles the full session lifecycle automatically: channel open, voucher signing, and retry after `402` responses.
 - If the server sets `suggestedDeposit`, the client uses `min(suggestedDeposit, maxDeposit)`.
@@ -707,6 +737,31 @@ const res = await fetch('http://localhost:3000/api/sessions/photo')
 ### Closing the channel
 
 After you're done making requests, close the channel to settle on-chain and reclaim unspent deposit:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash [client.ts]
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '1',
+})
+
+const res = await session.fetch('http://localhost:3000/api/sessions/photo')
+
+// Settle on-chain and reclaim unspent deposit
+const receipt = await session.close()
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash [client.ts]
 import { tempo } from 'mppx/client'
@@ -722,6 +777,9 @@ const res = await session.fetch('http://localhost:3000/api/sessions/photo')
 // Settle on-chain and reclaim unspent deposit
 const receipt = await session.close()
 ```
+
+</Tab>
+</Tabs>
 
 :::info
 Channels remain open for reuse. Closing is not required between individual requests—only when you're done with the session entirely.

--- a/src/pages/guides/split-payments.mdx
+++ b/src/pages/guides/split-payments.mdx
@@ -3,7 +3,7 @@ description: "Split a single charge across multiple recipients in one atomic tra
 imageDescription: "Split payments across multiple recipients"
 ---
 
-import { Cards } from 'vocs'
+import { Cards, Tab, Tabs } from 'vocs'
 import { OneTimePaymentsCard, PayAsYouGoCard, ServerQuickstartCard } from '../../components/cards'
 
 # Accept split payments [Distribute a charge across multiple recipients]
@@ -113,6 +113,33 @@ The client SDK handles split payments automatically — no client-side configura
 
 Use `expectedRecipients` to restrict which split recipients the client signs for. This prevents a compromised server from redirecting funds to unexpected addresses.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Mppx, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+// ---cut---
+Mppx.create({
+  methods: [
+    tempo.charge({
+      account: provider.getAccount({ signable: true }),
+      expectedRecipients: [ // [!code hl]
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', // platform // [!code hl]
+        '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC', // referrer // [!code hl]
+      ], // [!code hl]
+      getClient: provider.getClient,
+    }),
+  ],
+})
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -131,6 +158,9 @@ Mppx.create({
   ],
 })
 ```
+
+</Tab>
+</Tabs>
 
 If the server sends a Challenge with a split recipient not in the allowlist, the client throws an error instead of signing.
 

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -626,6 +626,33 @@ $ npx mppx http://localhost:3000
 
 Use `tempo.session.manager()` from `mppx/client` to create a session manager. The `.sse()` method connects to the SSE endpoint and handles voucher renewal automatically—if the server requests a new voucher mid-stream, the client signs and sends one without interrupting the stream.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts [client.ts]
+import { tempo } from "mppx/client";
+import { Provider } from "accounts";
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: "wallet_connect" })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: "1", // Reserve up to 1 pathUSD per channel
+});
+
+// .sse() returns an async iterable of SSE data payloads
+const stream = await session.sse("http://localhost:3000/api/sessions/poem");
+
+for await (const word of stream) {
+  process.stdout.write(word + " ");
+}
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts [client.ts]
 import { tempo } from "mppx/client";
 import { privateKeyToAccount } from "viem/accounts";
@@ -643,6 +670,9 @@ for await (const word of stream) {
 }
 ```
 
+</Tab>
+</Tabs>
+
 - **`tempo.session.manager()`** — Creates a session manager that handles the full Sessions lifecycle.
 - **`.sse()`** — Connects to an SSE endpoint. Automatically sends new vouchers when the server emits `payment-need-voucher` events.
 - **`maxDeposit: '1'`** — Reserves up to 1 pathUSD. At $0.001/word, this covers ~1,000 words before the channel needs a top-up.
@@ -650,6 +680,35 @@ for await (const word of stream) {
 ### Closing the channel
 
 After streaming completes, close the channel to settle and reclaim unspent deposit:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash [client.ts]
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '1',
+})
+
+const stream = await session.sse('http://localhost:3000/api/sessions/poem')
+
+for await (const word of stream) {
+  process.stdout.write(word + ' ')
+}
+
+// Settle on-chain and reclaim unspent deposit
+const receipt = await session.close()
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash [client.ts]
 import { tempo } from 'mppx/client'
@@ -669,6 +728,9 @@ for await (const word of stream) {
 // Settle on-chain and reclaim unspent deposit
 const receipt = await session.close()
 ```
+
+</Tab>
+</Tabs>
 
 ## WebSocket alternative
 

--- a/src/pages/guides/subscription-payments.mdx
+++ b/src/pages/guides/subscription-payments.mdx
@@ -3,6 +3,8 @@ description: "Build a subscription-gated API with MPP. Let clients authorize rec
 imageDescription: "Build recurring paid API access"
 ---
 
+import { Tab, Tabs } from 'vocs'
+
 import { MermaidDiagram } from '../../components/MermaidDiagram'
 
 # Create and manage subscriptions [Recurring access for paid APIs]
@@ -135,6 +137,34 @@ The first unpaid request returns `402`. After the client activates the subscript
 
 Register `tempo.subscription()` on the client. The SDK handles the `402` response, signs the key authorization, and retries the request.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash [client.ts]
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [tempo.subscription({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+})
+
+const response = await fetch('https://api.example.com/api/pro', {
+  headers: { 'X-User-Id': 'user_123' },
+})
+
+console.log(response.status)
+// @log: 200
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash [client.ts]
 import { Mppx, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -152,6 +182,9 @@ const response = await fetch('https://api.example.com/api/pro', {
 console.log(response.status)
 // @log: 200
 ```
+
+</Tab>
+</Tabs>
 
 ## Advanced options
 

--- a/src/pages/payment-methods/tempo/charge.mdx
+++ b/src/pages/payment-methods/tempo/charge.mdx
@@ -3,7 +3,7 @@ description: "Accept one-time stablecoin payments on Tempo with signed TIP-20 to
 imageDescription: "One-time stablecoin payments on Tempo"
 ---
 
-import { Cards } from "vocs";
+import { Cards, Tab, Tabs } from "vocs";
 import { SpecCard } from "../../../components/SpecCard";
 
 # Tempo charge [One-time TIP-20 token transfers]
@@ -194,6 +194,29 @@ See [`tempo.charge` server reference](/sdk/typescript/server/Method.tempo.charge
 
 Use [`tempo.charge`](/sdk/typescript/client/Method.tempo.charge) with `Mppx.create` to automatically handle `402` responses. For non-zero amounts, the client signs a TIP-20 transfer and retries with the Credential. For zero-amount Challenges, it signs a proof message and retries with a `proof` payload instead.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from "accounts";
+import { Mppx, tempo } from "mppx/client";
+
+const provider = Provider.create({ mpp: false }); // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: "wallet_connect" });
+
+Mppx.create({
+  methods: [tempo.charge({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+});
+
+const response = await fetch("https://api.example.com/resource");
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, tempo } from "mppx/client";
 import { privateKeyToAccount } from "viem/accounts";
@@ -207,9 +230,36 @@ Mppx.create({
 const response = await fetch("https://api.example.com/resource");
 ```
 
+</Tab>
+</Tabs>
+
 ### Without polyfill
 
 If you don't want to patch `globalThis.fetch`, use `mppx.fetch` directly:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from "accounts";
+import { Mppx, tempo } from "mppx/client";
+
+const provider = Provider.create({ mpp: false }); // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: "wallet_connect" });
+
+const mppx = Mppx.create({
+  methods: [tempo.charge({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+  polyfill: false,
+});
+
+const response = await mppx.fetch("https://api.example.com/resource");
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from "mppx/client";
@@ -225,6 +275,9 @@ const mppx = Mppx.create({
 const response = await mppx.fetch("https://api.example.com/resource");
 ```
 
+</Tab>
+</Tabs>
+
 :::info
 See [`tempo.charge` client reference](/sdk/typescript/client/Method.tempo.charge) for the full parameter list.
 :::
@@ -232,6 +285,30 @@ See [`tempo.charge` client reference](/sdk/typescript/client/Method.tempo.charge
 ### Chain pinning
 
 Set `expectedChainId` when the client should only pay on a specific Tempo network. The client rejects Challenges for other chains and uses this chain when the Challenge doesn't include `chainId`.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from "mppx/client";
+import { Provider } from "accounts";
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: "wallet_connect" })
+
+Mppx.create({
+  methods: [
+    tempo.charge({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+      expectedChainId: 4217, // Tempo mainnet // [!code hl]
+    }),
+  ],
+});
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from "mppx/client";
@@ -249,9 +326,36 @@ Mppx.create({
 });
 ```
 
+</Tab>
+</Tabs>
+
 ### Auto-swap
 
 When the client doesn't hold the requested currency, `autoSwap` automatically swaps from a fallback stablecoin (pathUSD, USDC.e) via the Tempo DEX before transferring.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from "accounts";
+import { Mppx, tempo } from "mppx/client";
+
+const provider = Provider.create({ mpp: false }); // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: "wallet_connect" });
+
+Mppx.create({
+  methods: [
+    tempo.charge({
+      account: provider.getAccount({ signable: true }),
+      autoSwap: true, // [!code hl]
+      getClient: provider.getClient,
+    }),
+  ],
+});
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from "mppx/client";
@@ -269,7 +373,38 @@ Mppx.create({
 });
 ```
 
+</Tab>
+</Tabs>
+
 Pass an object for custom fallback tokens or slippage:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from "accounts";
+import { Mppx, tempo } from "mppx/client";
+
+const provider = Provider.create({ mpp: false }); // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: "wallet_connect" });
+
+Mppx.create({
+  methods: [
+    tempo.charge({
+      account: provider.getAccount({ signable: true }),
+      autoSwap: {
+        // [!code hl]
+        slippage: 2, // max slippage % (default: 1) // [!code hl]
+        tokenIn: ["0x0000000000000000000000000000000000000001"], // [!code hl]
+      }, // [!code hl]
+      getClient: provider.getClient,
+    }),
+  ],
+});
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from "mppx/client";
@@ -290,6 +425,9 @@ Mppx.create({
   ],
 });
 ```
+
+</Tab>
+</Tabs>
 
 See [auto-swap](/payment-methods/tempo#auto-swap) for more details.
 

--- a/src/pages/payment-methods/tempo/session.mdx
+++ b/src/pages/payment-methods/tempo/session.mdx
@@ -292,6 +292,32 @@ export async function handler(request: Request) {
 
 Use [`tempo`](/sdk/typescript/client/Method.tempo) with `Mppx.create` when the same fetch wrapper should handle one-time charges and Sessions. The `tempo()` helper expands to both `tempo.charge()` and `tempo.session()`, so you don't need to declare Sessions separately.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const { fetch: mppxFetch } = Mppx.create({
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+    maxDeposit: '1',
+  })],
+  polyfill: false,
+})
+
+const response = await mppxFetch('https://api.example.com/v1/chat/completions')
+// Automatically opens the channel reserve and signs vouchers per chunk
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -307,9 +333,41 @@ const response = await mppxFetch('https://api.example.com/v1/chat/completions')
 // Automatically opens the channel reserve and signs vouchers per chunk
 ```
 
+</Tab>
+</Tabs>
+
 ### With explicit Sessions
 
 Register `tempo.session()` when this client should only handle Sessions. Use `tempo.session.manager()` for the standalone lifecycle manager shown in [closing the channel](#closing-the-channel).
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [
+    // [!code hl:start]
+    tempo.session({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+      maxDeposit: '1',
+    }),
+    // [!code hl:end]
+  ],
+  polyfill: false,
+})
+
+const response = await mppx.fetch('https://api.example.com/v1/chat/completions')
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -332,11 +390,42 @@ const mppx = Mppx.create({
 const response = await mppx.fetch('https://api.example.com/v1/chat/completions')
 ```
 
+</Tab>
+</Tabs>
+
 ### With multiple methods
 
 Register multiple methods so the client can handle servers that offer multiple payment methods.
 
 For example, to accept both charge and payment sessions:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    tempo.charge({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+    tempo.session({ // [!code hl]
+      account: provider.getAccount({ signable: true }), // [!code hl]
+      getClient: provider.getClient, // [!code hl]
+      maxDeposit: '1', // [!code hl]
+    }), // [!code hl]
+  ],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -352,9 +441,35 @@ Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### Closing the channel
 
 Use `tempo.session.manager()` when you want direct lifecycle control. Channels remain open for reuse across requests. Call `session.close()` to settle on-chain and reclaim unspent deposit.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '1',
+})
+
+const response = await session.fetch('https://api.example.com/v1/chat/completions')
+const receipt = await session.close()
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { tempo } from 'mppx/client'
@@ -370,6 +485,9 @@ const session = tempo.session.manager({
 const response = await session.fetch('https://api.example.com/v1/chat/completions')
 const receipt = await session.close()
 ```
+
+</Tab>
+</Tabs>
 
 :::warning
 Channels do not close automatically. If you don't call `close()`, the deposit stays reserved until the channel expires, the server closes it, or it is manually closed.
@@ -432,6 +550,48 @@ const mppx = Mppx.create({
 
 ### Client
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { createClient, http } from 'viem'
+import { Provider } from 'accounts'
+import { tempo as tempoMainnet } from 'viem/chains'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const { fetch: mppxFetch } = Mppx.create({
+  methods: [
+    tempo.session({
+      account: provider.getAccount({ signable: true }),
+      getClient: () =>
+        createClient({
+          chain: tempoMainnet,
+          transport: http('https://rpc.tempo.xyz'),
+        }),
+      maxDeposit: '1',
+    }),
+    tempo.sessionLegacy.method({
+      account: provider.getAccount({ signable: true }),
+      getClient: () =>
+        createClient({
+          chain: tempoMainnet,
+          transport: http('https://rpc.tempo.xyz'),
+        }),
+      maxDeposit: '1',
+    }),
+  ],
+  polyfill: false,
+})
+
+const response = await mppxFetch('https://api.example.com/resource')
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
 import { createClient, http } from 'viem'
@@ -466,6 +626,9 @@ const { fetch: mppxFetch } = Mppx.create({
 
 const response = await mppxFetch('https://api.example.com/resource')
 ```
+
+</Tab>
+</Tabs>
 
 ## Reserve precompile
 

--- a/src/pages/payment-methods/tempo/subscription.mdx
+++ b/src/pages/payment-methods/tempo/subscription.mdx
@@ -3,7 +3,7 @@ description: "Accept recurring stablecoin payments on Tempo with subscriptions b
 imageDescription: "Recurring stablecoin billing for APIs"
 ---
 
-import { Badge, Card, Cards } from 'vocs'
+import { Badge, Card, Cards, Tab, Tabs } from 'vocs'
 import { MermaidDiagram } from '../../../components/MermaidDiagram'
 
 # Tempo subscription [Recurring billing]
@@ -206,6 +206,31 @@ Use a durable atomic store such as Redis, Upstash, or Cloudflare KV for producti
 
 Register `tempo.subscription()` on the client. The SDK signs the access-key authorization and retries the request after the server returns a subscription Challenge.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [tempo.subscription({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+})
+
+const response = await fetch('https://api.example.com/pro')
+console.log(response.status)
+// @log: 200
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -220,6 +245,9 @@ const response = await fetch('https://api.example.com/pro')
 console.log(response.status)
 // @log: 200
 ```
+
+</Tab>
+</Tabs>
 
 ## Advanced options
 

--- a/src/pages/quickstart/client.mdx
+++ b/src/pages/quickstart/client.mdx
@@ -3,7 +3,7 @@ description: "Handle payment-gated resources in your app. Use the mppx client SD
 imageDescription: "Add payments to your app in minutes"
 ---
 
-import { Cards } from 'vocs'
+import { Cards, Tab, Tabs } from 'vocs'
 import { ClientPrompt } from '../../components/QuickstartPrompt'
 import { ServerQuickstartCard, MppxCreateReferenceCard } from '../../components/cards'
 
@@ -11,7 +11,7 @@ import { ServerQuickstartCard, MppxCreateReferenceCard } from '../../components/
 
 ## Overview
 
-Polyfill the global `fetch` to handle `402` responses. Your existing code works unchanged—payments happen in the background. Pick the path that suits you:
+Create a Tempo account and polyfill the global `fetch` to handle `402` responses. Your existing code works unchanged—payments happen in the background. Pick the path that suits you:
 
 - [**Prompt mode**](#prompt-mode): paste a prompt into your coding agent for fast setup
 - [**Manual mode**](#manual-mode): step-by-step setup with `mppx/client`
@@ -30,17 +30,30 @@ Paste this into your coding agent to set up your client with `mppx` in one promp
 
 :::code-group
 ```bash [npm]
-$ npm install mppx viem
+$ npm install accounts mppx viem
 ```
 ```bash [pnpm]
-$ pnpm add mppx viem
+$ pnpm add accounts mppx viem
 ```
 ```bash [bun]
-$ bun add mppx viem
+$ bun add accounts mppx viem
 ```
 :::
 
-### Define an account
+### Connect an account
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+
+const provider = Provider.create()
+await provider.request({ method: 'wallet_connect' })
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'
@@ -48,13 +61,25 @@ import { privateKeyToAccount } from 'viem/accounts'
 const account = privateKeyToAccount('0xabc…123')
 ```
 
-:::tip
-With Tempo, you can also use [Passkey or WebCrypto accounts](https://viem.sh/tempo/accounts).
-:::
+</Tab>
+</Tabs>
 
-### Create payment handler
+### Enable payments
 
-Call `Mppx.create` at startup. This polyfills the global `fetch` to automatically handle `402` payment challenges.
+`Provider.create()` enables MPP by default. It installs a payment-aware `fetch` that handles Tempo `402` payment Challenges with the connected account.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+
+const provider = Provider.create() // [!code hl]
+await provider.request({ method: 'wallet_connect' }) // [!code hl]
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'
@@ -67,17 +92,52 @@ Mppx.create({ // [!code hl]
 }) // [!code hl]
 ```
 
-:::tip
-If you want to avoid polyfilling, use the bound `fetch` instead.
+</Tab>
+</Tabs>
 
-```ts
+:::tip
+If you want to avoid polyfilling, disable the Accounts SDK MPP integration and use a bound `mppx` fetch instead.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Mppx, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
 const mppx = Mppx.create({
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
   polyfill: false, // [!code hl]
-  methods: [tempo({ account })]
 })
 
 const response = await mppx.fetch('https://mpp.dev/api/ping/paid') // [!code hl]
 ```
+
+</Tab>
+<Tab title="viem">
+
+```ts twoslash
+import { privateKeyToAccount } from 'viem/accounts'
+import { Mppx, tempo } from 'mppx/client'
+
+const account = privateKeyToAccount('0xabc…123')
+
+const mppx = Mppx.create({
+  methods: [tempo({ account })],
+  polyfill: false, // [!code hl]
+})
+
+const response = await mppx.fetch('https://mpp.dev/api/ping/paid') // [!code hl]
+```
+
+</Tab>
+</Tabs>
 :::
 
 ### Request protected resources
@@ -146,13 +206,42 @@ export const config = createConfig({
 
 Pass accounts on individual requests instead of at setup:
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Mppx, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    getClient: provider.getClient,
+  })],
+  polyfill: false,
+})
+
+const response = await mppx.fetch('https://mpp.dev/api/ping/paid', {
+  // [!code hl:start]
+  context: {
+    account: provider.getAccount({ signable: true }),
+  }
+  // [!code hl:end]
+})
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { privateKeyToAccount } from 'viem/accounts'
 import { Mppx, tempo } from 'mppx/client'
 
 const mppx = Mppx.create({
+  methods: [tempo()],
   polyfill: false,
-  methods: [tempo()]
 })
 
 const response = await mppx.fetch('https://mpp.dev/api/ping/paid', {
@@ -164,6 +253,9 @@ const response = await mppx.fetch('https://mpp.dev/api/ping/paid', {
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### Manual payment handling
 
 Use `Mppx.create` for full control over the payment flow:
@@ -172,15 +264,52 @@ Use `Mppx.create` for full control over the payment flow:
 - Implement custom retry logic
 - Handle credentials manually
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Mppx, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    getClient: provider.getClient,
+  })],
+  // [!code hl:start]
+  polyfill: false,
+  // [!code hl:end]
+})
+
+// [!code hl:start]
+const response = await fetch('https://mpp.dev/api/ping/paid')
+
+if (response.status === 402) {
+  const credential = await mppx.createCredential(response, {
+    account: provider.getAccount({ signable: true }),
+  })
+
+  const paidResponse = await fetch('https://mpp.dev/api/ping/paid', {
+    headers: { Authorization: credential },
+  })
+}
+// [!code hl:end]
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
 
 const mppx = Mppx.create({
+  methods: [tempo()],
   // [!code hl:start]
   polyfill: false,
   // [!code hl:end]
-  methods: [tempo()],
 })
 
 // [!code hl:start]
@@ -197,6 +326,9 @@ if (response.status === 402) {
 }
 // [!code hl:end]
 ```
+
+</Tab>
+</Tabs>
 
 ### Payment receipts
 

--- a/src/pages/sdk/typescript/client/Fetch.from.mdx
+++ b/src/pages/sdk/typescript/client/Fetch.from.mdx
@@ -3,11 +3,38 @@ description: "Wrap fetch with automatic MPP payments without changing global fet
 imageDescription: "Wrap fetch for paid API calls"
 ---
 
+import { Tab, Tabs } from 'vocs'
+
 # `Fetch.from` [Create a payment-aware fetch wrapper]
 
 Creates a scoped `fetch` wrapper that handles `402` Payment Required responses without modifying `globalThis.fetch`.
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Fetch, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const fetch = Fetch.from({
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+})
+
+const response = await fetch('https://mpp.dev/api/ping/paid')
+console.log(response.status)
+// @log: 200
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Fetch, tempo } from 'mppx/client'
@@ -24,9 +51,36 @@ console.log(response.status)
 // @log: 200
 ```
 
+</Tab>
+</Tabs>
+
 ### With allowed origins
 
 Use `acceptPaymentPolicy` to control where the wrapper injects `Accept-Payment`.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Fetch, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const fetch = Fetch.from({
+  acceptPaymentPolicy: {
+    origins: ['https://api.example.com', '*.paid.example.com'],
+  },
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Fetch, tempo } from 'mppx/client'
@@ -41,6 +95,9 @@ const fetch = Fetch.from({
   methods: [tempo({ account })],
 })
 ```
+
+</Tab>
+</Tabs>
 
 ## Return type
 

--- a/src/pages/sdk/typescript/client/Fetch.polyfill.mdx
+++ b/src/pages/sdk/typescript/client/Fetch.polyfill.mdx
@@ -3,11 +3,38 @@ description: "Install a global fetch wrapper that handles MPP payments automatic
 imageDescription: "Install paid fetch globally"
 ---
 
+import { Tab, Tabs } from 'vocs'
+
 # `Fetch.polyfill` [Install a global payment-aware fetch]
 
 Replaces `globalThis.fetch` with a payment-aware wrapper that handles `402` Payment Required responses.
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Fetch, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Fetch.polyfill({
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+})
+
+const response = await fetch('https://mpp.dev/api/ping/paid')
+console.log(response.status)
+// @log: 200
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Fetch, tempo } from 'mppx/client'
@@ -24,9 +51,36 @@ console.log(response.status)
 // @log: 200
 ```
 
+</Tab>
+</Tabs>
+
 ### With cross-origin payments
 
 In browsers, `Fetch.polyfill` defaults to same-origin `Accept-Payment` injection. Pass `acceptPaymentPolicy` when your paid API lives on another origin.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Fetch, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Fetch.polyfill({
+  acceptPaymentPolicy: {
+    origins: ['https://api.example.com'],
+  },
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Fetch, tempo } from 'mppx/client'
@@ -41,6 +95,9 @@ Fetch.polyfill({
   methods: [tempo({ account })],
 })
 ```
+
+</Tab>
+</Tabs>
 
 ## Return type
 

--- a/src/pages/sdk/typescript/client/Fetch.restore.mdx
+++ b/src/pages/sdk/typescript/client/Fetch.restore.mdx
@@ -3,11 +3,36 @@ description: "Restore the original fetch after installing the MPP fetch polyfill
 imageDescription: "Restore the original fetch"
 ---
 
+import { Tab, Tabs } from 'vocs'
+
 # `Fetch.restore` [Restore global fetch]
 
 Restores the original `globalThis.fetch` after `Fetch.polyfill` or `Mppx.create` installs a payment-aware wrapper.
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Fetch, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Fetch.polyfill({
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+})
+
+Fetch.restore()
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Fetch, tempo } from 'mppx/client'
@@ -21,6 +46,9 @@ Fetch.polyfill({
 
 Fetch.restore()
 ```
+
+</Tab>
+</Tabs>
 
 ## Return type
 

--- a/src/pages/sdk/typescript/client/McpClient.wrap.mdx
+++ b/src/pages/sdk/typescript/client/McpClient.wrap.mdx
@@ -1,8 +1,38 @@
+import { Tab, Tabs } from 'vocs'
+
 # `McpClient.wrap` [Payment-aware MCP client]
 
 Wraps an MCP SDK client with automatic payment handling. When a tool call returns a `-32042` payment required error, the wrapper creates a Credential and retries the call.
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts
+import { Provider } from 'accounts'
+import { Client } from '@modelcontextprotocol/sdk/client'
+import { McpClient, tempo } from 'mppx/mcp-sdk/client'
+
+const client = new Client({ name: 'my-client', version: '1.0.0' })
+await client.connect(transport)
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mcp = McpClient.wrap(client, {
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+})
+
+const result = await mcp.callTool({ name: 'premium_tool', arguments: {} })
+// @log: { content: [...], receipt: { ... } }
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts
 import { Client } from '@modelcontextprotocol/sdk/client'
@@ -19,6 +49,9 @@ const mcp = McpClient.wrap(client, {
 const result = await mcp.callTool({ name: 'premium_tool', arguments: {} })
 // @log: { content: [...], receipt: { ... } }
 ```
+
+</Tab>
+</Tabs>
 
 ### With call options
 

--- a/src/pages/sdk/typescript/client/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.charge.mdx
@@ -1,8 +1,37 @@
+import { Tab, Tabs } from 'vocs'
+
 # `Method.tempo.charge` [One-time payments]
 
 Creates a Tempo charge payment method for client-side transaction and proof signing.
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    // [!code focus:start]
+    tempo.charge({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+    // [!code focus:end]
+  ],
+})
+
+const response = await fetch('https://mpp.dev/api/ping/paid')
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -20,6 +49,9 @@ Mppx.create({
 
 const response = await fetch('https://mpp.dev/api/ping/paid')
 ```
+
+</Tab>
+</Tabs>
 
 For non-zero Challenges, the client returns either a `transaction` or `hash` payload depending on `mode`. For zero-amount Challenges, it always returns a `proof` payload and skips transaction construction.
 
@@ -39,6 +71,25 @@ type ReturnType = Method.Client
 
 Account to sign transactions and zero-dollar proofs with. You can override this per call using the context.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const method = tempo.charge({
+  account: provider.getAccount({ signable: true }), // [!code focus]
+  getClient: provider.getClient,
+})
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -48,6 +99,9 @@ const method = tempo.charge({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### autoSwap (optional)
 
 - **Type:** `boolean | { tokenIn?: Address[]; slippage?: number }`
@@ -55,6 +109,26 @@ const method = tempo.charge({
 Automatically swap from a supported stablecoin (USDC.e, pathUSD) via the Tempo DEX precompile when the client lacks sufficient balance of the requested currency. 
 
 Pass `true` to enable, or an object for custom tokens and slippage.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const method = tempo.charge({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  autoSwap: true, // [!code focus]
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { tempo } from 'mppx/client'
@@ -65,6 +139,9 @@ const method = tempo.charge({
   autoSwap: true, // [!code focus]
 })
 ```
+
+</Tab>
+</Tabs>
 
 ### clientId (optional)
 
@@ -78,6 +155,26 @@ Client identifier used to derive the client fingerprint in attribution memos.
 
 Chain ID this client accepts for Tempo charges. When set, the client rejects any Challenge with a different `chainId`, and uses this chain when the Challenge omits one.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const method = tempo.charge({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  expectedChainId: 4217, // Tempo mainnet // [!code focus]
+})
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -88,11 +185,36 @@ const method = tempo.charge({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### expectedRecipients (optional)
 
 - **Type:** `readonly string[]`
 
 Allowlist of addresses the client accepts as split recipients. When set, the client rejects any Challenge whose split recipients are not in this list, preventing a compromised server from redirecting funds.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const method = tempo.charge({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  expectedRecipients: [ // [!code focus]
+    '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', // [!code focus]
+  ], // [!code focus]
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { tempo } from 'mppx/client'
@@ -105,6 +227,9 @@ const method = tempo.charge({
   ], // [!code focus]
 })
 ```
+
+</Tab>
+</Tabs>
 
 
 ### getClient (optional)
@@ -124,6 +249,26 @@ Controls how non-zero charge transactions are submitted. Zero-amount Challenges 
 - `'push'`: the client broadcasts the transaction and sends the transaction hash to the server for verification.
 - `'pull'`: the client signs the transaction and sends the serialized transaction to the server, which broadcasts it. This is required for server-side [fee sponsorship](/quickstart/server#fee-sponsorship).
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const method = tempo.charge({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  mode: 'pull', // [!code focus]
+})
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -133,3 +278,6 @@ const method = tempo.charge({
   mode: 'pull', // [!code focus]
 })
 ```
+
+</Tab>
+</Tabs>

--- a/src/pages/sdk/typescript/client/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.mdx
@@ -4,6 +4,8 @@ description: "Register Tempo charge and session support in an MPP TypeScript cli
 imageDescription: "Handle Tempo payments in TypeScript clients"
 ---
 
+import { Tab, Tabs } from 'vocs'
+
 # `tempo` [Register default Tempo intents]
 
 Convenience function that creates both `tempo.charge` and Sessions method intents with shared configuration.
@@ -17,6 +19,31 @@ Use this helper when you want `Mppx.create` to handle both one-time charges and 
 :::
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    // [!code focus:start]
+    tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+    // [!code focus:end]
+  ],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -33,7 +60,37 @@ Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 This is equivalent to:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    tempo.charge({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+    tempo.session({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+  ],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -49,9 +106,35 @@ Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### Standalone session manager
 
 `tempo.session.manager()` creates a standalone Sessions manager with explicit `.fetch()`, `.topUp()`, `.close()`, `.sse()`, and `.ws()` methods. It does not register a method in `Mppx.create`; it owns one channel lifecycle directly.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '1',
+})
+
+const res = await session.fetch('https://api.example.com/resource')
+await session.close()
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { tempo } from 'mppx/client'
@@ -65,6 +148,9 @@ const session = tempo.session.manager({
 const res = await session.fetch('https://api.example.com/resource')
 await session.close()
 ```
+
+</Tab>
+</Tabs>
 
 See [`tempo.session.manager`](/sdk/typescript/client/Method.tempo.session-manager) for the full API.
 

--- a/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
@@ -1,3 +1,5 @@
+import { Tab, Tabs } from 'vocs'
+
 # `tempo.session.manager` [Sessions manager]
 
 Creates a Sessions manager that handles channel open, paid fetches, streaming, top-ups, and close.
@@ -11,6 +13,38 @@ Use `tempo.session()` instead when you only need to register the current Session
 :::
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '1',
+})
+
+// Make a paid request — opens a channel on first call
+const response = await session.fetch('https://api.example.com/resource')
+console.log(response.status)
+// @log: 200
+
+// Access payment metadata
+console.log(response.receipt)
+console.log(response.cumulative)
+
+// Close the channel and settle on-chain
+const receipt = await session.close()
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { tempo } from 'mppx/client'
@@ -36,6 +70,9 @@ console.log(response.cumulative)
 const receipt = await session.close()
 ```
 
+</Tab>
+</Tabs>
+
 :::warning
 Channels remain open until you call `session.close()`. Close sessions when done to settle on-chain and reclaim unspent deposit.
 :::
@@ -43,6 +80,39 @@ Channels remain open until you call `session.close()`. Close sessions when done 
 ### With SSE streaming
 
 Stream server-sent events with automatic voucher handling. The manager signs incremental vouchers as the server requests more payment during the stream.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '5',
+})
+
+const stream = await session.sse('https://api.example.com/stream', {
+  onReceipt(receipt) {
+    console.log('Receipt:', receipt)
+  },
+  signal: AbortSignal.timeout(30_000),
+})
+
+for await (const message of stream) {
+  console.log(message)
+}
+
+await session.close()
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { tempo } from 'mppx/client'
@@ -67,9 +137,51 @@ for await (const message of stream) {
 await session.close()
 ```
 
+</Tab>
+</Tabs>
+
 ### With WebSocket streaming
 
 Open a paid WebSocket session. The manager handles the HTTP `402` probe, channel open, in-band voucher signing, and payment control frames.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '1',
+})
+
+const url = new URL('wss://api.example.com/ws/chat')
+url.searchParams.set('prompt', 'Tell me something interesting')
+
+const socket = await session.ws(url, {
+  onReceipt(receipt) {
+    console.log('Receipt:', receipt)
+  },
+})
+
+socket.addEventListener('message', (event) => {
+  process.stdout.write(event.data)
+})
+
+await new Promise<void>((resolve) => {
+  socket.addEventListener('close', () => resolve(), { once: true })
+})
+
+const receipt = await session.close()
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts
 import { tempo } from 'mppx/client'
@@ -100,8 +212,33 @@ await new Promise<void>((resolve) => {
 const receipt = await session.close()
 ```
 
+</Tab>
+</Tabs>
+
 :::tip
 In Node.js or other server-side runtimes without a global `WebSocket`, pass the constructor to `tempo.session.manager()`:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts
+import { WebSocket } from 'isows'
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '1',
+  webSocket: WebSocket,
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts
 import { WebSocket } from 'isows'
@@ -115,11 +252,40 @@ const session = tempo.session.manager({
 })
 ```
 
+</Tab>
+</Tabs>
+
 :::
 
 ### With top-up
 
 Add deposit to the active channel without closing it.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '10',
+})
+
+await session.fetch('https://api.example.com/resource')
+
+const receipt = await session.topUp('2')
+console.log(receipt?.status)
+// @log: success
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { tempo } from 'mppx/client'
@@ -137,9 +303,47 @@ console.log(receipt?.status)
 // @log: success
 ```
 
+</Tab>
+</Tabs>
+
 ### With session resumption
 
 Pass `sessionStore` to persist channel hints between manager instances. The next manager sends the stored channel ID as a hint and hydrates from server snapshots when the server supports them.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import type { Session } from 'mppx/tempo'
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const channelStore = {
+  channel: null as Session.Client.StoredSessionChannel | null,
+  delete() {
+    this.channel = null
+  },
+  get() {
+    return this.channel
+  },
+  set(channel: Session.Client.StoredSessionChannel) {
+    this.channel = channel
+  },
+}
+
+const session = tempo.session.manager({
+  account: provider.getAccount({ signable: true }),
+  getClient: provider.getClient,
+  maxDeposit: '1',
+  sessionStore: channelStore,
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import type { Session } from 'mppx/tempo'
@@ -166,11 +370,47 @@ const session = tempo.session.manager({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ## Migrate from Legacy Sessions
 
 Legacy Sessions clients used `tempo.sessionLegacy()` or `tempo.sessionLegacy.method()`. Use `tempo.session.manager()` for a standalone manager, or `tempo()` when you want the same fetch wrapper to handle one-time charges and Sessions.
 
 Current Sessions and Legacy Sessions do not share channel state. Existing Legacy channels should be closed or settled through `tempo.sessionLegacy`; new channels should be opened through `tempo.session` or `tempo.session.manager()`. During a rolling migration, register both `tempo.session()` and `tempo.sessionLegacy.method()` if the client may talk to both server versions.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { createClient, http } from 'viem'
+import { Provider } from 'accounts'
+import { tempo as tempoMainnet } from 'viem/chains'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const { fetch: mppxFetch } = Mppx.create({
+  methods: [
+    tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: () =>
+        createClient({
+          chain: tempoMainnet,
+          transport: http('https://rpc.tempo.xyz'),
+        }),
+      maxDeposit: '1',
+    }),
+  ],
+  polyfill: false,
+})
+
+const response = await mppxFetch('https://api.example.com/resource')
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -197,6 +437,9 @@ const { fetch: mppxFetch } = Mppx.create({
 
 const response = await mppxFetch('https://api.example.com/resource')
 ```
+
+</Tab>
+</Tabs>
 
 Use `tempo.sessionLegacy()` only while the server still emits Legacy Sessions Challenges.
 

--- a/src/pages/sdk/typescript/client/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session.mdx
@@ -1,3 +1,5 @@
+import { Tab, Tabs } from 'vocs'
+
 # `tempo.session` [Sessions client method]
 
 Creates the low-level Tempo Sessions client method for `Mppx.create`.
@@ -11,6 +13,31 @@ Use `tempo.session()` when you need to register only the current Sessions intent
 :::
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    // [!code focus:start]
+    tempo.session({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+    // [!code focus:end]
+  ],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -27,9 +54,33 @@ Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### With charge and session
 
 Use the `tempo()` convenience function when you want the default Tempo charge and Sessions methods.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -42,11 +93,43 @@ Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### With Legacy Sessions
 
 Use `tempo.sessionLegacy.method()` only for servers that still issue Legacy Sessions Challenges.
 
 If a client must support both current and Legacy Sessions during migration, register both methods:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    tempo.session({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+      maxDeposit: '1',
+    }),
+    tempo.sessionLegacy.method({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+      maxDeposit: '1',
+    }),
+  ],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -62,6 +145,30 @@ Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [tempo.sessionLegacy.method({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+})
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -72,6 +179,9 @@ Mppx.create({
   methods: [tempo.sessionLegacy.method({ account })],
 })
 ```
+
+</Tab>
+</Tabs>
 
 ## Return type
 
@@ -89,6 +199,25 @@ type ReturnType = Method.Client
 
 Account to sign channel transactions and vouchers with. You can override this per call using the context.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const method = tempo.session({
+  account: provider.getAccount({ signable: true }), // [!code focus]
+  getClient: provider.getClient,
+})
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -97,6 +226,9 @@ const method = tempo.session({
   account: privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'), // [!code focus]
 })
 ```
+
+</Tab>
+</Tabs>
 
 ### authorizedSigner (optional)
 

--- a/src/pages/sdk/typescript/client/Method.tempo.subscription.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.subscription.mdx
@@ -1,8 +1,39 @@
+import { Tab, Tabs } from 'vocs'
+
 # `Method.tempo.subscription` [Recurring stablecoin payments]
 
 Creates a Tempo subscription client method for signing access-key authorizations.
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    // [!code focus:start]
+    tempo.subscription({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+    // [!code focus:end]
+  ],
+})
+
+const response = await fetch('https://api.example.com/pro')
+console.log(response.status)
+// @log: 200
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -23,9 +54,40 @@ console.log(response.status)
 // @log: 200
 ```
 
+</Tab>
+</Tabs>
+
 ### With request validation
 
 Use `validateRequest` to enforce local client policy before signing.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    tempo.subscription({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+      validateRequest: (request) => {
+        if (request.periodUnit !== 'week') {
+          throw new Error('Expected weekly billing')
+        }
+      },
+    }),
+  ],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -47,9 +109,39 @@ Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### With explicit access key
 
 Most servers include an access key in the Challenge. Pass `accessKey` only when the server expects the client to supply a specific key.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    tempo.subscription({
+      accessKey: {
+        accessKeyAddress: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        keyType: 'secp256k1',
+      },
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+  ],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -69,6 +161,9 @@ Mppx.create({
   ],
 })
 ```
+
+</Tab>
+</Tabs>
 
 ## Return type
 
@@ -108,6 +203,32 @@ Runs before the client signs the key authorization. Throw to reject subscription
 
 Pass request-specific values through fetch context when needed.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo.subscription({
+    getClient: provider.getClient,
+  })],
+})
+
+await mppx.fetch('https://api.example.com/pro', {
+  context: {
+    account: provider.getAccount({ signable: true }),
+  },
+})
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -124,6 +245,9 @@ await mppx.fetch('https://api.example.com/pro', {
   },
 })
 ```
+
+</Tab>
+</Tabs>
 
 ### accessKey (optional)
 

--- a/src/pages/sdk/typescript/client/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/client/Mppx.create.mdx
@@ -1,8 +1,34 @@
+import { Tab, Tabs } from 'vocs'
+
 # `Mppx.create` [Create a payment-aware fetch client]
 
 Creates a client-side payment handler. Returns a payment handler with a `fetch` function that automatically handles `402` Payment Required responses. By default, also polyfills `globalThis.fetch`.
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+})
+
+// Global fetch now handles 402 automatically
+const res = await fetch('https://mpp.dev/api/ping/paid')
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -18,9 +44,49 @@ Mppx.create({
 const res = await fetch('https://mpp.dev/api/ping/paid')
 ```
 
+</Tab>
+</Tabs>
+
 ### With payment hooks
 
 Register hooks on the returned `mppx` instance to observe the payment flow.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+  polyfill: false,
+})
+
+const offFailure = mppx.onPaymentFailed(({ error, input }) => {
+  console.error('payment failed:', input, error)
+})
+
+const offResponse = mppx.onPaymentResponse(({ challenge, response }) => {
+  console.log('payment response:', challenge.id, response.status)
+})
+
+const res = await mppx.fetch('https://mpp.dev/api/ping/paid')
+console.log(res.status)
+// @log: 200
+
+offFailure()
+offResponse()
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -49,9 +115,37 @@ offFailure()
 offResponse()
 ```
 
+</Tab>
+</Tabs>
+
 ### Without polyfill
 
 Set `polyfill: false` to get a scoped fetch without modifying the global:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+  polyfill: false, // [!code hl]
+})
+
+// Use the returned fetch // [!code hl]
+const res = await mppx.fetch('https://mpp.dev/api/ping/paid') // [!code hl]
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -68,9 +162,47 @@ const mppx = Mppx.create({
 const res = await mppx.fetch('https://mpp.dev/api/ping/paid') // [!code hl]
 ```
 
+</Tab>
+</Tabs>
+
 ### Manual credential handling
 
 For full control over the payment flow:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    getClient: provider.getClient,
+  })],
+  polyfill: false, // [!code hl]
+})
+
+// [!code hl:start]
+const response = await fetch('https://mpp.dev/api/ping/paid')
+
+if (response.status === 402) {
+  const credential = await mppx.createCredential(response, {
+    account: provider.getAccount({ signable: true }),
+  })
+
+  const paidResponse = await fetch('https://mpp.dev/api/ping/paid', {
+    headers: { Authorization: credential },
+  })
+}
+// [!code hl:end]
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -96,7 +228,37 @@ if (response.status === 402) {
 // [!code hl:end]
 ```
 
+</Tab>
+</Tabs>
+
 Pass `acceptPayment` to override method selection for this one response:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo()],
+  polyfill: false,
+})
+
+const response = await fetch('https://mpp.dev/api/ping/paid')
+
+const credential = await mppx.createCredential(
+  response,
+  { account: provider.getAccount({ signable: true }) },
+  { acceptPayment: 'tempo/charge;q=1, tempo/session;q=0' }, // [!code focus]
+)
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -115,6 +277,9 @@ const credential = await mppx.createCredential(
   { acceptPayment: 'tempo/charge;q=1, tempo/session;q=0' }, // [!code focus]
 )
 ```
+
+</Tab>
+</Tabs>
 
 ## Return type
 
@@ -151,6 +316,31 @@ type Mppx = {
 
 The original `fetch` function, before payment interception. Use `rawFetch` when you need to make requests that bypass the 402 handler—for example, probing a 402 endpoint for websocket auth tokens or calling APIs that return 402 for non-payment reasons.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  polyfill: false,
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+})
+
+// Bypass payment interception
+const raw = await mppx.rawFetch('https://api.example.com/ws-auth') // [!code focus]
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -166,6 +356,9 @@ const mppx = Mppx.create({
 const raw = await mppx.rawFetch('https://api.example.com/ws-auth') // [!code focus]
 ```
 
+</Tab>
+</Tabs>
+
 ## Payment hooks
 
 Payment hooks are for logging, monitoring, tracing, and request-local context. Each registration returns an unsubscribe function.
@@ -179,6 +372,37 @@ Payment hooks are for logging, monitoring, tracing, and request-local context. E
 | `on('*', handler)` | Any client payment event fires |
 
 `onChallengeReceived` runs before `onChallenge`. It can return a non-empty Credential string to override the default credential flow. Other hooks are observers: thrown errors are ignored and don't change payment handling.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+  polyfill: false,
+})
+
+mppx.onChallengeReceived(async ({ challenge, createCredential }) => {
+  console.log('challenge received:', challenge.id)
+  return createCredential()
+})
+
+mppx.on('*', ({ name }) => {
+  console.log('payment event:', name)
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -201,6 +425,9 @@ mppx.on('*', ({ name }) => {
 })
 ```
 
+</Tab>
+</Tabs>
+
 ## Parameters
 
 ### acceptPaymentPolicy (optional)
@@ -211,6 +438,30 @@ mppx.on('*', ({ name }) => {
 Controls when `mppx` injects `Accept-Payment` on outgoing requests. Browser polyfills default to same-origin injection to avoid CORS preflight failures on APIs that don't support payment discovery.
 
 Use `{ origins }` for cross-origin paid APIs. Origin patterns support `*.` subdomain wildcards.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  acceptPaymentPolicy: {
+    origins: ['https://api.example.com', '*.paid.example.com'],
+  }, // [!code focus]
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -226,12 +477,39 @@ Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### fetch (optional)
 
 - **Type:** `typeof globalThis.fetch`
 - **Default:** `globalThis.fetch`
 
 Custom fetch function to wrap.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const customFetch = globalThis.fetch
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  fetch: customFetch, // [!code focus]
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -247,11 +525,37 @@ const mppx = Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### methods
 
 - **Type:** `readonly Method.Client[]`
 
 Array of payment methods to use.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  // [!code focus:start]
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+  // [!code focus:end]
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -266,11 +570,39 @@ const mppx = Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### onChallenge (optional)
 
 - **Type:** `(challenge: Challenge, helpers: { createCredential: (context?) => Promise<string> }) => Promise<string | undefined>`
 
 Called when a `402` challenge is received, before credential creation. Return a credential string to use it directly, or `undefined` to fall back to the default credential flow.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+  onChallenge: async (challenge, { createCredential }) => { // [!code focus:start]
+    console.log('Challenge received:', challenge.method)
+    return createCredential()
+  }, // [!code focus:end]
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -287,6 +619,9 @@ const mppx = Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### paymentPreferences (optional)
 
 - **Type:** `AcceptPayment.Config<methods>`
@@ -294,6 +629,45 @@ const mppx = Mppx.create({
 Configures which payment methods the client prefers when a server offers multiple options via `Mppx.compose`. Emits an `Accept-Payment` header on requests so the server can filter Challenges to the client's preferred methods.
 
 Accepts a definition map or a callback that receives a typed key tree. Each key is a `method/intent` string (like `'tempo/charge'`). Values are q-values from 0 to 1—higher means more preferred. Set to 0 to explicitly opt out.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, stripe, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+    stripe.charge({
+      createToken: async (opts) => {
+        const res = await fetch('/api/create-spt', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(opts),
+        })
+        const { spt } = await res.json() as { spt: string }
+        return spt
+      },
+    }),
+  ],
+  paymentPreferences: ({ tempo, stripe }) => ({ // [!code focus:start]
+    [tempo.charge]: 1,
+    [stripe.charge]: 0.5,
+    [tempo.session]: 0.2,
+  }), // [!code focus:end]
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, stripe, tempo } from 'mppx/client'
@@ -324,7 +698,49 @@ Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 With a plain definition map:
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, stripe, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [
+    tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    }),
+    stripe.charge({
+      createToken: async (opts) => {
+        const res = await fetch('/api/create-spt', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(opts),
+        })
+        const { spt } = await res.json() as { spt: string }
+        return spt
+      },
+    }),
+  ],
+  paymentPreferences: { // [!code focus:start]
+    'tempo/charge': 1,
+    'stripe/charge': 0.5,
+    'tempo/session': 0.2,
+  }, // [!code focus:end]
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, stripe, tempo } from 'mppx/client'
@@ -355,12 +771,37 @@ Mppx.create({
 })
 ```
 
+</Tab>
+</Tabs>
+
 ### polyfill (optional)
 
 - **Type:** `boolean`
 - **Default:** `true`
 
 Whether to polyfill `globalThis.fetch` with the payment-aware wrapper.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+  polyfill: false, // [!code focus]
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -373,6 +814,9 @@ const mppx = Mppx.create({
   polyfill: false, // [!code focus]
 })
 ```
+
+</Tab>
+</Tabs>
 
 ## Manual credential options
 
@@ -389,6 +833,28 @@ Request-local method preference override for `mppx.createCredential(response, co
 
 Transport to use for extracting challenges and attaching credentials.
 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Mppx, Transport, tempo } from 'mppx/client'
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+      account: provider.getAccount({ signable: true }),
+      getClient: provider.getClient,
+    })],
+  transport: Transport.mcp(), // [!code focus]
+})
+```
+
+</Tab>
+<Tab title="viem">
+
 ```ts twoslash
 import { Mppx, Transport, tempo } from 'mppx/client'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -400,3 +866,6 @@ const mppx = Mppx.create({
   transport: Transport.mcp(), // [!code focus]
 })
 ```
+
+</Tab>
+</Tabs>

--- a/src/pages/sdk/typescript/client/Mppx.restore.mdx
+++ b/src/pages/sdk/typescript/client/Mppx.restore.mdx
@@ -1,8 +1,35 @@
+import { Tab, Tabs } from 'vocs'
+
 # `Mppx.restore` [Restore the original global fetch]
 
 Restores the original `fetch` after `Mppx.create()` polyfilled it.
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Mppx, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+})
+
+// ... use payment-aware fetch ...
+
+Mppx.restore()
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/client'
@@ -18,6 +45,9 @@ Mppx.create({
 
 Mppx.restore()
 ```
+
+</Tab>
+</Tabs>
 
 ## Return type
 

--- a/src/pages/sdk/typescript/client/Transport.http.mdx
+++ b/src/pages/sdk/typescript/client/Transport.http.mdx
@@ -1,8 +1,32 @@
+import { Tab, Tabs } from 'vocs'
+
 # `Transport.http` [HTTP transport for payments]
 
 HTTP transport for client-side payment handling.
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Mppx, Transport, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+  transport: Transport.http(), // [!code focus]
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, Transport, tempo } from 'mppx/client'
@@ -15,6 +39,9 @@ const mppx = Mppx.create({
   transport: Transport.http(), // [!code focus]
 })
 ```
+
+</Tab>
+</Tabs>
 
 ## Behavior
 

--- a/src/pages/sdk/typescript/client/Transport.mcp.mdx
+++ b/src/pages/sdk/typescript/client/Transport.mcp.mdx
@@ -1,8 +1,32 @@
+import { Tab, Tabs } from 'vocs'
+
 # `Transport.mcp` [MCP transport for payments]
 
 MCP transport for client-side payment handling.
 
 ## Usage
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Mppx, Transport, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+const mppx = Mppx.create({
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
+  transport: Transport.mcp(), // [!code focus]
+})
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash
 import { Mppx, Transport, tempo } from 'mppx/client'
@@ -15,6 +39,9 @@ const mppx = Mppx.create({
   transport: Transport.mcp(), // [!code focus]
 })
 ```
+
+</Tab>
+</Tabs>
 
 ## Behavior
 

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -49,7 +49,25 @@ You can apply the same patterns to [other payment methods](/payment-methods).
 
 ### Install peer dependencies
 
-In this example, you use the `viem` library to instantiate an account.
+In this example, you use the Tempo Accounts SDK to connect an account. You can also use a viem account directly.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+:::code-group
+```bash [npm]
+$ npm install accounts
+```
+```bash [pnpm]
+$ pnpm add accounts
+```
+```bash [bun]
+$ bun add accounts
+```
+:::
+
+</Tab>
+<Tab title="viem">
 
 :::code-group
 ```bash [npm]
@@ -63,9 +81,25 @@ $ bun add viem
 ```
 :::
 
-### Define an account
+</Tab>
+</Tabs>
 
-Next, define an account to sign payments.
+### Connect an account
+
+Next, connect a Tempo account to sign payments.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash [define-account.ts]
+import { Provider } from 'accounts'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash [define-account.ts]
 import { privateKeyToAccount } from 'viem/accounts'
@@ -73,13 +107,33 @@ import { privateKeyToAccount } from 'viem/accounts'
 const account = privateKeyToAccount('0xabc…123')
 ```
 
-:::tip
-When using Tempo, you can also use [Passkey or WebCrypto accounts](https://viem.sh/tempo/accounts).
-:::
+</Tab>
+</Tabs>
 
 ### Create payment handler
 
 Call `Mppx.create` at startup. This polyfills the global `fetch` to automatically handle `402` payment challenges.
+
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash [create-paid-fetch.ts]
+import { Provider } from 'accounts'
+import { Mppx, tempo } from 'mppx/client' // [!code hl]
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
+Mppx.create({ // [!code hl]
+  methods: [tempo({ // [!code hl]
+    account: provider.getAccount({ signable: true }), // [!code hl]
+    getClient: provider.getClient, // [!code hl]
+  })], // [!code hl]
+}) // [!code hl]
+```
+
+</Tab>
+<Tab title="viem">
 
 ```ts twoslash [create-paid-fetch.ts]
 import { privateKeyToAccount } from 'viem/accounts'
@@ -92,17 +146,52 @@ Mppx.create({ // [!code hl]
 }) // [!code hl]
 ```
 
+</Tab>
+</Tabs>
+
 :::tip
 If you want to avoid polyfilling, use the returned `fetch` instead.
 
-```ts 
+<Tabs stateKey="account-source">
+<Tab title="Accounts SDK">
+
+```ts twoslash
+import { Provider } from 'accounts'
+import { Mppx, tempo } from 'mppx/client'
+
+const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
+await provider.request({ method: 'wallet_connect' })
+
 const mppx = Mppx.create({
+  methods: [tempo({
+    account: provider.getAccount({ signable: true }),
+    getClient: provider.getClient,
+  })],
   polyfill: false, // [!code hl]
-  methods: [tempo({ account })]
 })
 
 const response = await mppx.fetch('https://mpp.dev/api/ping/paid') // [!code hl]
 ```
+
+</Tab>
+<Tab title="viem">
+
+```ts twoslash
+import { privateKeyToAccount } from 'viem/accounts'
+import { Mppx, tempo } from 'mppx/client'
+
+const account = privateKeyToAccount('0xabc…123')
+
+const mppx = Mppx.create({
+  methods: [tempo({ account })],
+  polyfill: false, // [!code hl]
+})
+
+const response = await mppx.fetch('https://mpp.dev/api/ping/paid') // [!code hl]
+```
+
+</Tab>
+</Tabs>
 :::
 
 ### Request protected resources


### PR DESCRIPTION
## Summary

- Add Accounts SDK as the primary tabbed option for Tempo client examples
- Preserve viem account examples as secondary tabs
- Add the Accounts SDK dependency for docs snippets