### PR TITLE
Add 5 Tempo MPP services: Price Feed, Gas Estimator, Token Info, Activity Score, Random Stable Fact

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6779,4 +6779,64 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── Tempo Token Info ─────────────────────────────────────────────────────
+  {
+    id: "tempo-token-info",
+    name: "Tempo Token Info",
+    url: "https://tempo-token-info.vercel.app",
+    serviceUrl: "https://tempo-token-info.vercel.app",
+    description:
+      "Look up TIP-20 token metadata on Tempo — symbol, name, decimals, and total supply — from a token contract address. No API key, pay-per-request.",
+
+    categories: ["data", "blockchain"],
+    integration: "third-party",
+    tags: ["token", "tip-20", "metadata", "tempo", "erc20"],
+    status: "active",
+    docs: {
+      homepage: "https://tempo-token-info.vercel.app",
+      apiReference: "https://tempo-token-info.vercel.app/openapi.json",
+    },
+    provider: { name: "dmitrykmak", url: "https://github.com/dmitrykmak" },
+    realm: "tempo-token-info.vercel.app",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /api/service",
+        desc: "Get TIP-20 token metadata (symbol, name, decimals, total supply)",
+        amount: "10000",
+      },
+    ],
+  },
+
+  // ── Tempo Activity Score ─────────────────────────────────────────────────
+  {
+    id: "tempo-activity-score",
+    name: "Tempo Activity Score",
+    url: "https://tempo-activity-score.vercel.app",
+    serviceUrl: "https://tempo-activity-score.vercel.app",
+    description:
+      "Heuristic 0-100 activity score for any Tempo wallet, derived from transaction count and USDC.e balance. No API key, pay-per-request.",
+
+    categories: ["data", "blockchain"],
+    integration: "third-party",
+    tags: ["wallet", "score", "activity", "tempo", "analytics"],
+    status: "active",
+    docs: {
+      homepage: "https://tempo-activity-score.vercel.app",
+      apiReference: "https://tempo-activity-score.vercel.app/openapi.json",
+    },
+    provider: { name: "dmitrykmak", url: "https://github.com/dmitrykmak" },
+    realm: "tempo-activity-score.vercel.app",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /api/service",
+        desc: "Get a 0-100 activity score for a Tempo wallet",
+        amount: "10000",
+      },
+    ],
+  },
 ];

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6689,4 +6689,94 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── Tempo Price Feed ─────────────────────────────────────────────────────
+  {
+    id: "tempo-price-feed",
+    name: "Tempo Price Feed",
+    url: "https://tempo-price-feed-one.vercel.app",
+    serviceUrl: "https://tempo-price-feed-one.vercel.app",
+    description:
+      "Current USD prices for all Tempo stablecoins in a single call. Reads the official Tempo token list and resolves live prices via CoinGecko — no API key, pay-per-request.",
+
+    categories: ["data", "blockchain"],
+    integration: "third-party",
+    tags: ["prices", "stablecoins", "defi", "tempo", "coingecko"],
+    status: "active",
+    docs: {
+      homepage: "https://tempo-price-feed-one.vercel.app",
+      apiReference: "https://tempo-price-feed-one.vercel.app/openapi.json",
+    },
+    provider: { name: "dmitrykmak", url: "https://github.com/dmitrykmak" },
+    realm: "tempo-price-feed-one.vercel.app",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /api/service",
+        desc: "Get current USD prices of all Tempo stablecoins",
+        amount: "10000",
+      },
+    ],
+  },
+
+  // ── Tempo Gas Estimator ──────────────────────────────────────────────────
+  {
+    id: "tempo-gas-estimator",
+    name: "Tempo Gas Estimator",
+    url: "https://tempo-gas-estimator-snowy.vercel.app",
+    serviceUrl: "https://tempo-gas-estimator-snowy.vercel.app",
+    description:
+      "Estimates the stablecoin gas cost of common Tempo operations (transfers, contract calls) from the live gas price — no API key, pay-per-request.",
+
+    categories: ["data", "blockchain"],
+    integration: "third-party",
+    tags: ["gas", "fees", "estimate", "tempo", "infrastructure"],
+    status: "active",
+    docs: {
+      homepage: "https://tempo-gas-estimator-snowy.vercel.app",
+      apiReference: "https://tempo-gas-estimator-snowy.vercel.app/openapi.json",
+    },
+    provider: { name: "dmitrykmak", url: "https://github.com/dmitrykmak" },
+    realm: "tempo-gas-estimator-snowy.vercel.app",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /api/service",
+        desc: "Estimate gas costs on Tempo for common operations",
+        amount: "5000",
+      },
+    ],
+  },
+
+  // ── Random Stable Fact ───────────────────────────────────────────────────
+  {
+    id: "random-stable-fact",
+    name: "Random Stable Fact",
+    url: "https://random-stable-fact-snowy.vercel.app",
+    serviceUrl: "https://random-stable-fact-snowy.vercel.app",
+    description:
+      "Returns a random, sourced fact about stablecoins and the Tempo network on each call — a minimal reference MPP service. No API key, pay-per-request.",
+
+    categories: ["data"],
+    integration: "third-party",
+    tags: ["facts", "stablecoins", "tempo", "trivia"],
+    status: "active",
+    docs: {
+      homepage: "https://random-stable-fact-snowy.vercel.app",
+      apiReference: "https://random-stable-fact-snowy.vercel.app/openapi.json",
+    },
+    provider: { name: "dmitrykmak", url: "https://github.com/dmitrykmak" },
+    realm: "random-stable-fact-snowy.vercel.app",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /api/service",
+        desc: "Get a random stablecoin fact",
+        amount: "5000",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
This PR adds five live, third-party MPP services on Tempo to the directory. All accept USDC.e via the `tempo` charge intent, require no API key, and are registered on MPPScan.

## Services

| Service | Price | Endpoint | Description |
|---|---|---|---|
| **Tempo Price Feed** | \$0.01 | `GET /api/service` | Live USD prices for all Tempo stablecoins (Tempo token list + CoinGecko) |
| **Tempo Gas Estimator** | \$0.005 | `GET /api/service` | Stablecoin gas-cost estimates for common Tempo operations |
| **Tempo Token Info** | \$0.01 | `GET /api/service?token=0x...` | TIP-20 token metadata: symbol, name, decimals, total supply |
| **Tempo Activity Score** | \$0.01 | `GET /api/service?address=0x...` | Heuristic 0-100 wallet activity score |
| **Random Stable Fact** | \$0.005 | `GET /api/service` | A random sourced fact about stablecoins and Tempo |

## Checklist

- [x] Services are **live and accepting payments** via MPP (each returns `402` + `WWW-Authenticate: Payment` unpaid, `200` after payment)
- [x] Added entries to `schemas/services.ts`
- [x] Types pass: `tsc --noEmit` clean
- [x] `node scripts/generate-discovery.ts` succeeds (100 services, all entries present)
- [x] Registered on [MPPScan](https://www.mppscan.com/register)

Each service pins its `realm` to its stable production domain so on-chain stats attribute correctly.