### PR TITLE
docs: document tempo common helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "accounts": "^0.14.9",
     "hono": "^4.12.23",
     "mermaid": "^11.15.0",
-    "mppx": "https://pkg.pr.new/mppx@530",
+    "mppx": "https://pkg.pr.new/mppx@557",
     "react": "^19",
     "react-dom": "^19",
     "stripe": "^22.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       mppx:
-        specifier: https://pkg.pr.new/mppx@530
-        version: https://pkg.pr.new/mppx@530(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.23)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))
+        specifier: https://pkg.pr.new/mppx@557
+        version: https://pkg.pr.new/mppx@557(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.23)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3))
       react:
         specifier: ^19
         version: 19.2.7
@@ -2984,15 +2984,15 @@ packages:
       hono:
         optional: true
 
-  mppx@https://pkg.pr.new/mppx@530:
-    resolution: {tarball: https://pkg.pr.new/mppx@530}
-    version: 0.6.31
+  mppx@https://pkg.pr.new/mppx@557:
+    resolution: {tarball: https://pkg.pr.new/mppx@557}
+    version: 0.7.0
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.18'
+      hono: '>=4.12.25'
       viem: '>=2.51.0'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
@@ -7158,8 +7158,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@https://pkg.pr.new/mppx@530(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.23)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3)):
+  mppx@https://pkg.pr.new/mppx@557(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.23)(typescript@6.0.3)(viem@2.52.2(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
+      '@stripe/stripe-js': 9.7.0
       incur: 0.4.8
       ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
       viem: 2.52.2(typescript@6.0.3)(zod@4.4.3)
@@ -8252,7 +8253,7 @@ snapshots:
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
       hono: 4.12.23
-      ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
+      ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
       rettime: 0.11.11
       zod: 4.4.3
     transitivePeerDependencies:
@@ -8265,7 +8266,7 @@ snapshots:
 
   webauthx@0.1.2(typescript@6.0.3)(zod@4.4.3):
     dependencies:
-      ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
+      ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
     transitivePeerDependencies:
       - typescript
       - zod

--- a/src/pages/payment-methods/tempo/subscription.mdx
+++ b/src/pages/payment-methods/tempo/subscription.mdx
@@ -161,7 +161,7 @@ Subscription Receipts confirm activation or renewal. The `reference` field is th
 
 ### Server
 
-Register `tempo.subscription()` explicitly. The `tempo()` convenience helper registers charge and session intents, but it doesn't register subscriptions.
+Register `tempo.subscription()` explicitly. The `tempo.common()` helper registers charge and session intents, but it doesn't register subscriptions.
 
 ```ts twoslash
 import { Mppx, Store, tempo } from 'mppx/server'

--- a/src/pages/sdk/typescript/client/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.mdx
@@ -6,13 +6,15 @@ imageDescription: "Handle Tempo payments in TypeScript clients"
 
 import { Tab, Tabs } from 'vocs'
 
-# `tempo` [Register default Tempo intents]
+# `tempo.common` [Register default Tempo intents]
 
-Convenience function that creates both `tempo.charge` and Sessions method intents with shared configuration.
+Explicit alias that creates both `tempo.charge` and Sessions method intents with shared configuration.
+
+Use `tempo.common()` when a client should handle both one-time payments and Sessions through the same fetch wrapper. The older `tempo()` callable form remains available for compatibility, but `tempo.common()` makes it clear that this helper registers the common bundle, not every Tempo intent.
 
 Register [`tempo.subscription`](/sdk/typescript/client/Method.tempo.subscription) separately for recurring payments.
 
-Use this helper when you want `Mppx.create` to handle both one-time charges and current Sessions through the same fetch wrapper. If you need to close, top up, or stream a single channel explicitly, use [`tempo.session.manager()`](/sdk/typescript/client/Method.tempo.session-manager) instead.
+If you need to close, top up, or stream a single channel explicitly, use [`tempo.session.manager()`](/sdk/typescript/client/Method.tempo.session-manager) instead.
 
 :::warning[Legacy Sessions]
 `tempo.session` is the current Sessions implementation. The previous contract-backed flow is Legacy Sessions, also called Sessions v1, and is available as `tempo.sessionLegacy`.
@@ -33,7 +35,7 @@ await provider.request({ method: 'wallet_connect' })
 Mppx.create({
   methods: [
     // [!code focus:start]
-    tempo({
+    tempo.common({
       account: provider.getAccount({ signable: true }),
       getClient: provider.getClient,
     }),
@@ -54,7 +56,7 @@ const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef012345678
 Mppx.create({
   methods: [
     // [!code focus:start]
-    tempo({ account }),
+    tempo.common({ account }),
     // [!code focus:end]
   ],
 })

--- a/src/pages/sdk/typescript/server/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.mdx
@@ -4,9 +4,11 @@ description: "Register Tempo charge and session support in an MPP TypeScript ser
 imageDescription: "Accept Tempo payments in TypeScript servers"
 ---
 
-# `tempo` [Register default Tempo intents]
+# `tempo.common` [Register default Tempo intents]
 
-Convenience function that creates both `tempo.charge` and Sessions method intents with shared configuration.
+Explicit alias that creates both `tempo.charge` and Sessions method intents with shared configuration.
+
+Use `tempo.common()` when a server should accept both one-time payments and Sessions from the same shared Tempo configuration. The older `tempo()` callable form remains available for compatibility, but `tempo.common()` makes it clear that this helper registers the common bundle, not every Tempo intent.
 
 Register [`tempo.subscription`](/sdk/typescript/server/Method.tempo.subscription) separately for recurring payments.
 
@@ -25,7 +27,7 @@ const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef012345678
 Mppx.create({
   methods: [
     // [!code focus:start]
-    tempo({
+    tempo.common({
       account,
       chainId: 4217,
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo


### PR DESCRIPTION
## Summary

- Documented `tempo.common()` as the explicit helper for the shared Tempo charge/session bundle
- Updated client and server examples to use `tempo.common()`
- Clarified that subscriptions still require explicit `tempo.subscription()` registration

## Motivation

Keeps the docs aligned with https://github.com/wevm/mppx/pull/557 and makes the shared helper intent clearer.

## Key design considerations

- Kept `tempo()` mentioned as compatibility context
- Left charge, session, and subscription-specific docs focused on their dedicated helpers