### PR TITLE
docs: document tempo session bootstrap

### DIFF
--- a/src/pages/payment-methods/tempo/session.mdx
+++ b/src/pages/payment-methods/tempo/session.mdx
@@ -28,6 +28,8 @@ There are two current Sessions client APIs:
 | `tempo.session.manager({ account, maxDeposit })` | You want direct lifecycle control with `.fetch()`, `.topUp()`, `.close()`, `.sse()`, or `.ws()`. Use this when your code must explicitly close or top up a channel. |
 | `tempo.sessionLegacy` / `tempo.sessionLegacy.method()` | You still need compatibility with contract-backed Sessions v1. Do not use this for new integrations. |
 
+For browser reloads or app restarts, pass a [`sessionStore`](/sdk/typescript/client/Method.tempo.session-manager#sessionstore) to `tempo.session.manager()`. Servers can pair this with [`bootstrap: true`](/sdk/typescript/server/Method.tempo.session#with-same-route-bootstrap) so clients lazily recover a previous channel from the same protected route before opening a new one.
+
 ## Why Sessions matter in MPP
 
 Traditional payment rails target human purchase flows: a buyer decides, pays, and receives goods. Usage-based billing—the model that powers cloud infrastructure, LLM APIs, and metered services—requires something fundamentally different. It needs payment verification that can keep pace with the service itself.

--- a/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
@@ -531,6 +531,37 @@ type StoredSessionChannel = {
 | `opened` | Whether the channel was open when stored. Closed channels are ignored. |
 | `updatedAt` | Client timestamp for debugging or app-level eviction. |
 
+### `SessionSnapshot`
+
+`SessionSnapshot` is the server-provided channel state used by `bootstrap` and `sessionStore` hydration.
+
+```ts
+type SessionSnapshot = {
+  acceptedCumulative: string
+  chainId: number
+  channelId: Hex
+  closeRequestedAt?: string
+  deposit: string
+  descriptor: ChannelDescriptor
+  escrow: Address
+  requiredCumulative: string
+  settled: string
+  spent: string
+  units?: number
+}
+```
+
+### Snapshot helpers
+
+Use these helpers when you need to read or write the `Payment-Session-Snapshot` header yourself.
+
+```ts
+import { tempo } from 'mppx/client'
+
+const header = tempo.session.manager.serializeSnapshot(snapshot)
+const snapshot = tempo.session.manager.deserializeSnapshot(header)
+```
+
 ### `PaymentResponse`
 
 `session.fetch()` returns a standard `Response` extended with payment metadata:
@@ -543,6 +574,68 @@ type PaymentResponse = Response & {
   receipt: SessionReceipt | null
 }
 ```
+
+### `SessionManagerSseOptions`
+
+`session.sse()` accepts standard `RequestInit` fields plus receipt and cancellation hooks.
+
+```ts
+type SessionManagerSseOptions = RequestInit & {
+  onReceipt?: (receipt: SessionReceipt) => void
+  signal?: AbortSignal
+}
+```
+
+### `SessionManagerWebSocketOptions`
+
+```ts
+type SessionManagerWebSocketOptions = {
+  onReceipt?: (receipt: SessionReceipt) => void
+  protocols?: string | string[]
+  signal?: AbortSignal
+}
+```
+
+### `SessionManagedWebSocket`
+
+`session.ws()` returns a managed WebSocket facade. Payment protocol frames are handled internally; application listeners only receive application messages and close/error/open events.
+
+```ts
+type SessionManagedWebSocket = {
+  readonly bufferedAmount: number
+  readonly extensions: string
+  readonly protocol: string
+  readonly readyState: number
+  readonly url: string
+  onclose: ((event: CloseEvent) => void) | null
+  onerror: ((event: Event) => void) | null
+  onmessage: ((event: MessageEvent<string>) => void) | null
+  onopen: ((event: Event) => void) | null
+  addEventListener(type: string, listener: EventListener, options?: boolean | AddEventListenerOptions): void
+  close(code?: number, reason?: string): void
+  removeEventListener(type: string, listener: EventListener): void
+  send(data: string): void
+}
+```
+
+### `SessionState`
+
+`session.state` exposes the reducer state for UI, logs, or app-level orchestration.
+
+| Status | Meaning |
+|---|---|
+| `idle` | No session challenge has been handled yet. |
+| `challenged` | A `tempo/session` Challenge was selected. |
+| `hydrating` | A server snapshot is being used to restore a reusable channel. |
+| `opening` | An opening channel credential is being created or submitted. |
+| `active` | Channel is open or hydrated and can sign vouchers. |
+| `voucherNeeded` | Server requested a larger voucher and no top-up is required. |
+| `toppingUp` | Server-requested cumulative spend exceeds current deposit. |
+| `settling` | Accepted voucher spend is being settled on-chain. |
+| `closeRequested` | Unilateral close has been requested and withdrawal is not yet available. |
+| `withdrawable` | Close delay elapsed and funds can be withdrawn. |
+| `closing` | Cooperative close credential or close transaction is in flight. |
+| `closed` | Channel close finalized. |
 
 ### `SessionReceipt`
 

--- a/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
@@ -373,6 +373,38 @@ const session = tempo.session.manager({
 </Tab>
 </Tabs>
 
+In browsers, scope the key to the authenticated user and API origin so one user's channel hint is not reused for another user.
+
+```ts
+import type { Session } from 'mppx/tempo'
+import { tempo } from 'mppx/client'
+
+const storageKey = 'mppx-session:api.example.com:user-123'
+
+const sessionStore: Session.Client.SessionStore = {
+  get() {
+    const value = localStorage.getItem(storageKey)
+    return value ? (JSON.parse(value) as Session.Client.StoredSessionChannel) : null
+  },
+  set(channel) {
+    localStorage.setItem(storageKey, JSON.stringify(channel))
+  },
+  delete() {
+    localStorage.removeItem(storageKey)
+  },
+}
+
+const session = tempo.session.manager({
+  account,
+  client,
+  bootstrap: true,
+  maxDeposit: '1',
+  sessionStore,
+})
+```
+
+When `bootstrap: true` is enabled, the manager first sends a same-route `HEAD` request if it has no active channel and no stored channel. Servers that enable bootstrap can answer with a `$0` identity Challenge and then return a `Payment-Session-Snapshot` header. The manager hydrates from that snapshot and persists it through `sessionStore`.
+
 ## Migrate from Legacy Sessions
 
 Legacy Sessions clients used `tempo.sessionLegacy()` or `tempo.sessionLegacy.method()`. Use `tempo.session.manager()` for a standalone manager, or `tempo()` when you want the same fetch wrapper to handle one-time charges and Sessions.
@@ -460,6 +492,44 @@ type SessionManager = {
   ws(input: string | URL, init?: SessionManagerWebSocketOptions): Promise<SessionManagedWebSocket>
 }
 ```
+
+### `SessionStore`
+
+`sessionStore` is optional client persistence for channel hints. It does not authorize payment by itself; the server still verifies the channel snapshot and voucher signatures.
+
+```ts
+type SessionStore = {
+  get(): Promise<StoredSessionChannel | null | undefined> | StoredSessionChannel | null | undefined
+  set(channel: StoredSessionChannel): Promise<void> | void
+  delete?(): Promise<void> | void
+}
+```
+
+### `StoredSessionChannel`
+
+```ts
+type StoredSessionChannel = {
+  channelId: Hex
+  cumulativeAmount: string
+  deposit: string
+  descriptor: ChannelDescriptor
+  escrow: Address
+  chainId: number
+  opened: boolean
+  updatedAt: number
+}
+```
+
+| Field | Description |
+|---|---|
+| `channelId` | Latest known channel ID. Sent as a `Payment-Session` hint on the next request. |
+| `cumulativeAmount` | Latest local cumulative voucher authorization in raw token units. |
+| `deposit` | Latest known deposit in raw token units. |
+| `descriptor` | TIP-1034 descriptor used if the server cannot provide a snapshot. |
+| `escrow` | Escrow precompile address used to derive the channel ID. |
+| `chainId` | Tempo chain ID used to derive the channel ID and voucher domain. |
+| `opened` | Whether the channel was open when stored. Closed channels are ignored. |
+| `updatedAt` | Client timestamp for debugging or app-level eviction. |
 
 ### `PaymentResponse`
 

--- a/src/pages/sdk/typescript/client/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session.mdx
@@ -266,3 +266,35 @@ Maximum deposit in human-readable units. Caps server-suggested channel opens and
 - **Type:** `(entry: ChannelEntry) => void`
 
 Called whenever channel state changes.
+
+## Credential context
+
+Most clients should omit context and let `tempo.session()` open, recover, top up, and voucher automatically from server Challenges. Advanced callers can pass context to `method.createCredential()` for manual credentials or per-call overrides.
+
+```ts
+type SessionContext = {
+  account?: Account
+  action?: 'open' | 'topUp' | 'voucher' | 'close'
+  channelId?: Hex
+  cumulativeAmount?: string
+  cumulativeAmountRaw?: string
+  transaction?: Hex
+  descriptor?: ChannelDescriptor
+  additionalDeposit?: string
+  additionalDepositRaw?: string
+  depositRaw?: string
+}
+```
+
+| Field | Description |
+|---|---|
+| `account` | Account override for this credential only. |
+| `action` | Manual credential action. Omit for automatic session management. |
+| `channelId` | Channel ID to reuse or manually operate on. |
+| `descriptor` | TIP-1034 descriptor required for recovery and manual credentials. |
+| `transaction` | Signed Tempo transaction for manual `open` or `topUp` credentials. |
+| `cumulativeAmount` | Human-readable cumulative voucher authorization, parsed with `decimals`. |
+| `cumulativeAmountRaw` | Raw cumulative voucher authorization. Takes precedence over `cumulativeAmount`. |
+| `additionalDeposit` | Human-readable top-up amount, parsed with `decimals`. |
+| `additionalDepositRaw` | Raw top-up amount. Takes precedence over `additionalDeposit`. |
+| `depositRaw` | Raw opening deposit override for automatic open credentials. |

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -110,6 +110,36 @@ const mppx = Mppx.create({
 
 Use `tempo.sessionLegacy()` only while clients still send Legacy Sessions Credentials.
 
+### With same-route bootstrap
+
+Set `bootstrap: true` and provide `resolveChannelId` when clients should recover a previous channel before opening a new one. Bootstrap uses the protected route itself: the client sends `HEAD`, answers a `$0` Tempo charge Challenge, and the server uses the verified `source` plus request metadata to look up an existing channel.
+
+```ts twoslash
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const store = Store.memory()
+const channelIdsBySource = new Map<string, string>()
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      bootstrap: true,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      store,
+      resolveChannelId({ request, source }) {
+        return (source ? channelIdsBySource.get(source) : undefined) ?? request?.headers.get('Payment-Session') ?? undefined
+      },
+    }),
+  ],
+})
+```
+
+If the resolver returns a known channel ID, the server responds with `Payment-Session` and `Payment-Session-Snapshot`. If it returns `undefined`, the server returns `204` without a snapshot and the client falls back to opening a new channel.
+
 ## Return type
 
 ```ts
@@ -218,6 +248,27 @@ Default recipient address for payments. Defaults to the `account` address.
 - **Type:** `ResolveSessionChannelId`
 
 Function that resolves a reusable channel ID from request identity when no Credential or request channel ID is present.
+
+```ts
+type ResolveSessionChannelId = (
+  parameters: ResolveSessionChannelIdParameters,
+) => Promise<string | null | undefined> | string | null | undefined
+
+type ResolveSessionChannelIdParameters = {
+  request?: {
+    readonly headers: Headers
+    readonly hasBody?: boolean
+    readonly method: string
+    readonly url?: URL
+  }
+  credential: Credential | null | undefined
+  source?: string
+  paymentRequest: SessionPaymentRequestInput
+  store: ChannelStore
+}
+```
+
+Use `source` for identity bootstrap. It is only set after the server verifies the client's zero-amount proof. Use `request.headers` for app session cookies or explicit `Payment-Session` hints. The returned channel ID is treated as a hint; the server still verifies that the channel exists and matches the current payment request.
 
 ### settlementSchedule (optional)
 

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -282,6 +282,8 @@ Server-owned automatic settlement cadence. Clients don't receive or control this
 
 Enable SSE streaming. Pass `true` to enable with defaults, or pass an options object to configure SSE.
 
+When `poll` is enabled, the stream checks the store at `pollingInterval` instead of waiting on store notifications. Use this for runtimes where promises cannot be resolved across request contexts.
+
 ### store (optional)
 
 - **Type:** `Store.AtomicStore`
@@ -315,6 +317,33 @@ Unit type label, such as `"token"`, `"byte"`, or `"request"`.
 
 ## Related
 
+### Snapshot helpers
+
+Use these helpers when you need to read or write the `Payment-Session-Snapshot` header yourself.
+
+```ts
+import { tempo } from 'mppx/server'
+
+const header = tempo.session.serializeSnapshot(snapshot)
+const snapshot = tempo.session.deserializeSnapshot(header)
+```
+
+```ts
+type SessionSnapshot = {
+  acceptedCumulative: string
+  chainId: number
+  channelId: Hex
+  closeRequestedAt?: string
+  deposit: string
+  descriptor: ChannelDescriptor
+  escrow: Address
+  requiredCumulative: string
+  settled: string
+  spent: string
+  units?: number
+}
+```
+
 ### `tempo.session.charge`
 
 Charges against a precompile-backed channel's stored balance outside an HTTP handler.
@@ -324,6 +353,8 @@ import { tempo } from 'mppx/server'
 
 const state = await tempo.session.charge(store, channelId, 10_000n)
 ```
+
+This returns the updated channel state and throws if the channel is missing, closed, or does not have enough unspent deposit.
 
 ### `tempo.session.settle`
 
@@ -335,6 +366,8 @@ import { tempo } from 'mppx/server'
 const txHash = await tempo.session.settle(store, client, channelId)
 ```
 
+The sender must be the channel payee or a nonzero operator. You can pass an account or fee-payer options as the fourth argument.
+
 ### `tempo.session.settleBatch`
 
 Settles multiple precompile-backed channels on-chain.
@@ -344,3 +377,5 @@ import { tempo } from 'mppx/server'
 
 const txHashes = await tempo.session.settleBatch(store, client, channelIds)
 ```
+
+`settleBatch` applies the same validation as `settle` to each channel and returns the settlement transaction hashes in order.


### PR DESCRIPTION
## Summary

- Documented `tempo.session.manager` `sessionStore` usage and `StoredSessionChannel` fields.
- Documented server-side same-route bootstrap with `resolveChannelId` and session snapshot headers.
- Linked the Sessions guide to the client resumption and server bootstrap references.
