### PR TITLE
docs: show explicit mpp secret key

### DIFF
--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -42,6 +42,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 // [!code hl:end]
 
@@ -62,6 +63,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 // [!code hl:end]
 
@@ -82,6 +84,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 // [!code hl:end]
 
@@ -104,6 +107,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 // [!code hl:end]
 
@@ -143,6 +147,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 
 // [!code focus:start]
@@ -193,6 +198,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 
 type IncomingMessage = import('node:http').IncomingMessage
@@ -232,6 +238,7 @@ const mppx = Mppx.create({
     mode: 'push', // [!code focus]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 ```
 
@@ -251,6 +258,7 @@ const mppx = Mppx.create({
     feePayer: privateKeyToAccount('0x…'), // [!code focus]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 ```
 
@@ -265,6 +273,7 @@ const mppx = Mppx.create({
     feePayer: 'https://sponsor.example.com', // [!code focus]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 ```
 
@@ -281,6 +290,7 @@ const mppx = Mppx.create({
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     waitForConfirmation: false, // [!code focus]
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 ```
 
@@ -304,6 +314,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 
 app.get('/resource', mppx.charge({ amount: '0.1' }), (c) => c.json({ data: '...' }))

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -224,6 +224,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 // [!code hl:end]
 
@@ -244,6 +245,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 // [!code hl:end]
 
@@ -264,6 +266,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 // [!code hl:end]
 
@@ -286,6 +289,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 // [!code hl:end]
 
@@ -331,6 +335,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 
 // [!code focus:start]
@@ -387,6 +392,7 @@ const mppx = Mppx.create({
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
   })],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 
 type IncomingMessage = import('node:http').IncomingMessage


### PR DESCRIPTION
## Summary

- Added explicit `secretKey: process.env.MPP_SECRET_KEY!` lines to TypeScript server quickstart examples.
- Mirrored the same guidance in the TypeScript SDK landing page examples.

## Motivation

The mppx server API requires a secret key for HMAC-bound Challenges. The docs should show the same explicit setup as the mppx README update.

Related mppx PR: https://github.com/wevm/mppx/pull/553

## Key design considerations

- Kept existing `MPP_SECRET_KEY` security guidance intact.
- Limited changes to TypeScript server examples that instantiate `Mppx.create()`.