### PR TITLE
docs: clarify proxy route values

### DIFF
--- a/src/pages/sdk/typescript/proxy.mdx
+++ b/src/pages/sdk/typescript/proxy.mdx
@@ -61,6 +61,12 @@ The proxy returns two handlers:
 - **`fetch`** — Fetch API handler. Works with Bun, Deno, Next.js, Hono, Elysia, and SvelteKit.
 - **`listener`** — Node.js request listener. Works with Express, Fastify, and `http.createServer`.
 
+Route values use the current `EndpointMap` shape:
+
+- Use an mppx intent handler like `mppx.charge({ amount: '0.05' })` for paid routes.
+- Use `true` for free passthrough routes.
+- Use a method-specific handler, such as `mppx.tempo.session({ amount, unitType })`, for session-priced routes.
+
 ### Multiple services
 
 Pass multiple services to gate several upstream APIs behind a single proxy.


### PR DESCRIPTION
## Summary

- Documented the current `EndpointMap` route value shapes for proxy routes.
- Clarified paid handlers, free passthrough routes, and session-priced route handlers.

## Motivation

The mppx README now removes stale `stream()` and `free()` examples. The docs should make the current proxy route API explicit so users know which route values are supported.

Related mppx PR: https://github.com/wevm/mppx/pull/554

## Key design considerations

- Kept existing proxy examples intact.
- Added a short route-shape note near the first proxy example.