### PR TITLE
Add ip402.xyz to the service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -5571,6 +5571,38 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── ip402 ───────────────────────────────────────────────────────────
+  {
+    id: "ip402",
+    name: "ip402.xyz",
+    url: "https://ip402.xyz",
+    serviceUrl: "https://ip402.xyz",
+    description:
+      "Paid IP geolocation and ASN lookup for agents. Send an IPv4/IPv6 address, get normalized geolocation (country, city, location, time zone) and network (ASN, organization) data back. Payment is the access control — no accounts, no API keys.",
+
+    categories: ["data"],
+    integration: "third-party",
+    tags: ["ip", "geoip", "geolocation", "asn", "network"],
+    status: "active",
+    docs: {
+      homepage: "https://ip402.xyz/",
+      llmsTxt: "https://ip402.xyz/llms.txt",
+      apiReference: "https://ip402.xyz/openapi.json",
+    },
+    provider: { name: "ip402.xyz", url: "https://ip402.xyz" },
+    realm: "ip402.xyz",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /v1/geo",
+        desc: "Geolocate a single IPv4 or IPv6 address — country, city, location, time zone, and ASN/organization",
+        amount: "10000",
+        unitType: "request",
+      },
+    ],
+  },
+
   // ── IPinfo ───────────────────────────────────────────────────────────
   {
     id: "ipinfo",


### PR DESCRIPTION
## Add ip402.xyz to the service directory

**ip402.xyz** is a pay-per-call **IP geolocation + ASN lookup** API built for agents. Send an IPv4/IPv6 address, get normalized geolocation (country, city, location, time zone) and network (ASN, organization) data back. Payment is the access control — no accounts, no API keys.

### Discovery
- Homepage: https://ip402.xyz/
- OpenAPI 3.1 (with `x-payment-info` offers + `x-service-info`): https://ip402.xyz/openapi.json
- llms.txt: https://ip402.xyz/llms.txt

### Payments
- **Tempo MPP** — `charge` intent, USDC.e on Tempo mainnet, `$0.01`/lookup (`10000` base units). Realm `ip402.xyz`.
- The same endpoint also advertises **x402** (USDC on Base & Solana mainnet) on its own 402 header, so a single integration reaches both ecosystems.

### Why it's not just another IP API
- **Dual-rail in one endpoint** — one `GET /v1/geo` accepts both Tempo MPP and x402 (Base/Solana); the client picks the protocol it already speaks.
- **Independently hosted & self-describing** — not a proxy wrapper; the 402 challenge embeds the input/output JSON Schema so agents can call it with no docs.
- **No accounts / no API keys** — payment is the only gate.

### Checklist
- [x] Live and accepting payments via MPP (Tempo mainnet `charge`)
- [x] Entry added to `schemas/services.ts` (passes `biome check`)
- [ ] Registering on MPPScan separately

Happy to adjust categorization, pricing detail, or copy as needed.
