### PR TITLE
docs: prefer nested server handlers

### DIFF
--- a/src/pages/_api/api/agent/directions.ts
+++ b/src/pages/_api/api/agent/directions.ts
@@ -5,7 +5,7 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const destination = url.searchParams.get("to") || "The Coffee Movement";
 
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.002",
     currency: import.meta.env.VITE_DEFAULT_CURRENCY!,
     expires: Expires.minutes(5),

--- a/src/pages/_api/api/agent/location.ts
+++ b/src/pages/_api/api/agent/location.ts
@@ -2,7 +2,7 @@ import { Expires } from "mppx/server";
 import { mppx } from "../../../../mppx.server";
 
 export async function GET(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.001",
     currency: import.meta.env.VITE_DEFAULT_CURRENCY!,
     expires: Expires.minutes(5),

--- a/src/pages/_api/api/agent/reviews.ts
+++ b/src/pages/_api/api/agent/reviews.ts
@@ -5,7 +5,7 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const placeId = url.searchParams.get("place") || "place_001";
 
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.003",
     currency: import.meta.env.VITE_DEFAULT_CURRENCY!,
     expires: Expires.minutes(5),

--- a/src/pages/_api/api/agent/search.ts
+++ b/src/pages/_api/api/agent/search.ts
@@ -5,7 +5,7 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const query = url.searchParams.get("q") || "coffee";
 
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.002",
     currency: import.meta.env.VITE_DEFAULT_CURRENCY!,
     expires: Expires.minutes(5),

--- a/src/pages/_api/api/demo/ascii.ts
+++ b/src/pages/_api/api/demo/ascii.ts
@@ -27,7 +27,7 @@ const asciiArts = [
 ];
 
 export async function GET(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.001",
     description: "ASCII art",
   })(request);

--- a/src/pages/_api/api/demo/image.ts
+++ b/src/pages/_api/api/demo/image.ts
@@ -25,7 +25,7 @@ const imageResults = [
 ];
 
 export async function GET(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.003",
     description: "Image generation",
   })(request);

--- a/src/pages/_api/api/demo/search.ts
+++ b/src/pages/_api/api/demo/search.ts
@@ -70,7 +70,7 @@ const searchResults = [
 ];
 
 export async function GET(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.005",
     description: "Web search",
   })(request);

--- a/src/pages/_api/api/openapi.json.ts
+++ b/src/pages/_api/api/openapi.json.ts
@@ -17,7 +17,7 @@ const discoveryRoute = discovery(mppx, {
   info: { title: "mpp.dev", version: "1.0.0" },
   routes: [
     {
-      handler: mppx.charge({
+      handler: mppx.tempo.charge({
         amount: "0.1",
         currency: USDCe,
         description: "Ping endpoint access",

--- a/src/pages/_api/api/payment-link/photo.ts
+++ b/src/pages/_api/api/payment-link/photo.ts
@@ -1,7 +1,7 @@
 import { mppx } from "../../../../mppx-payment-link.server";
 
 export async function GET(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.01",
     description: "A random unique image",
   })(request);

--- a/src/pages/_api/api/photo.ts
+++ b/src/pages/_api/api/photo.ts
@@ -1,7 +1,7 @@
 import { mppx } from "../../../mppx.server";
 
 export async function GET(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.01",
     description: "Random stock photo",
   })(request);

--- a/src/pages/_api/api/ping/paid.ts
+++ b/src/pages/_api/api/ping/paid.ts
@@ -2,7 +2,7 @@ import { Expires } from "mppx/server";
 import { mppx } from "../../../../mppx.server";
 
 export async function GET(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.1",
     currency: import.meta.env.VITE_DEFAULT_CURRENCY!,
     expires: Expires.minutes(5),

--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -50,7 +50,7 @@ const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY,
 })
 
-app.get('/v1/fortune', mppx.charge({ amount: '0.01' }), (c) => c.json({ fortune: 'You will be rich' }))
+app.get('/v1/fortune', mppx.tempo.charge({ amount: '0.01' }), (c) => c.json({ fortune: 'You will be rich' }))
 
 // [!code hl:start]
 discovery(app, mppx, {
@@ -82,7 +82,7 @@ const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY,
 })
 
-const pay = mppx.charge({ amount: '0.01' })
+const pay = mppx.tempo.charge({ amount: '0.01' })
 app.get('/v1/fortune', pay, (req, res) => res.json({ fortune: 'You will be rich' }))
 
 // [!code hl:start]

--- a/src/pages/advanced/identity.mdx
+++ b/src/pages/advanced/identity.mdx
@@ -92,7 +92,7 @@ After the payment middleware verifies the Credential, extract the client's ident
 import { Credential } from 'mppx'
 
 export async function handler(request: Request) {
-  const result = await mppx.charge({ amount: '1.00' })(request)
+  const result = await mppx.tempo.charge({ amount: '1.00' })(request)
   if (result.status === 402) return result.challenge
 
   const credential = Credential.fromRequest(request)
@@ -109,7 +109,7 @@ The client polls the job endpoint. The server issues a zero-dollar Challenge—t
 
 ```ts [server.ts]
 export async function statusHandler(request: Request) {
-  const result = await mppx.charge({ amount: '0' })(request) // [!code hl]
+  const result = await mppx.tempo.charge({ amount: '0' })(request) // [!code hl]
   if (result.status === 402) return result.challenge
 
   const credential = Credential.fromRequest(request)
@@ -137,7 +137,7 @@ The client pays once to gain access. The server records the public key as an aut
 
 ```ts [server.ts]
 export async function unlockHandler(request: Request) {
-  const result = await mppx.charge({ amount: '50.00' })(request)
+  const result = await mppx.tempo.charge({ amount: '50.00' })(request)
   if (result.status === 402) return result.challenge
 
   const credential = Credential.fromRequest(request)
@@ -153,7 +153,7 @@ Subsequent requests use zero-dollar auth. The server checks the client's identit
 
 ```ts [server.ts]
 export async function accessHandler(request: Request) {
-  const result = await mppx.charge({ amount: '0' })(request) // [!code hl]
+  const result = await mppx.tempo.charge({ amount: '0' })(request) // [!code hl]
   if (result.status === 402) return result.challenge
 
   const credential = Credential.fromRequest(request)
@@ -179,7 +179,7 @@ The agent pays to kick off generation. The server returns a pipeline ID tied to 
 
 ```ts [server.ts]
 export async function createPipelineHandler(request: Request) {
-  const result = await mppx.charge({ amount: '5.00' })(request)
+  const result = await mppx.tempo.charge({ amount: '5.00' })(request)
   if (result.status === 402) return result.challenge
 
   const credential = Credential.fromRequest(request)
@@ -195,7 +195,7 @@ The agent polls each stage of the pipeline. Every request proves the same identi
 
 ```ts [server.ts]
 export async function stageHandler(request: Request) {
-  const result = await mppx.charge({ amount: '0' })(request) // [!code hl]
+  const result = await mppx.tempo.charge({ amount: '0' })(request) // [!code hl]
   if (result.status === 402) return result.challenge
 
   const credential = Credential.fromRequest(request)
@@ -216,7 +216,7 @@ The final download also uses zero-dollar auth—the server already collected pay
 
 ```ts [server.ts]
 export async function resultHandler(request: Request) {
-  const result = await mppx.charge({ amount: '0' })(request) // [!code hl]
+  const result = await mppx.tempo.charge({ amount: '0' })(request) // [!code hl]
   if (result.status === 402) return result.challenge
 
   const credential = Credential.fromRequest(request)

--- a/src/pages/guides/accept-card-payments.mdx
+++ b/src/pages/guides/accept-card-payments.mdx
@@ -101,7 +101,7 @@ const mppx = Mppx.create({
 
 ### Add a paid endpoint
 
-Use `mppx.charge` to gate your endpoint. Set the `amount` in the smallest currency unit (cents for USD), and specify `currency` and `decimals`.
+Use `mppx.stripe.charge` to gate your endpoint. Set the `amount` in the smallest currency unit (cents for USD), and specify `currency` and `decimals`.
 
 ```ts twoslash
 import Stripe from 'stripe'
@@ -121,7 +121,7 @@ const mppx = Mppx.create({
 
 // ---cut---
 export async function handler(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.stripe.charge({
     amount: '100',
     currency: 'usd',
     decimals: 2,

--- a/src/pages/guides/monetize-mcp-server.mdx
+++ b/src/pages/guides/monetize-mcp-server.mdx
@@ -131,7 +131,7 @@ await server.connect(transport)
 
 ### Add `.charge` to the tool handler
 
-Call `mppx.charge` inside the tool handler. If the agent hasn't paid, throw the Challenge. Otherwise, attach a Receipt to the result.
+Call `mppx.tempo.charge` inside the tool handler. If the agent hasn't paid, throw the Challenge. Otherwise, attach a Receipt to the result.
 
 ```ts [server.ts]
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
@@ -154,7 +154,7 @@ server.registerTool(
   'search',
   { description: 'Search the web' },
   async ({ query }, extra) => {
-    const result = await mppx.charge({ // [!code ++]
+    const result = await mppx.tempo.charge({ // [!code ++]
       amount: '0.01', // [!code ++]
       description: 'Web search query', // [!code ++]
     })(extra) // [!code ++]
@@ -174,7 +174,7 @@ await server.connect(mcpTransport)
 
 Three lines turn a free tool into a paid one:
 
-- **`mppx.charge()`** checks for a valid Credential in the tool call's `_meta`
+- **`mppx.tempo.charge()`** checks for a valid Credential in the tool call's `_meta`
 - **`throw result.challenge`** sends a `-32042` error with the payment requirements
 - **`result.withReceipt()`** attaches a Receipt to the tool result
 
@@ -192,7 +192,7 @@ $ echo '{"method":"tools/call","params":{"name":"search","arguments":{"query":"h
 
 ## Multiple tools with different prices
 
-Set different prices per tool. Free tools don't need `mppx.charge` at all.
+Set different prices per tool. Free tools don't need `mppx.tempo.charge` at all.
 
 ```ts [server.ts]
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
@@ -225,7 +225,7 @@ server.registerTool(
   'search',
   { description: 'Search the web' },
   async ({ query }, extra) => {
-    const result = await mppx.charge({ amount: '0.01' })(extra)
+    const result = await mppx.tempo.charge({ amount: '0.01' })(extra)
     if (result.status === 402) throw result.challenge
     return result.withReceipt({
       content: [{ type: 'text', text: `Results for: ${query}` }],
@@ -238,7 +238,7 @@ server.registerTool(
   'generate-image',
   { description: 'Generate an image from a prompt' },
   async ({ prompt }, extra) => {
-    const result = await mppx.charge({ amount: '0.10' })(extra)
+    const result = await mppx.tempo.charge({ amount: '0.10' })(extra)
     if (result.status === 402) throw result.challenge
     return result.withReceipt({
       content: [{ type: 'text', text: `Image generated for: ${prompt}` }],

--- a/src/pages/guides/one-time-payments.mdx
+++ b/src/pages/guides/one-time-payments.mdx
@@ -10,8 +10,8 @@ import { TerminalPhoto } from '../../components/TerminalPhoto'
 
 # Accept one-time payments [Charge per request with a payment-gated API]
 
-Build a payment-gated image generation API that charges $0.01 per request using `mppx`. 
-The server returns a random photo from [Picsum](https://picsum.photos) behind a paywall, 
+Build a payment-gated image generation API that charges $0.01 per request using `mppx`.
+The server returns a random photo from [Picsum](https://picsum.photos) behind a paywall,
 but you could swap in an AI model like [OpenAI Image Generation](https://developers.openai.com/api/reference/resources/images) instead.
 
 ## Demo
@@ -28,9 +28,9 @@ Paste this into your coding agent to build the entire guide in one prompt:
 
 <PromptBlock>
 {`Use https://mpp.dev/guides/one-time-payments.md as reference.
-Add mppx to my app with a payment-gated photo endpoint 
-that charges $0.01 per request using the Tempo payment method with 
-PathUSD. When payment is verified, fetch a random photo from 
+Add mppx to my app with a payment-gated photo endpoint
+that charges $0.01 per request using the Tempo payment method with
+PathUSD. When payment is verified, fetch a random photo from
 https://picsum.photos/1024/1024 and return the URL as JSON.`}
 </PromptBlock>
 
@@ -103,7 +103,7 @@ export const GET = async () => {
 
 ### Add `.charge` to the route handler
 
-Add payment verification using `mppx.charge` as route middleware. 
+Add payment verification using `mppx.tempo.charge` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [app/api/photo/route.ts]
@@ -121,7 +121,7 @@ export const mppx = Mppx.create({
 
 // [!code focus:start]
 export const GET =
-  mppx.charge({ amount: '0.01', description: 'Random stock photo' }) // [!code ++]
+  mppx.tempo.charge({ amount: '0.01', description: 'Random stock photo' }) // [!code ++]
   (async () => {
     const res = await fetch('https://picsum.photos/1024/1024')
     return Response.json({ url: res.url })
@@ -136,7 +136,7 @@ export const GET =
 $ npx mppx account create
 
 # Make a paid request
-$ npx mppx http://localhost:3000/api/photo 
+$ npx mppx http://localhost:3000/api/photo
 ```
 
 ::::
@@ -211,7 +211,7 @@ app.get('/api/photo', async (c) => {
 
 ### Add `.charge` to the route handler
 
-Add payment verification using `mppx.charge` as route middleware.
+Add payment verification using `mppx.tempo.charge` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [server.ts]
@@ -233,7 +233,7 @@ const mppx = Mppx.create({
 // [!code focus:start]
 app.get(
   '/api/photo',
-  mppx.charge({ amount: '0.01', description: 'Random stock photo' }), // [!code ++]
+  mppx.tempo.charge({ amount: '0.01', description: 'Random stock photo' }), // [!code ++]
   async (c) => {
     const res = await fetch('https://picsum.photos/1024/1024')
     return c.json({ url: res.url })
@@ -249,7 +249,7 @@ app.get(
 $ npx mppx account create
 
 # Make a paid request
-$ npx mppx http://localhost:3000/api/photo 
+$ npx mppx http://localhost:3000/api/photo
 ```
 
 ::::
@@ -320,7 +320,7 @@ export default {
 
 ### Add `.charge` to the route handler
 
-Add payment verification using `mppx.charge`. If the status is `402`, return the Challenge. Otherwise, fetch the photo and attach a Receipt to the response.
+Add payment verification using `mppx.tempo.charge`. If the status is `402`, return the Challenge. Otherwise, fetch the photo and attach a Receipt to the response.
 
 ```ts [src/index.ts]
 import crypto from 'crypto'
@@ -338,7 +338,7 @@ const mppx = Mppx.create({
 // [!code focus:start]
 export default {
   async fetch(request: Request) {
-    const result = await mppx.charge({ // [!code ++]
+    const result = await mppx.tempo.charge({ // [!code ++]
       amount: '0.01', // [!code ++]
       description: 'Random stock photo', // [!code ++]
     })(request) // [!code ++]
@@ -359,7 +359,7 @@ export default {
 $ npx mppx account create
 
 # Make a paid request
-$ npx mppx http://localhost:8787 
+$ npx mppx http://localhost:8787
 ```
 
 ::::
@@ -434,7 +434,7 @@ app.get('/api/photo', async (req, res) => {
 
 ### Add `.charge` to the route handler
 
-Add payment verification using `mppx.charge` as route middleware.
+Add payment verification using `mppx.tempo.charge` as route middleware.
 The handler runs only after payment is verified.
 
 ```ts [server.ts]
@@ -456,7 +456,7 @@ const mppx = Mppx.create({
 // [!code focus:start]
 app.get(
   '/api/photo',
-  mppx.charge({ amount: '0.01', description: 'Random stock photo' }), // [!code ++]
+  mppx.tempo.charge({ amount: '0.01', description: 'Random stock photo' }), // [!code ++]
   async (req, res) => {
     const response = await fetch('https://picsum.photos/1024/1024')
     res.json({ url: response.url })
@@ -472,7 +472,7 @@ app.get(
 $ npx mppx account create
 
 # Make a paid request
-$ npx mppx http://localhost:3000/api/photo 
+$ npx mppx http://localhost:3000/api/photo
 ```
 
 ::::
@@ -548,7 +548,7 @@ Bun.serve({
 
 ### Add `.charge` to the route handler
 
-Add payment verification using `mppx.charge`. If the status is `402`, return the Challenge. Otherwise, fetch the photo and attach a Receipt to the response.
+Add payment verification using `mppx.tempo.charge`. If the status is `402`, return the Challenge. Otherwise, fetch the photo and attach a Receipt to the response.
 
 ```ts [server.ts]
 import crypto from 'crypto'
@@ -566,7 +566,7 @@ const mppx = Mppx.create({
 // [!code focus:start]
 Bun.serve({
   async fetch(request) {
-    const result = await mppx.charge({ // [!code ++]
+    const result = await mppx.tempo.charge({ // [!code ++]
       amount: '0.01', // [!code ++]
       description: 'Random stock photo', // [!code ++]
     })(request) // [!code ++]

--- a/src/pages/guides/payment-links.mdx
+++ b/src/pages/guides/payment-links.mdx
@@ -83,7 +83,7 @@ export const mppx = Mppx.create({
 
 ### Create the `/api/photo` route
 
-Create the photo route with `mppx.charge`. Browsers see a payment page; programmatic clients get the standard `402` flow.
+Create the photo route with `mppx.tempo.charge`. Browsers see a payment page; programmatic clients get the standard `402` flow.
 
 ```ts [app/api/photo/route.ts]
 import crypto from 'crypto'
@@ -101,7 +101,7 @@ export const mppx = Mppx.create({
 
 // [!code focus:start]
 export const GET =
-  mppx.charge({ amount: '0.01', description: 'Random stock photo' })
+  mppx.tempo.charge({ amount: '0.01', description: 'Random stock photo' })
   (async () => {
     const res = await fetch('https://picsum.photos/1024/1024')
     return Response.json({ url: res.url })
@@ -180,7 +180,7 @@ const mppx = Mppx.create({
 // [!code focus:start]
 app.get(
   '/api/photo',
-  mppx.charge({ amount: '0.01', description: 'Random stock photo' }),
+  mppx.tempo.charge({ amount: '0.01', description: 'Random stock photo' }),
   async (c) => {
     const res = await fetch('https://picsum.photos/1024/1024')
     return c.json({ url: res.url })
@@ -258,7 +258,7 @@ const mppx = Mppx.create({
 // [!code focus:start]
 app.get(
   '/api/photo',
-  mppx.charge({ amount: '0.01', description: 'Random stock photo' }),
+  mppx.tempo.charge({ amount: '0.01', description: 'Random stock photo' }),
   async (req, res) => {
     const response = await fetch('https://picsum.photos/1024/1024')
     res.json({ url: response.url })
@@ -337,7 +337,7 @@ const mppx = Mppx.create({
 // [!code focus:start]
 Bun.serve({
   async fetch(request) {
-    const result = await mppx.charge({
+    const result = await mppx.tempo.charge({
       amount: '0.01',
       description: 'Random stock photo',
     })(request)

--- a/src/pages/guides/proxy-existing-service.mdx
+++ b/src/pages/guides/proxy-existing-service.mdx
@@ -77,7 +77,7 @@ const proxy = Proxy.create({
       bearer: process.env.WEATHER_API_KEY!, // [!code hl]
       description: 'Weather forecast API',
       routes: {
-        'GET /v1/forecast': mppx.charge({ amount: '0.01' }),
+        'GET /v1/forecast': mppx.tempo.charge({ amount: '0.01' }),
         'GET /v1/status': true, // [!code hl]
       },
       title: 'Weather API',
@@ -107,8 +107,8 @@ const proxy = Proxy.create({
       bearer: process.env.WEATHER_API_KEY!,
       description: 'Weather forecast API',
       routes: {
-        'GET /v1/forecast': mppx.charge({ amount: '0.01' }), // [!code focus]
-        'GET /v1/historical/:date': mppx.charge({ amount: '0.05' }), // [!code focus]
+        'GET /v1/forecast': mppx.tempo.charge({ amount: '0.01' }), // [!code focus]
+        'GET /v1/historical/:date': mppx.tempo.charge({ amount: '0.05' }), // [!code focus]
         'GET /v1/status': true, // [!code focus]
       },
       title: 'Weather API',
@@ -137,8 +137,8 @@ const proxy = Proxy.create({
       bearer: process.env.WEATHER_API_KEY!,
       description: 'Weather forecast API',
       routes: {
-        'GET /v1/forecast': mppx.charge({ amount: '0.01' }),
-        'GET /v1/historical/:date': mppx.charge({ amount: '0.05' }),
+        'GET /v1/forecast': mppx.tempo.charge({ amount: '0.01' }),
+        'GET /v1/historical/:date': mppx.tempo.charge({ amount: '0.05' }),
         'GET /v1/status': true,
       },
       title: 'Weather API',
@@ -192,14 +192,14 @@ const proxy = Proxy.create({
       apiKey: process.env.OPENAI_API_KEY!,
       routes: {
         'GET /v1/models': true,
-        'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
+        'POST /v1/chat/completions': mppx.tempo.charge({ amount: '0.05' }),
       },
     }),
     Service.from('internal', { // [!code hl]
       baseUrl: 'https://api.internal.example.com',
       headers: { 'X-API-Key': process.env.INTERNAL_API_KEY! }, // [!code hl]
       routes: {
-        'POST /v1/analyze': mppx.charge({ amount: '0.10' }),
+        'POST /v1/analyze': mppx.tempo.charge({ amount: '0.10' }),
       },
     }),
 // [!code focus:end]

--- a/src/pages/guides/split-payments.mdx
+++ b/src/pages/guides/split-payments.mdx
@@ -30,7 +30,7 @@ Split amounts are in human-readable units, the same as the top-level `amount`. T
 
 ## Server
 
-Add a `splits` array to any `mppx.charge` call. Each entry specifies a `recipient` and `amount`.
+Add a `splits` array to any `mppx.tempo.charge` call. Each entry specifies a `recipient` and `amount`.
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'
@@ -38,7 +38,7 @@ import { Mppx, tempo } from 'mppx/server'
 const mppx = Mppx.create({ methods: [tempo.charge()] })
 // ---cut---
 export async function handler(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: '1.00',
     currency: '0x20c0000000000000000000000000000000000000', // pathUSD
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', // seller
@@ -67,7 +67,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 declare const request: Request
 // ---cut---
-const result = await mppx.charge({
+const result = await mppx.tempo.charge({
   amount: '1.00',
   currency: '0x20c0000000000000000000000000000000000000', // pathUSD
   memo: '0x6f726465722d313233', // order-123
@@ -93,7 +93,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 declare const request: Request
 // ---cut---
-const result = await mppx.charge({
+const result = await mppx.tempo.charge({
   amount: '1.00',
   currency: '0x20c0000000000000000000000000000000000000', // pathUSD
   feePayer: true, // [!code hl]

--- a/src/pages/payment-methods/lightning/charge.mdx
+++ b/src/pages/payment-methods/lightning/charge.mdx
@@ -29,7 +29,7 @@ const mppx = Mppx.create({
 })
 
 export async function handler(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.spark.charge({
     amount: '100',
     currency: 'BTC',
     description: 'Premium API access',
@@ -52,7 +52,7 @@ const mppx = Mppx.create({
 })
 
 export async function handler(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.spark.charge({
     amount: '100',
     currency: 'BTC',
     expires: Expires.minutes(10), // [!code hl]

--- a/src/pages/payment-methods/monad/charge.mdx
+++ b/src/pages/payment-methods/monad/charge.mdx
@@ -26,7 +26,7 @@ const mppx = Mppx.create({
 });
 
 export async function handler(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.monad.charge({
     amount: "0.1",
     currency: "0x754704Bc059F8C67012fEd69BC8A327a5aafb603", // USDC
     recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",

--- a/src/pages/payment-methods/stellar/charge.mdx
+++ b/src/pages/payment-methods/stellar/charge.mdx
@@ -63,7 +63,7 @@ app.get('/my-service', async (req, res) => {
     headers: new Headers(req.headers as Record<string, string>),
   })
 
-  const result = await mppx.charge({
+  const result = await mppx.stellar.charge({
     amount: '0.01',
     description: 'Premium API access',
   })(webReq)

--- a/src/pages/payment-methods/stripe/charge.mdx
+++ b/src/pages/payment-methods/stripe/charge.mdx
@@ -40,7 +40,7 @@ const mppx = Mppx.create({
 })
 
 export async function handler(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.stripe.charge({
     amount: '1',
     currency: 'usd',
     decimals: 2,

--- a/src/pages/payment-methods/tempo/charge.mdx
+++ b/src/pages/payment-methods/tempo/charge.mdx
@@ -18,7 +18,7 @@ This method is best for single API calls, content access, or one-off purchases.
 
 ## Server
 
-Use [`mppx.charge`](/sdk/typescript/server/Method.tempo.charge) to gate any endpoint behind a one-time payment. The method handles Challenge generation, Credential verification, transaction broadcast for paid requests, and Receipt creation.
+Use [`mppx.tempo.charge`](/sdk/typescript/server/Method.tempo.charge) to gate any endpoint behind a one-time payment. The method handles Challenge generation, Credential verification, transaction broadcast for paid requests, and Receipt creation.
 
 ```ts twoslash
 import { Mppx, tempo } from "mppx/server";
@@ -28,7 +28,7 @@ const mppx = Mppx.create({
 });
 
 export async function handler(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.1",
     currency: "0x20c0000000000000000000000000000000000000",
     recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -50,7 +50,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] });
 import { Expires } from "mppx";
 
 export async function handler(request: Request) {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: "0.1",
     currency: "0x20c0000000000000000000000000000000000000",
     expires: Expires.minutes(10), // [!code hl]
@@ -71,7 +71,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] });
 
 declare const request: Request;
 // ---cut---
-const result = await mppx.charge({
+const result = await mppx.tempo.charge({
   amount: "0.1",
   currency: "0x20c0000000000000000000000000000000000000",
   feePayer: true, // [!code hl]
@@ -92,7 +92,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] });
 
 declare const request: Request;
 // ---cut---
-const result = await mppx.charge({
+const result = await mppx.tempo.charge({
   amount: "0", // [!code hl]
   currency: "0x20c0000000000000000000000000000000000000",
   recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -114,7 +114,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] });
 
 declare const request: Request;
 // ---cut---
-const result = await mppx.charge({
+const result = await mppx.tempo.charge({
   amount: "1.00",
   currency: "0x20c0000000000000000000000000000000000000", // pathUSD
   recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", // seller
@@ -146,7 +146,7 @@ const mppx = Mppx.create({
 
 declare const request: Request;
 // ---cut---
-const result = await mppx.charge({
+const result = await mppx.tempo.charge({
   amount: "0.1",
   currency: "0x20c0000000000000000000000000000000000000",
   recipient: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -176,7 +176,7 @@ export async function handler(request: Request) {
     ],
   });
 
-  const result = await mppx.charge({ amount: "0.01" })(request);
+  const result = await mppx.tempo.charge({ amount: "0.01" })(request);
  
   if (result.status === 402) return result.challenge;
  

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -45,8 +45,8 @@ const mppx = Mppx.create({
 })
 // [!code hl:end]
 
-export const GET = 
-  mppx.charge({ amount: '0.1' }) // [!code hl]
+export const GET =
+  mppx.tempo.charge({ amount: '0.1' }) // [!code hl]
   (() => Response.json({ data: '...' }))
 ```
 
@@ -66,8 +66,8 @@ const mppx = Mppx.create({
 // [!code hl:end]
 
 app.get(
-  '/resource', 
-  mppx.charge({ amount: '0.1' }), // [!code hl]
+  '/resource',
+  mppx.tempo.charge({ amount: '0.1' }), // [!code hl]
   (c) => c.json({ data: '...' }),
 )
 ```
@@ -87,7 +87,7 @@ const mppx = Mppx.create({
 
 const app = new Elysia()
   .guard(
-    { beforeHandle: mppx.charge({ amount: '0.1' }) }, // [!code hl]
+    { beforeHandle: mppx.tempo.charge({ amount: '0.1' }) }, // [!code hl]
     (app) => app.get('/resource', () => ({ data: '...' })),
   )
 ```
@@ -108,8 +108,8 @@ const mppx = Mppx.create({
 // [!code hl:end]
 
 app.get(
-  '/resource', 
-  mppx.charge({ amount: '0.1' }), // [!code hl]
+  '/resource',
+  mppx.tempo.charge({ amount: '0.1' }), // [!code hl]
   (req, res) => res.json({ data: '...' }))
 ```
 
@@ -119,8 +119,8 @@ app.get(
 You can also override `currency` and `recipient` per call if different routes need different payment configurations.
 
 ```ts
-mppx.charge({ 
-  amount: '0.1', 
+mppx.tempo.charge({
+  amount: '0.1',
   currency: '0x…', // [!code ++]
   recipient: '0x…', // [!code ++]
 })
@@ -146,16 +146,16 @@ const mppx = Mppx.create({
 })
 
 // [!code focus:start]
-export async function handler(request: Request) { 
-  const response = await mppx.charge({ amount: '0.1' })(request) 
+export async function handler(request: Request) {
+  const response = await mppx.tempo.charge({ amount: '0.1' })(request)
   // [!code focus:end]
 
-  // Payment required: send 402 response with challenge 
-  if (response.status === 402) return response.challenge 
+  // Payment required: send 402 response with challenge
+  if (response.status === 402) return response.challenge
 
-  // Payment verified: attach receipt and return resource 
-  return response.withReceipt(Response.json({ data: '...' })) 
-} 
+  // Payment verified: attach receipt and return resource
+  return response.withReceipt(Response.json({ data: '...' }))
+}
 ```
 
 :::info[Currency and recipient values]
@@ -171,11 +171,11 @@ The Fetch API is compatible with most server frameworks, including: [Hono](https
 You can also override `currency` and `recipient` per call if different routes need different payment configurations.
 
 ```ts
-const response = await mppx.charge({ 
-  amount: '0.1', 
+const response = await mppx.tempo.charge({
+  amount: '0.1',
   currency: '0x…', // [!code ++]
   recipient: '0x…', // [!code ++]
-})(request) 
+})(request)
 ```
 :::
 
@@ -198,17 +198,17 @@ const mppx = Mppx.create({
 type IncomingMessage = import('node:http').IncomingMessage
 type ServerResponse = import('node:http').ServerResponse
 // ---cut---
-export async function handler(req: IncomingMessage, res: ServerResponse) { 
+export async function handler(req: IncomingMessage, res: ServerResponse) {
   const response = await Mppx.toNodeListener( // [!code ++]
-    mppx.charge({ amount: '0.1' })
+    mppx.tempo.charge({ amount: '0.1' })
   )(req, res) // [!code ++]
 
-  // Payment required: send 402 response with challenge 
-  if (response.status === 402) return response.challenge 
+  // Payment required: send 402 response with challenge
+  if (response.status === 402) return response.challenge
 
-  // Payment verified: attach receipt and return resource 
-  return response.withReceipt(Response.json({ data: '...' })) 
-} 
+  // Payment verified: attach receipt and return resource
+  return response.withReceipt(Response.json({ data: '...' }))
+}
 ```
 
 
@@ -306,7 +306,7 @@ const mppx = Mppx.create({
   })],
 })
 
-app.get('/resource', mppx.charge({ amount: '0.1' }), (c) => c.json({ data: '...' }))
+app.get('/resource', mppx.tempo.charge({ amount: '0.1' }), (c) => c.json({ data: '...' }))
 
 // [!code hl:start]
 discovery(app, mppx, {

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -227,8 +227,8 @@ const mppx = Mppx.create({
 })
 // [!code hl:end]
 
-export const GET = 
-  mppx.charge({ amount: '0.1' }) // [!code hl]
+export const GET =
+  mppx.tempo.charge({ amount: '0.1' }) // [!code hl]
   (() => Response.json({ data: '...' }))
 ```
 
@@ -248,8 +248,8 @@ const mppx = Mppx.create({
 // [!code hl:end]
 
 app.get(
-  '/resource', 
-  mppx.charge({ amount: '0.1' }), // [!code hl]
+  '/resource',
+  mppx.tempo.charge({ amount: '0.1' }), // [!code hl]
   (c) => c.json({ data: '...' }),
 )
 ```
@@ -269,7 +269,7 @@ const mppx = Mppx.create({
 
 const app = new Elysia()
   .guard(
-    { beforeHandle: mppx.charge({ amount: '0.1' }) }, // [!code hl]
+    { beforeHandle: mppx.tempo.charge({ amount: '0.1' }) }, // [!code hl]
     (app) => app.get('/resource', () => ({ data: '...' })),
   )
 ```
@@ -290,8 +290,8 @@ const mppx = Mppx.create({
 // [!code hl:end]
 
 app.get(
-  '/resource', 
-  mppx.charge({ amount: '0.1' }), // [!code hl]
+  '/resource',
+  mppx.tempo.charge({ amount: '0.1' }), // [!code hl]
   (req, res) => res.json({ data: '...' }))
 ```
 
@@ -301,8 +301,8 @@ app.get(
 You can also override `currency` and `recipient` per call if different routes need different payment configurations.
 
 ```ts
-mppx.charge({ 
-  amount: '0.1', 
+mppx.tempo.charge({
+  amount: '0.1',
   currency: '0x…', // [!code ++]
   recipient: '0x…', // [!code ++]
 })
@@ -334,16 +334,16 @@ const mppx = Mppx.create({
 })
 
 // [!code focus:start]
-export async function handler(request: Request) { 
-  const response = await mppx.charge({ amount: '0.1' })(request) 
+export async function handler(request: Request) {
+  const response = await mppx.tempo.charge({ amount: '0.1' })(request)
   // [!code focus:end]
 
-  // Payment required: send 402 response with challenge 
-  if (response.status === 402) return response.challenge 
+  // Payment required: send 402 response with challenge
+  if (response.status === 402) return response.challenge
 
-  // Payment verified: attach receipt and return resource 
-  return response.withReceipt(Response.json({ data: '...' })) 
-} 
+  // Payment verified: attach receipt and return resource
+  return response.withReceipt(Response.json({ data: '...' }))
+}
 ```
 
 :::info[Currency and recipient values]
@@ -359,11 +359,11 @@ The Fetch API is compatible with most server frameworks, including: [Hono](https
 You can also override `currency` and `recipient` per call if different routes need different payment configurations.
 
 ```ts
-const response = await mppx.charge({ 
-  amount: '0.1', 
+const response = await mppx.tempo.charge({
+  amount: '0.1',
   currency: '0x…', // [!code ++]
   recipient: '0x…', // [!code ++]
-})(request) 
+})(request)
 ```
 :::
 
@@ -392,17 +392,17 @@ const mppx = Mppx.create({
 type IncomingMessage = import('node:http').IncomingMessage
 type ServerResponse = import('node:http').ServerResponse
 // ---cut---
-export async function handler(req: IncomingMessage, res: ServerResponse) { 
+export async function handler(req: IncomingMessage, res: ServerResponse) {
   const response = await Mppx.toNodeListener( // [!code ++]
-    mppx.charge({ amount: '0.1' })
+    mppx.tempo.charge({ amount: '0.1' })
   )(req, res) // [!code ++]
 
-  // Payment required: send 402 response with challenge 
-  if (response.status === 402) return response.challenge 
+  // Payment required: send 402 response with challenge
+  if (response.status === 402) return response.challenge
 
-  // Payment verified: attach receipt and return resource 
-  return response.withReceipt(Response.json({ data: '...' })) 
-} 
+  // Payment verified: attach receipt and return resource
+  return response.withReceipt(Response.json({ data: '...' }))
+}
 ```
 
 </div>

--- a/src/pages/sdk/typescript/middlewares/elysia.mdx
+++ b/src/pages/sdk/typescript/middlewares/elysia.mdx
@@ -38,7 +38,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 const app = new Elysia()
   .guard(
-    { beforeHandle: mppx.charge({ amount: '1' }) },
+    { beforeHandle: mppx.tempo.charge({ amount: '1' }) },
     (app) => app.get('/premium', () => ({ data: 'paid content' })),
   )
 ```
@@ -54,7 +54,7 @@ import { Mppx, tempo } from 'mppx/elysia'
 const mppx = Mppx.create({ methods: [tempo.charge()] }) // [!code hl]
 
 const app = new Elysia()
-  .onBeforeHandle(mppx.charge({ amount: '1' })) // [!code hl]
+  .onBeforeHandle(mppx.tempo.charge({ amount: '1' })) // [!code hl]
   .get('/premium', () => ({ data: 'paid content' }))
   .get('/another', () => ({ data: 'also paid' }))
 ```

--- a/src/pages/sdk/typescript/middlewares/express.mdx
+++ b/src/pages/sdk/typescript/middlewares/express.mdx
@@ -39,7 +39,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] }) // [!code hl]
 
 app.get(
   '/premium', 
-  mppx.charge({ amount: '1' }), // [!code hl]
+  mppx.tempo.charge({ amount: '1' }), // [!code hl]
   (req, res) => res.json({ data: 'paid content' }),
 )
 ```
@@ -89,7 +89,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 app.get(
   '/premium',
-  mppx.charge({ amount: '1' }),
+  mppx.tempo.charge({ amount: '1' }),
   (req, res) => {
     const credential = Credential.deserialize(req.headers.authorization!)
     const payer = credential.source // "did:pkh:eip155:1:0x..."

--- a/src/pages/sdk/typescript/middlewares/hono.mdx
+++ b/src/pages/sdk/typescript/middlewares/hono.mdx
@@ -39,7 +39,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] }) // [!code hl]
 
 app.get(
   '/premium', 
-  mppx.charge({ amount: '1' }), // [!code hl]
+  mppx.tempo.charge({ amount: '1' }), // [!code hl]
   (c) => c.json({ data: 'paid content' }),
 )
 ```
@@ -89,7 +89,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 app.get(
   '/premium',
-  mppx.charge({ amount: '1' }),
+  mppx.tempo.charge({ amount: '1' }),
   (c) => {
     const credential = Credential.deserialize(c.req.header('Authorization')!)
     const payer = credential.source // "did:pkh:eip155:1:0x..."

--- a/src/pages/sdk/typescript/middlewares/nextjs.mdx
+++ b/src/pages/sdk/typescript/middlewares/nextjs.mdx
@@ -36,7 +36,7 @@ import { Mppx, tempo } from 'mppx/nextjs'
 const mppx = Mppx.create({ methods: [tempo.charge()] }) // [!code hl]
 
 export const GET = 
-  mppx.charge({ amount: '1' }) // [!code hl]
+  mppx.tempo.charge({ amount: '1' }) // [!code hl]
   (() => Response.json({ data: 'paid content' }))
 ```
 
@@ -78,7 +78,7 @@ import { Mppx, tempo } from 'mppx/nextjs'
 const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 export const GET =
-  mppx.charge({ amount: '1' })
+  mppx.tempo.charge({ amount: '1' })
   ((request) => {
     const credential = Credential.deserialize(request.headers.get('Authorization')!)
     const payer = credential.source // "did:pkh:eip155:1:0x..."

--- a/src/pages/sdk/typescript/proxy.mdx
+++ b/src/pages/sdk/typescript/proxy.mdx
@@ -41,7 +41,7 @@ const proxy = Proxy.create({
     openai({
       apiKey: process.env.OPENAI_API_KEY!,
       routes: {
-        'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
+        'POST /v1/chat/completions': mppx.tempo.charge({ amount: '0.05' }),
         'GET /v1/models': true,
       },
     }),
@@ -78,19 +78,19 @@ const proxy = Proxy.create({
     openai({
       apiKey: process.env.OPENAI_API_KEY!,
       routes: {
-        'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
+        'POST /v1/chat/completions': mppx.tempo.charge({ amount: '0.05' }),
       },
     }),
     anthropic({
       apiKey: process.env.ANTHROPIC_API_KEY!,
       routes: {
-        'POST /v1/messages': mppx.charge({ amount: '0.03' }),
+        'POST /v1/messages': mppx.tempo.charge({ amount: '0.03' }),
       },
     }),
     stripe({
       apiKey: process.env.STRIPE_API_KEY!,
       routes: {
-        'POST /v1/charges': mppx.charge({ amount: '1' }),
+        'POST /v1/charges': mppx.tempo.charge({ amount: '1' }),
         'GET /v1/customers/:id': true,
       },
     }),
@@ -112,9 +112,9 @@ import { openai } from 'mppx/proxy'
 openai({
   apiKey: 'sk-...',
   routes: {
-    'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
-    'POST /v1/embeddings': mppx.charge({ amount: '0.01' }),
-    'POST /v1/images/generations': mppx.charge({ amount: '0.10' }),
+    'POST /v1/chat/completions': mppx.tempo.charge({ amount: '0.05' }),
+    'POST /v1/embeddings': mppx.tempo.charge({ amount: '0.01' }),
+    'POST /v1/images/generations': mppx.tempo.charge({ amount: '0.10' }),
     'GET /v1/models': true,
   },
 })
@@ -138,8 +138,8 @@ import { anthropic } from 'mppx/proxy'
 anthropic({
   apiKey: 'sk-ant-...',
   routes: {
-    'POST /v1/messages': mppx.charge({ amount: '0.03' }),
-    'POST /v1/complete': mppx.charge({ amount: '0.02' }),
+    'POST /v1/messages': mppx.tempo.charge({ amount: '0.03' }),
+    'POST /v1/complete': mppx.tempo.charge({ amount: '0.02' }),
   },
 })
 ```
@@ -162,7 +162,7 @@ import { stripe } from 'mppx/proxy'
 stripe({
   apiKey: 'sk-...',
   routes: {
-    'POST /v1/charges': mppx.charge({ amount: '1' }),
+    'POST /v1/charges': mppx.tempo.charge({ amount: '1' }),
     'GET /v1/customers/:id': true,
   },
 })
@@ -196,7 +196,7 @@ const proxy = Proxy.create({
       description: 'Example upstream API',
       title: 'My API',
       routes: {
-        'POST /v1/generate': mppx.charge({ amount: '0.01' }),
+        'POST /v1/generate': mppx.tempo.charge({ amount: '0.01' }),
         'GET /v1/status': true,
       },
     }),
@@ -216,7 +216,7 @@ Service.from('custom-api', {
     'X-Org-Id': 'org-123',
   },
   routes: {
-    'POST /v1/query': mppx.charge({ amount: '0.02' }),
+    'POST /v1/query': mppx.tempo.charge({ amount: '0.02' }),
   },
 })
 ```
@@ -235,7 +235,7 @@ Service.from('advanced-api', {
     return request
   },
   routes: {
-    'POST /v1/generate': mppx.charge({ amount: '0.05' }),
+    'POST /v1/generate': mppx.tempo.charge({ amount: '0.05' }),
   },
 })
 ```

--- a/src/pages/sdk/typescript/server/Method.stripe.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.stripe.charge.mdx
@@ -21,7 +21,7 @@ const mppx = Mppx.create({
 
 export async function handler(request: Request) {
   // [!code focus:start]
-  const response = await mppx.charge({
+  const response = await mppx.stripe.charge({
     amount: '1',
     currency: 'usd',
     decimals: 2,

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -13,7 +13,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 export async function handler(request: Request) {
   // [!code focus:start]
-  const response = await mppx.charge({
+  const response = await mppx.tempo.charge({
     amount: '0.1',
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -37,7 +37,7 @@ const mppx = Mppx.create({ methods: [tempo.charge()] })
 import { Expires } from 'mppx'
 
 export async function handler(request: Request) {
-  const response = await mppx.charge({
+  const response = await mppx.tempo.charge({
     amount: '0.1',
     currency: '0x20c0000000000000000000000000000000000000',
     expires: Expires.minutes(10), // [!code focus]
@@ -59,7 +59,7 @@ import { Mppx, tempo } from 'mppx/server'
 const mppx = Mppx.create({ methods: [tempo.charge()] })
 // ---cut---
 export async function handler(request: Request) {
-  const response = await mppx.charge({
+  const response = await mppx.tempo.charge({
     amount: '0.1',
     currency: '0x20c0000000000000000000000000000000000000',
     description: 'API access for /resource', // [!code focus]
@@ -112,7 +112,7 @@ const mppx = Mppx.create({
 })
 
 export async function handler(request: Request) {
-  const response = await mppx.charge({
+  const response = await mppx.tempo.charge({
     amount: '0',
     currency: '0x20c0000000000000000000000000000000000000',
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -303,7 +303,7 @@ import { Mppx, tempo } from 'mppx/server'
 const mppx = Mppx.create({ methods: [tempo.charge()] })
 // ---cut---
 export async function handler(request: Request) {
-  const response = await mppx.charge({
+  const response = await mppx.tempo.charge({
     amount: '1.00',
     currency: '0x20c0000000000000000000000000000000000000', // pathUSD
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', // seller

--- a/src/pages/sdk/typescript/server/Mppx.toNodeListener.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.toNodeListener.mdx
@@ -14,7 +14,7 @@ const mppx = Mppx.create({
 
 http.createServer(async (req, res) => {
   const result = await Mppx.toNodeListener(
-    mppx.charge({
+    mppx.tempo.charge({
       amount: '0.1', 
       currency: '0x...', 
       recipient: '0x...',
@@ -60,7 +60,7 @@ const mppx = Mppx.create({
 http.createServer(async (req, res) => {
   const result = await Mppx.toNodeListener(
     // [!code focus:start]
-    mppx.charge({
+    mppx.tempo.charge({
       amount: '0.1',
       currency: '0x...',
       recipient: '0x...',

--- a/src/pages/sdk/typescript/server/Transport.mcpSdk.mdx
+++ b/src/pages/sdk/typescript/server/Transport.mcpSdk.mdx
@@ -16,7 +16,7 @@ const mppx = Mppx.create({
 const server = new McpServer({ name: 'example', version: '1.0.0' })
 
 server.registerTool('premium', { description: 'A premium tool' }, async (extra) => {
-  const result = await mppx.charge({
+  const result = await mppx.tempo.charge({
     amount: '0.1', currency: '0x...', recipient: '0x...',
   })(extra)
 


### PR DESCRIPTION
## Summary

- Updated core TypeScript server docs to use namespaced handlers like `mppx.tempo.charge(...)`
- Updated middleware, proxy, MCP, API demo, and payment-method examples to use method-specific handlers
- Left aggregate multi-method and x402 compatibility examples on the shorthand form where they intentionally describe combined behavior

## Motivation

Keeps docs aligned with https://github.com/wevm/mppx/pull/558 and makes copied examples safer when multiple methods expose the same intent name.

## Key design considerations

- Used method-specific namespaces for single-method examples
- Preserved aggregate shorthand examples where the guide is specifically about multi-method dispatch
- Kept this as a docs-only change