### PR TITLE
[codex] add Hermes MPP blog post

### DIFF
--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -13,6 +13,7 @@ type Page =
   | { path: '/advanced/security'; render: 'static' }
   | { path: '/blog/evm-x402-support'; render: 'static' }
   | { path: '/blog/go-and-ruby-sdks'; render: 'static' }
+  | { path: '/blog/hermes-mpp'; render: 'static' }
   | { path: '/blog'; render: 'static' }
   | { path: '/blog/multi-method-discovery'; render: 'static' }
   | { path: '/blog/payment-hooks'; render: 'static' }

--- a/src/pages/blog/hermes-mpp.mdx
+++ b/src/pages/blog/hermes-mpp.mdx
@@ -1,0 +1,59 @@
+---
+layout: minimal
+outline: false
+showAskAi: false
+showFeedback: false
+showSearch: false
+description: "Nous Research added an MPP skill to Hermes so agents can pay per request for APIs."
+imageDescription: "Hermes agents can pay for APIs with MPP"
+---
+
+<div className="blog-narrow">
+
+<a href="/blog" className="blog-back">Blog</a>
+
+<p className="blog-date" style={{ color: 'var(--vocs-color_text3)', fontSize: '14px' }}>Wednesday, June 17, 2026</p>
+
+# Hermes agents can now pay for APIs with MPP [Nous Research adds an MPP skill for per-request agent payments]
+
+Nous Research has added an MPP payments skill to Hermes. With `mpp-agent`, a Hermes agent can pay APIs that charge per request, settling each call as it happens instead of relying on a subscription, shared API key, or manual checkout.
+
+The skill is part of a broader set of payments capabilities built with Stripe, and it uses the Machine Payments Protocol for the `402` payment flow.
+
+## What MPP does
+
+MPP is an open standard for machine payments. It defines how a client pays for a resource over HTTP. A server responds with `402 Payment Required` and a Challenge describing the price, the client submits a Credential, and the server fulfills the request with a Receipt.
+
+The same pattern supports one-time charges, variable usage within a single request, and recurring subscriptions. MPP was co-authored by Tempo and Stripe.
+
+## What the skill does
+
+The `mpp-agent` skill is a client for these flows. It installs on its own, with no changes to Hermes itself:
+
+```bash [terminal]
+$ hermes skills install official/payments/mpp-agent
+```
+
+Once installed, Hermes can pay `402`-gated endpoints using the `mppx` client and a wallet of the user's choosing, including Tempo Wallet. Users who don't need payments don't have new core tools or configuration to manage.
+
+## The agent acts, the user sets the spending bound
+
+Nous designed the skill so autonomy doesn't mean losing control of spend. Wallet keys never enter the agent's transcript, logs, or memory. Spend approvals sit outside the agent and can't be bypassed by it. Final amounts are confirmed before any payment goes through.
+
+That split makes machine payments workable in production. The agent decides what to pay for, request by request, within limits the user sets and the agent can't override.
+
+## Why an open standard matters
+
+Nous built this without involvement from the MPP team. That's what an open standard is for. Any agent framework, wallet, or API can implement MPP and interoperate with the rest, without asking permission and without locking into a single provider.
+
+The `mpp-agent` skill supports more than one wallet, and MPP works across payment methods and chains.
+
+## Build with MPP
+
+If you're building an agent that needs to pay for things, you can add MPP the same way Nous did. If you run an API, you can price it per request and accept MPP payments directly.
+
+- [Connect an agent to MPP services](/quickstart/agent)
+- [Accept MPP payments on your API](/quickstart/server)
+- [Browse MPP-enabled services](/services)
+
+</div>

--- a/src/pages/blog/hermes-mpp.mdx
+++ b/src/pages/blog/hermes-mpp.mdx
@@ -4,7 +4,7 @@ outline: false
 showAskAi: false
 showFeedback: false
 showSearch: false
-description: "Nous Research added an MPP skill to Hermes so agents can pay per request for APIs."
+description: "MPP is live in Hermes Agent. Nous Research's mpp-agent skill lets Hermes agents pay for APIs one call at a time."
 imageDescription: "Hermes agents can pay for APIs with MPP"
 ---
 
@@ -14,17 +14,17 @@ imageDescription: "Hermes agents can pay for APIs with MPP"
 
 <p className="blog-date" style={{ color: 'var(--vocs-color_text3)', fontSize: '14px' }}>Wednesday, June 17, 2026</p>
 
-# Hermes agents can now pay for APIs with MPP [Nous Research adds an MPP skill for per-request agent payments]
+# Hermes agents can now pay for APIs with MPP [MPP is live in Hermes Agent]
 
-Nous Research has added an MPP payments skill to Hermes. With `mpp-agent`, a Hermes agent can pay APIs that charge per request, settling each call as it happens instead of relying on a subscription, shared API key, or manual checkout.
+_MPP is live in Hermes Agent. Nous Research's new `mpp-agent` skill lets a Hermes agent pay for APIs one call at a time, using MPP, the open standard for machine payments co-authored with Stripe. [Read the protocol](/protocol)._
 
-The skill is part of a broader set of payments capabilities built with Stripe, and it uses the Machine Payments Protocol for the `402` payment flow.
+MPP is now live in Hermes Agent. Nous Research has added an `mpp-agent` skill that lets a Hermes agent pay for APIs that charge per request, settling each call as it happens rather than running on a subscription or a shared API key. The skill is part of a broader set of payments capabilities Nous built with Stripe.
 
 ## What MPP does
 
-MPP is an open standard for machine payments. It defines how a client pays for a resource over HTTP. A server responds with `402 Payment Required` and a Challenge describing the price, the client submits a Credential, and the server fulfills the request with a Receipt.
+MPP is an open standard for machine payments. It defines how a client pays for a resource over HTTP. A server responds with `402 Payment Required` and a price, the client signs and submits payment, and the server fulfills the request and returns a Receipt.
 
-The same pattern supports one-time charges, variable usage within a single request, and recurring subscriptions. MPP was co-authored by Tempo and Stripe.
+The same pattern supports one-time charges, variable usage within a single request, and recurring subscriptions. MPP was co-authored with Stripe.
 
 ## What the skill does
 
@@ -34,26 +34,26 @@ The `mpp-agent` skill is a client for these flows. It installs on its own, with 
 $ hermes skills install official/payments/mpp-agent
 ```
 
-Once installed, Hermes can pay `402`-gated endpoints using the `mppx` client and a wallet of the user's choosing, including Tempo Wallet. Users who don't need payments don't have new core tools or configuration to manage.
+Once installed, the agent can pay `402`-gated endpoints using the `mppx` client and a wallet of the user's choosing, including Tempo Wallet. There are no new core tools and nothing new to configure for users who do not need payments.
 
-## The agent acts, the user sets the spending bound
+## The agent acts, the user sets the bound
 
-Nous designed the skill so autonomy doesn't mean losing control of spend. Wallet keys never enter the agent's transcript, logs, or memory. Spend approvals sit outside the agent and can't be bypassed by it. Final amounts are confirmed before any payment goes through.
+Nous designed the skill so that autonomy never means losing control of spend. Wallet keys never enter the agent's transcript, logs, or memory. Spend approvals sit outside the agent and cannot be bypassed by it. Final amounts are confirmed before any payment goes through.
 
-That split makes machine payments workable in production. The agent decides what to pay for, request by request, within limits the user sets and the agent can't override.
+That split is what makes machine payments workable in production. The agent decides what to pay for, request by request, within limits the user sets and the agent cannot override.
 
 ## Why an open standard matters
 
-Nous built this without involvement from the MPP team. That's what an open standard is for. Any agent framework, wallet, or API can implement MPP and interoperate with the rest, without asking permission and without locking into a single provider.
+Nous built this without any involvement from the MPP team. That is what an open standard is for. Any agent framework, wallet, or API can implement MPP and interoperate with the rest, without asking permission and without locking into a single provider.
 
 The `mpp-agent` skill supports more than one wallet, and MPP works across payment methods and chains.
 
 ## Build with MPP
 
-If you're building an agent that needs to pay for things, you can add MPP the same way Nous did. If you run an API, you can price it per request and accept MPP payments directly.
+If you are building an agent that needs to pay for things, you can add MPP the same way Nous did. If you run an API, you can price it per request and accept MPP payments directly.
 
-- [Connect an agent to MPP services](/quickstart/agent)
-- [Accept MPP payments on your API](/quickstart/server)
-- [Browse MPP-enabled services](/services)
+- [Read the protocol](/protocol)
+- [Browse the SDKs](/sdk)
+- [See the payments directory](/services)
 
 </div>

--- a/src/pages/blog/index.mdx
+++ b/src/pages/blog/index.mdx
@@ -9,15 +9,21 @@ imageDescription: "Updates on the Machine Payments Protocol"
 ---
 
 <h1 className="blog-index-title">Blog</h1>
-<p className="blog-index-description">
+<div className="blog-index-description">
   Updates from the MPP team on protocol development, integrations, and the future of machine payments.
-</p>
+</div>
 
 {/* TODO: Replace with ::blog-posts directive when Vocs v2 adds blog support */}
 
 import { BlogPostList } from "../../components/BlogPostList";
 
 <BlogPostList posts={[
+  {
+    date: "Wednesday, June 17, 2026",
+    title: "Hermes agents can now pay for APIs with MPP",
+    description: <>Nous Research added an MPP skill to Hermes so agents can pay per request for APIs.</>,
+    to: "/blog/hermes-mpp",
+  },
   {
     date: "Wednesday, June 17, 2026",
     title: "An improved sessions experience",

--- a/src/pages/blog/index.mdx
+++ b/src/pages/blog/index.mdx
@@ -21,7 +21,7 @@ import { BlogPostList } from "../../components/BlogPostList";
   {
     date: "Wednesday, June 17, 2026",
     title: "Hermes agents can now pay for APIs with MPP",
-    description: <>Nous Research added an MPP skill to Hermes so agents can pay per request for APIs.</>,
+    description: <>Nous Research's <code>mpp-agent</code> skill lets Hermes agents pay for APIs one call at a time.</>,
     to: "/blog/hermes-mpp",
   },
   {


### PR DESCRIPTION
## Summary

Adds a new mpp.dev blog post about Nous Research adding an MPP payments skill to Hermes, using the revised copy that frames MPP as live in Hermes Agent.

Also updates the blog index to list the post and changes the index description wrapper from `p` to `div` to avoid invalid nested paragraph markup during hydration.

## Impact

- Publishes `/blog/hermes-mpp`.
- Adds the post to `/blog`.
- Keeps the bottom CTAs within mpp.dev: `/protocol`, `/sdk`, and `/services`.

## Validation

- `pnpm check`
- `pnpm build`
- `pnpm check:generated`