### PR TITLE
docs: clarify PaymentRequest namespace

### DIFF
--- a/src/pages/sdk/typescript/core/PaymentRequest.from.mdx
+++ b/src/pages/sdk/typescript/core/PaymentRequest.from.mdx
@@ -2,6 +2,10 @@
 
 Creates a payment request from the given parameters.
 
+`PaymentRequest` is the root `mppx` namespace for serialized payment request
+payloads. Server HTTP helpers use the separate `Request` namespace under
+`mppx/server`.
+
 ## Usage
 
 ```ts twoslash


### PR DESCRIPTION
## Summary

- Added a note that `PaymentRequest` is the root `mppx` namespace for payment request payload helpers.
- Clarified that server HTTP request helpers live under `mppx/server`'s `Request` namespace.

## Motivation

The mppx JSDoc now uses `PaymentRequest` consistently. The docs should make the namespace distinction explicit for readers moving between core and server APIs.

Related mppx PR: https://github.com/wevm/mppx/pull/555

## Key design considerations

- Kept existing examples unchanged because they already use `PaymentRequest`.
- Scoped the clarification to the primary `PaymentRequest.from` reference page.