### PR TITLE
docs: recommend lowercase evm namespaces

### DIFF
--- a/src/pages/sdk/typescript/server/Method.evm.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.evm.charge.mdx
@@ -39,6 +39,8 @@ export async function handler(request: Request) {
 
 Use `x402.facilitator` to run x402 exact settlement inline with the MPP route. Use `settle` when you want to verify and settle Credentials yourself.
 
+Use lowercase `evm.assets` and `evm.chains` for known asset and chain metadata. Uppercase aliases remain available for compatibility, but new code should use the lowercase namespaces.
+
 ## Return type
 
 Returns a function that accepts a `Request` and returns a response object with payment status.


### PR DESCRIPTION
## Summary

- Added guidance to use lowercase `evm.assets` and `evm.chains` for known EVM metadata.
- Noted that uppercase aliases remain compatibility exports.

## Motivation

The mppx public API now marks duplicate uppercase aliases as deprecated. The docs should identify the canonical lowercase namespaces for new code.

Related mppx PR: https://github.com/wevm/mppx/pull/556

## Key design considerations

- Kept existing examples unchanged because they already use lowercase namespaces.
- Scoped the note to the EVM charge reference where known asset metadata is introduced.