### PR TITLE
Add Blog to mobile navigation

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -72,6 +72,9 @@ function MobileNav() {
       <a href="/services" data-mobile-nav-item="">
         Services
       </a>
+      <a href="/blog" data-mobile-nav-item="">
+        Blog
+      </a>
       <a
         href="https://paymentauth.org"
         target="_blank"


### PR DESCRIPTION
## Summary
- Add Blog to the mobile navigation global link cluster between Services and Specification.

## Verification
- pnpm check:ci
- pnpm generate:discovery && pnpm check:types
- Verified local mobile drawer at 390px shows Blog linking to /blog.

Prompted by: @max-digi