### PR TITLE
feat: add WC2026 Prediction Engine (sports predictions, Tempo MPP)

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6689,4 +6689,41 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── WC2026 Prediction Engine ─────────────────────────────────────────────
+  {
+    id: "wc2026",
+    name: "WC2026 Prediction Engine",
+    url: "https://wc2026mpp.xyz",
+    serviceUrl: "https://wc2026mpp.xyz",
+    description:
+      "Probabilistic match intelligence for FIFA World Cup 2026. Poisson-modelled win probabilities, BTTS, correct scores, halftime splits, live in-play updates, H2H history, parlay combiners and tournament winner forecasts across 48 nations — $0.02 per call, no signup.",
+    categories: ["data", "ai"],
+    integration: "third-party",
+    tags: ["football", "soccer", "world-cup", "sports", "prediction", "betting", "wc2026"],
+    status: "active",
+    docs: {
+      homepage: "https://wc2026mpp.xyz",
+      llmsTxt: "https://wc2026mpp.xyz/llms.txt",
+      apiReference: "https://wc2026mpp.xyz/openapi.json",
+    },
+    provider: { name: "WC2026 Prediction Engine", url: "https://wc2026mpp.xyz" },
+    realm: "wc2026mpp.xyz",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      { route: "POST /api/service",       desc: "Full ensemble prediction — Poisson 45% + market 35% + H2H 20%", amount: "20000" },
+      { route: "POST /api/btts",          desc: "Both teams to score probability", amount: "20000" },
+      { route: "POST /api/goals",         desc: "Expected goals and over/under thresholds (0.5–4.5)", amount: "20000" },
+      { route: "POST /api/correct-score", desc: "Top 8 exact scoreline probabilities", amount: "20000" },
+      { route: "POST /api/halftime",      desc: "Half-time H/D/A result prediction", amount: "20000" },
+      { route: "POST /api/live",          desc: "In-play win probability given current score and minute", amount: "20000" },
+      { route: "POST /api/form",          desc: "Team form and stats profile", amount: "20000" },
+      { route: "POST /api/h2h",           desc: "Head-to-head history between two teams", amount: "20000" },
+      { route: "POST /api/upset",         desc: "Upset and underdog probability with value rating", amount: "20000" },
+      { route: "POST /api/winner",        desc: "Tournament winner probabilities for all 48 teams", amount: "20000" },
+      { route: "POST /api/final",         desc: "Knockout reach probabilities — R16 through winner", amount: "20000" },
+      { route: "POST /api/parlay",        desc: "Parlay / accumulator analyser for 2–8 matches", amount: "20000" },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary

Adds **WC2026 Prediction Engine** (`wc2026mpp.xyz`) to the MPP services registry.

### Service
- **URL:** https://wc2026mpp.xyz
- **Categories:** `data`, `ai`
- **Payment:** Tempo USDC.e · $0.02 per call
- **Endpoints:** 12 (GET + POST)
- **Teams covered:** 58 confirmed WC2026 qualifiers

### Endpoints
| Route | Description |
|---|---|
| `POST /api/service` | Full ensemble prediction — Poisson 45% + market 35% + H2H 20% |
| `POST /api/btts` | Both teams to score probability |
| `POST /api/goals` | Expected goals and over/under thresholds (0.5–4.5) |
| `POST /api/correct-score` | Top 8 exact scoreline probabilities |
| `POST /api/halftime` | Half-time H/D/A result prediction |
| `POST /api/live` | In-play win probability given current score and minute |
| `POST /api/form` | Team form and stats profile |
| `POST /api/h2h` | Head-to-head history between two teams |
| `POST /api/upset` | Upset and underdog probability with value rating |
| `POST /api/winner` | Tournament winner probabilities for all 58 teams |
| `POST /api/final` | Knockout reach probabilities — R16 through winner |
| `POST /api/parlay` | Parlay / accumulator analyser for 2–8 matches |

### Data Sources
- **ESPN live API** — real WC2026 scores, standings, scorers (refreshed every 20–90s)
- **The Odds API** — real bookmaker h2h odds averaged across up to 24 books, vig-removed
- **Bayesian blending** — live WC results progressively update pre-tournament priors

### Verification
- OpenAPI spec: https://wc2026mpp.xyz/openapi.json
- LLMs.txt: https://wc2026mpp.xyz/llms.txt
- MPPScan: https://www.mppscan.com/server/13f6379e42d0a65a575b1cc28cbda1a1147f24143a92187a98dad4369d4ae836

---

## Checklist

### Required
- [x] Service is **live and accepting payments** via MPP — returns HTTP 402 with `WWW-Authenticate: tempo` challenge
- [x] Entry added to `schemas/services.ts` following the contributing guide
- [x] Types pass: `pnpm check:types` — all fields match `ServiceDef` interface exactly
- [x] Build succeeds: `pnpm build`

### Recommended
- [x] Service registered on [MPPScan](https://www.mppscan.com/server/13f6379e42d0a65a575b1cc28cbda1a1147f24143a92187a98dad4369d4ae836) — discoverable by agents