### PR TITLE
Match mobile nav labels to desktop

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -81,7 +81,7 @@ function MobileNav() {
         rel="noopener noreferrer"
         data-mobile-nav-item=""
       >
-        Specification
+        IETF Specs
       </a>
       <span data-mobile-nav-label="">GitHub</span>
       <div data-mobile-nav-subitems="" data-mobile-nav-flat="">


### PR DESCRIPTION
## Summary
- Rename the mobile navigation paymentauth link from `Specification` to `IETF Specs` so the mobile global nav matches desktop: Docs, Services, Blog, IETF Specs.

## Verification
- pnpm check:ci
- Local mobile drawer check at 390px returned: Docs, Services, Blog, IETF Specs.

Prompted by: @brendanjryan