### PR TITLE
Add production MPP services MCP worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [lint, typecheck, test, build]
+    needs: [lint, typecheck, test, mcp-services, build]
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -59,6 +59,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: node scripts/generate-discovery.ts
       - run: pnpm test
+
+  mcp-services:
+    name: MCP Services Worker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm mcp-services:check
 
   build:
     name: Build

--- a/.github/workflows/mcp-services-deploy.yml
+++ b/.github/workflows/mcp-services-deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy MPP Services MCP
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "workers/mcp-services/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/mcp-services-deploy.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: mcp-services-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  NODE_ENV: production
+  WRANGLER_SEND_METRICS: false
+
+jobs:
+  deploy:
+    name: mpp-services-mcp
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm mcp-services:check
+      - name: Deploy Worker
+        run: pnpm mcp-services:deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ src/pages.gen.ts
 .dev.vars*
 .env
 worker-configuration.d.ts
+wrangler.deploy.jsonc
 public/specs/
 src/pages/specs/index.mdx
 src/pages/_vocs.generated.css

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "dev": "node scripts/generate-discovery.ts && vite dev",
     "generate:discovery": "node scripts/generate-discovery.ts",
     "generate:pages": "node scripts/generate-pages.ts",
+    "mcp-services:check": "pnpm --filter mpp-services-mcp check",
+    "mcp-services:deploy": "pnpm --filter mpp-services-mcp deploy",
     "preinstall": "pnpx only-allow pnpm",
     "prepare": "pnpm simple-git-hooks",
     "preview": "vite preview",
@@ -70,7 +72,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "esbuild"
+      "esbuild",
+      "sharp",
+      "workerd"
     ],
     "ignoredBuiltDependencies": [
       "es5-ext",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,21 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@25.9.1)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  workers/mcp-services:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@25.9.2)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      wrangler:
+        specifier: ^4.101.0
+        version: 4.101.0
+
 packages:
 
   '@adraffy/ens-normalize@1.11.1':
@@ -303,6 +318,49 @@ packages:
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260616.1':
+    resolution: {integrity: sha512-8QaDRQABkwkwoeviNiyScol7EQgXfGsPNSyUn52GiXObthY4XPiokoJsgDSDNcAelHjEvDLmdvQBHPK8YvGn4A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260616.1':
+    resolution: {integrity: sha512-xEhiZQ62CBJ+vyKSmM13rkK/wB1kLP5sKFkF3+P+3R/c2bmnSG3Vcd5FfXUu9V0PdC+KlR02nByvZjqEw2N6Ag==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260616.1':
+    resolution: {integrity: sha512-p5laSYPiRUMHaLkneaZ9ZfIkNpmEnGFwgYmXtfcHJutTfEd8o3IBnsUVRSbPL+phcshKqmapLsQSxDEX6WSFfA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260616.1':
+    resolution: {integrity: sha512-XQ7GonEl8ORvbz5fhe8Eyw2t/j09Li0KbXJxaldA318E+syF+PPTc4IRQudgqPWzzdzkH5nF7PuMOGySLSjFFw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260616.1':
+    resolution: {integrity: sha512-RaDVF9bSbPiPTq6vHYrgnv1TcQEcYnOr0WB3hWJ4yg2fBfpi2ygU6cYPuFeDwyFE9aPW5S6FBAkNmpKYueK4DQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
   '@codemirror/autocomplete@6.20.0':
     resolution: {integrity: sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==}
 
@@ -342,6 +400,10 @@ packages:
       react: ^16.8.0 || ^17 || ^18 || ^19
       react-dom: ^16.8.0 || ^17 || ^18 || ^19
 
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
@@ -362,16 +424,34 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -380,16 +460,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -398,10 +496,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -410,10 +520,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -422,10 +544,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -434,10 +568,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -446,10 +592,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -458,16 +616,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -476,10 +652,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -488,11 +676,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -500,16 +700,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -566,6 +784,159 @@ packages:
   '@iconify/utils@3.1.3':
     resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -584,6 +955,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@lezer/common@1.5.1':
     resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
@@ -678,6 +1052,15 @@ packages:
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@react-hook/intersection-observer@3.1.2':
     resolution: {integrity: sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==}
@@ -1034,6 +1417,13 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.17':
+    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -1816,6 +2206,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -1936,6 +2329,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -2212,6 +2609,9 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -2246,6 +2646,11 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -2627,6 +3032,10 @@ packages:
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
 
@@ -2948,6 +3357,11 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  miniflare@4.20260616.0:
+    resolution: {integrity: sha512-cEpzoNgSWjedzYmhJvttUPmL4Jk6nSzzeNNi118T5zwnmYP9fnM8UXwFU/Qa/1qoQ4SzGqtM1Q7tinHvHvIGtw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
@@ -3123,6 +3537,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -3352,6 +3769,11 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -3362,6 +3784,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3642,9 +4068,16 @@ packages:
     resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
     engines: {node: '>=18.17'}
 
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
   undici@8.1.0:
     resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
     engines: {node: '>=22.19.0'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3949,6 +4382,21 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  workerd@1.20260616.1:
+    resolution: {integrity: sha512-aRGWYxviSjYZwyu97pCr5GyJ9ObpgmNcfZZs3/o+kG7Wz3SBTqA8d8uhNueY5u7ADeUp2ibJvK6mXkFLrUmPgg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.101.0:
+    resolution: {integrity: sha512-dZDDiRcT7MiA09lBDxWKmiL/iybEZ+SZe3IZmnVx1m1n1DOo730vOY5SeO7z9xFK8a/+vhGKDYB8mDXrvzEr5g==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260616.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -3983,6 +4431,12 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -4210,6 +4664,29 @@ snapshots:
 
   '@chevrotain/types@11.1.2': {}
 
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260616.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260616.1
+
+  '@cloudflare/workerd-darwin-64@1.20260616.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260616.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260616.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260616.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260616.1':
+    optional: true
+
   '@codemirror/autocomplete@6.20.0':
     dependencies:
       '@codemirror/language': 6.12.1
@@ -4318,6 +4795,10 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-is: 17.0.2
 
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@date-fns/tz@1.4.1':
     optional: true
 
@@ -4345,79 +4826,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -4479,6 +5038,102 @@ snapshots:
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
 
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4499,6 +5154,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4639,6 +5299,18 @@ snapshots:
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@react-hook/intersection-observer@3.1.2(react@19.2.7)':
     dependencies:
@@ -4929,6 +5601,10 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.17': {}
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -5347,7 +6023,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
 
   '@typescript/vfs@1.6.3(typescript@6.0.3)':
     dependencies:
@@ -5412,6 +6088,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -5646,6 +6330,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.20: {}
 
+  blake3-wasm@2.1.5: {}
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -5742,6 +6428,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cors@2.8.6:
     dependencies:
@@ -6038,6 +6726,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  error-stack-parser-es@1.0.5: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -6081,6 +6771,35 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -6524,6 +7243,8 @@ snapshots:
       commander: 8.3.0
 
   khroma@2.1.0: {}
+
+  kleur@4.1.5: {}
 
   layout-base@1.0.2: {}
 
@@ -7125,6 +7846,18 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  miniflare@4.20260616.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260616.1
+      ws: 8.20.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minisearch@7.2.0: {}
 
   mipd@0.0.7(typescript@6.0.3):
@@ -7283,6 +8016,8 @@ snapshots:
   path-data-parser@0.1.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.4.2: {}
 
@@ -7625,6 +8360,8 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.8.4: {}
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -7651,6 +8388,37 @@ snapshots:
       - supports-color
 
   setprototypeof@1.2.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -7900,7 +8668,13 @@ snapshots:
 
   undici@6.26.0: {}
 
+  undici@7.24.8: {}
+
   undici@8.1.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unified@11.0.5:
     dependencies:
@@ -8056,6 +8830,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
+  vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.2
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.48.0
+      tsx: 4.21.0
+      yaml: 2.9.0
+
   vitefu@1.1.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -8085,6 +8875,35 @@ snapshots:
     optionalDependencies:
       '@edge-runtime/vm': 3.2.0
       '@types/node': 25.9.1
+      happy-dom: 20.9.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.8(@edge-runtime/vm@3.2.0)(@types/node@25.9.2)(happy-dom@20.9.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 3.2.0
+      '@types/node': 25.9.2
       happy-dom: 20.9.0
     transitivePeerDependencies:
       - msw
@@ -8326,6 +9145,30 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  workerd@1.20260616.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260616.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260616.1
+      '@cloudflare/workerd-linux-64': 1.20260616.1
+      '@cloudflare/workerd-linux-arm64': 1.20260616.1
+      '@cloudflare/workerd-windows-64': 1.20260616.1
+
+  wrangler@4.101.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260616.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260616.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260616.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
@@ -8335,6 +9178,19 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.9.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.17
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zod-to-json-schema@3.25.1(zod@4.4.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "workers/*"
+
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - mppx
@@ -6,6 +9,17 @@ minimumReleaseAgeExclude:
   - waku
 blockExoticSubdeps: true
 strictDepBuilds: true
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - workerd
+ignoredBuiltDependencies:
+  - es5-ext
+  - simple-git-hooks
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true
 trustPolicy: no-downgrade
 trustPolicyExclude:
   - semver@6.3.1

--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -28,6 +28,11 @@ Registries aggregate discovery documents from multiple services, making it easy 
 | [MPPScan](https://mppscan.com) | Public registry of MPP-enabled services with search and analytics | [Manually register](https://www.mppscan.com/register) in one click |
 | [MPP Services directory](https://mpp.dev/services) | Curated list of live services on mpp.dev | [Submit a PR](https://github.com/tempoxyz/mpp) to add your service |
 
+Agents can query the curated services directory over MCP at
+`https://mpp.dev/mcp/services`. The server is read-only and exposes tools to
+list services, search by category or payment method, inspect endpoint offers,
+and fetch advisory OpenAPI summaries.
+
 ## Quick start
 
 The `mppx` SDK generates discovery documents from your route configuration. Add `discovery()` to your server and it serves `/openapi.json` automatically.

--- a/src/pages/services.mdx
+++ b/src/pages/services.mdx
@@ -10,3 +10,10 @@ imageDescription: "Browse live APIs that accept machine payments"
 import { ServicesPage } from "../components/ServicesPage";
 
 <ServicesPage />
+
+## Agent discovery
+
+Agents can query the read-only services MCP server at
+`https://mpp.dev/mcp/services` to list and search the catalog, inspect payment
+offers, and fetch advisory OpenAPI summaries. Runtime `402` Challenges remain
+the authoritative source of payment terms.

--- a/vercel.mjs
+++ b/vercel.mjs
@@ -12,6 +12,18 @@ const OPENAPI_DISCOVERY_LINK_VALUE = [
   '</.well-known/agent-skills/index.json>; rel="describedby"; type="application/json"',
 ].join(", ");
 
+const MPP_SERVICES_MCP_WORKER_ORIGIN =
+  process.env.MPP_SERVICES_MCP_WORKER_ORIGIN?.replace(/\/+$/, "");
+
+if (
+  process.env.VERCEL_ENV === "production" &&
+  !MPP_SERVICES_MCP_WORKER_ORIGIN
+) {
+  throw new Error(
+    "MPP_SERVICES_MCP_WORKER_ORIGIN must be set for production Vercel builds",
+  );
+}
+
 const CONTENT_NEGOTIATION_HEADERS = [header("Vary", "Accept, User-Agent")];
 
 const API_CATALOG_HEADERS = [
@@ -67,6 +79,20 @@ export const config = {
       ]),
     ),
   ],
+  ...(MPP_SERVICES_MCP_WORKER_ORIGIN
+    ? {
+        rewrites: [
+          rewriteRule(
+            "/mcp/services",
+            `${MPP_SERVICES_MCP_WORKER_ORIGIN}/mcp/services`,
+          ),
+          rewriteRule(
+            "/mcp/services/:path*",
+            `${MPP_SERVICES_MCP_WORKER_ORIGIN}/mcp/services`,
+          ),
+        ],
+      }
+    : {}),
   redirects: [
     {
       source: "/index",
@@ -93,4 +119,8 @@ function header(key, value) {
 
 function headerRule(source, headers) {
   return { source, headers };
+}
+
+function rewriteRule(source, destination) {
+  return { source, destination };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -162,7 +162,7 @@ export default defineConfig(({ mode }) => {
       vocs(),
       contentSignalsRobotsTxt(),
       pruneSitemap(),
-      ...(mode !== "production"
+      ...(mode !== "production" && mode !== "test"
         ? [mkcert({ force: true, hosts: ["localhost"] })]
         : []),
     ],
@@ -181,7 +181,7 @@ export default defineConfig(({ mode }) => {
       external: ["typescript"],
     },
     test: {
-      exclude: [...configDefaults.exclude, "e2e/**"],
+      exclude: [...configDefaults.exclude, "e2e/**", "workers/**"],
     },
   };
 });

--- a/workers/mcp-services/README.md
+++ b/workers/mcp-services/README.md
@@ -1,0 +1,97 @@
+# mpp-services-mcp
+
+Read-only Cloudflare Worker MCP server for the MPP service discovery catalog.
+
+Production endpoint:
+
+```text
+https://mpp.dev/mcp/services
+```
+
+The production URL is served by the `mpp.dev` Vercel app through a rewrite to
+this Worker. Set the Vercel environment variable
+`MPP_SERVICES_MCP_WORKER_ORIGIN` to the production Worker origin.
+
+Dev mirror:
+
+```text
+https://mpp-discovery-mcp.tempo-dev.workers.dev/mcp
+```
+
+The dev mirror remains deployed from `tempoxyz/mpp-discovery-mcp`.
+
+## Data source
+
+The Worker reads `GET https://mpp.dev/api/services`, which returns:
+
+```ts
+{ version: number, services: Service[] }
+```
+
+Offers are read from `service.endpoints[].payment`. The Worker does not fetch
+per-service `/openapi.json` files while refreshing the catalog.
+
+Discovery is advisory. The runtime `402 Challenge` from the target paid API is
+authoritative.
+
+## Refresh model
+
+- KV binding: `MPP_CATALOG_CACHE`
+- Cache key: `mpp:services:v1`
+- Hourly cron: `0 * * * *`
+- Requests use fresh KV data when it is less than one hour old.
+- If KV data is stale, requests serve the last-good cached catalog and refresh
+  in the background.
+- If `mpp.dev` is unreachable during cron refresh, the Worker logs the failure
+  and keeps the last-good KV value.
+- There is no public write, sync, registration, payment, or auth path.
+
+## Tools
+
+All tool responses include `structuredContent`, an `outputSchema`, and a text
+summary. Discovery is advisory; the runtime `402 Challenge` from the target
+paid API remains authoritative.
+
+- `list_services(limit?, offset?)`
+- `search_services(query?, category?, method?, integration?, status?, limit?, offset?)`
+- `get_service(id_or_name)`
+- `get_offers(service, route?)`
+- `get_openapi(service, raw?)`
+
+## MCP client config
+
+```json
+{
+  "mcpServers": {
+    "mpp-services": {
+      "url": "https://mpp.dev/mcp/services"
+    }
+  }
+}
+```
+
+## Development
+
+```bash
+pnpm install
+pnpm --filter mpp-services-mcp check
+pnpm --filter mpp-services-mcp dev
+```
+
+Deploys are pinned to the Tempo Production Cloudflare account:
+
+```text
+Tempo Production Resources / ba6ee3674b03f08481e57ff9992c601e
+```
+
+Deploy:
+
+```bash
+pnpm --filter mpp-services-mcp deploy:dry-run
+pnpm --filter mpp-services-mcp deploy
+```
+
+The deploy script creates `wrangler.deploy.jsonc` locally, resolving or creating
+the production `MPP_CATALOG_CACHE` KV namespace before invoking Wrangler. It
+requires `CLOUDFLARE_API_TOKEN` with Account Read, Workers Scripts Write, and
+Workers KV Storage Write permissions. Zone permissions are not required.

--- a/workers/mcp-services/package.json
+++ b/workers/mcp-services/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mpp-services-mcp",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev --port 8787",
+    "deploy": "node scripts/prepare-deploy-config.mjs && wrangler deploy --config wrangler.deploy.jsonc",
+    "deploy:dry-run": "node scripts/prepare-deploy-config.mjs --dry-run && wrangler deploy --dry-run --config wrangler.deploy.jsonc",
+    "gen:types": "wrangler types",
+    "check:types": "tsc --noEmit",
+    "test": "vitest --run",
+    "check": "pnpm gen:types && pnpm check:types && pnpm test"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8",
+    "wrangler": "^4.101.0"
+  }
+}

--- a/workers/mcp-services/scripts/prepare-deploy-config.mjs
+++ b/workers/mcp-services/scripts/prepare-deploy-config.mjs
@@ -1,0 +1,128 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const CONFIG_PATH = new URL("../wrangler.jsonc", import.meta.url);
+const DEPLOY_CONFIG_PATH = new URL("../wrangler.deploy.jsonc", import.meta.url);
+const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
+const DRY_RUN_PLACEHOLDER_ID = "00000000000000000000000000000000";
+const dryRun = process.argv.includes("--dry-run");
+
+const config = JSON.parse(await readFile(CONFIG_PATH, "utf8"));
+const accountId = config.account_id;
+const envAccountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+
+if (!accountId) {
+  throw new Error("wrangler.jsonc must include the production account_id");
+}
+
+if (envAccountId && envAccountId !== accountId) {
+  throw new Error(
+    `CLOUDFLARE_ACCOUNT_ID (${envAccountId}) does not match wrangler.jsonc account_id (${accountId})`,
+  );
+}
+
+const namespace = config.kv_namespaces?.find(
+  (binding) => binding.binding === "MPP_CATALOG_CACHE",
+);
+
+if (!namespace) {
+  throw new Error("wrangler.jsonc must include MPP_CATALOG_CACHE");
+}
+
+const namespaceId =
+  process.env.MPP_CATALOG_CACHE_KV_NAMESPACE_ID ||
+  (dryRun && !process.env.CLOUDFLARE_API_TOKEN
+    ? DRY_RUN_PLACEHOLDER_ID
+    : await ensureKvNamespace(accountId, namespace.binding));
+
+if (!/^[0-9a-f]{32}$/i.test(namespaceId)) {
+  throw new Error(`Invalid KV namespace id for ${namespace.binding}`);
+}
+
+namespace.id = namespaceId;
+
+await writeFile(DEPLOY_CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
+
+console.log(`Prepared ${DEPLOY_CONFIG_PATH.pathname}`);
+console.log(`Using KV namespace ${namespace.binding} (${namespaceId})`);
+
+async function ensureKvNamespace(accountId, title) {
+  const token = process.env.CLOUDFLARE_API_TOKEN;
+
+  if (!token) {
+    throw new Error(
+      "CLOUDFLARE_API_TOKEN is required to resolve or create MPP_CATALOG_CACHE",
+    );
+  }
+
+  const existing = await listKvNamespaces(accountId, token);
+  const match = existing.find((item) => item.title === title);
+  if (match) return match.id;
+
+  const created = await cloudflareRequest({
+    accountId,
+    token,
+    method: "POST",
+    path: "/storage/kv/namespaces",
+    body: { title },
+  });
+
+  return created.result.id;
+}
+
+async function listKvNamespaces(accountId, token) {
+  const namespaces = [];
+  let page = 1;
+  let totalPages = 1;
+
+  do {
+    const response = await cloudflareRequest({
+      accountId,
+      token,
+      method: "GET",
+      path: "/storage/kv/namespaces",
+      query: { page, per_page: 100 },
+    });
+    namespaces.push(...response.result);
+    totalPages = response.result_info?.total_pages || 1;
+    page += 1;
+  } while (page <= totalPages);
+
+  return namespaces;
+}
+
+async function cloudflareRequest({
+  accountId,
+  token,
+  method,
+  path,
+  query,
+  body,
+}) {
+  const url = new URL(`${CLOUDFLARE_API_BASE}/accounts/${accountId}${path}`);
+  for (const [key, value] of Object.entries(query || {})) {
+    url.searchParams.set(key, String(value));
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(body ? { "content-type": "application/json" } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const payload = await response.json();
+
+  if (!payload.success) {
+    const errors = payload.errors
+      ?.map((error) => `${error.code}: ${error.message}`)
+      .join("; ");
+    throw new Error(
+      `Cloudflare API request failed: ${errors || response.status}`,
+    );
+  }
+
+  return payload.result !== undefined
+    ? { result: payload.result, result_info: payload.result_info }
+    : payload;
+}

--- a/workers/mcp-services/src/cache.ts
+++ b/workers/mcp-services/src/cache.ts
@@ -1,0 +1,107 @@
+import type { ServicesResponse } from "./types.js";
+
+const CACHE_KEY = "mpp:services:v1";
+const CACHE_MAX_AGE_MS = 60 * 60 * 1000;
+const DEFAULT_SERVICES_URL = "https://mpp.dev/api/services";
+
+export type CachedCatalog = ServicesResponse & {
+  fetchedAt: string;
+  sourceUrl: string;
+};
+
+export type CatalogSnapshot = CachedCatalog & {
+  cacheStatus: "fresh" | "stale" | "refreshed";
+  refreshError?: string;
+};
+
+export async function getCatalog(
+  env: Env,
+  ctx?: ExecutionContext,
+): Promise<CatalogSnapshot> {
+  const cached = await readCachedCatalog(env);
+  if (cached && isFresh(cached)) {
+    return { ...cached, cacheStatus: "fresh" };
+  }
+
+  if (cached) {
+    if (ctx) {
+      ctx.waitUntil(
+        refreshCatalog(env).catch((error) => {
+          log("catalog.background_refresh_failed", {
+            error: errorMessage(error),
+          });
+        }),
+      );
+    }
+    return { ...cached, cacheStatus: "stale" };
+  }
+
+  return refreshCatalog(env);
+}
+
+export async function refreshCatalog(env: Env): Promise<CatalogSnapshot> {
+  const sourceUrl = env.MPP_SERVICES_URL || DEFAULT_SERVICES_URL;
+  const catalog = await fetchCatalog(sourceUrl);
+  const cached: CachedCatalog = {
+    ...catalog,
+    sourceUrl,
+    fetchedAt: new Date().toISOString(),
+  };
+  await env.MPP_CATALOG_CACHE.put(CACHE_KEY, JSON.stringify(cached));
+  return { ...cached, cacheStatus: "refreshed" };
+}
+
+async function readCachedCatalog(env: Env): Promise<CachedCatalog | undefined> {
+  const cached = await env.MPP_CATALOG_CACHE.get(CACHE_KEY, "json");
+  if (isCachedCatalog(cached)) return cached;
+  return undefined;
+}
+
+async function fetchCatalog(sourceUrl: string): Promise<ServicesResponse> {
+  const response = await fetch(sourceUrl, {
+    headers: { accept: "application/json" },
+    cf: { cacheTtl: 60 },
+  });
+  if (!response.ok) {
+    throw new Error(`MPP services fetch failed: ${response.status}`);
+  }
+  const body = await response.json();
+  if (!isServicesResponse(body)) {
+    throw new Error("MPP services response did not match expected shape");
+  }
+  return body;
+}
+
+function isFresh(cached: CachedCatalog): boolean {
+  const fetchedAt = Date.parse(cached.fetchedAt);
+  return (
+    Number.isFinite(fetchedAt) && Date.now() - fetchedAt < CACHE_MAX_AGE_MS
+  );
+}
+
+function isCachedCatalog(value: unknown): value is CachedCatalog {
+  return (
+    isServicesResponse(value) &&
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { fetchedAt?: unknown }).fetchedAt === "string" &&
+    typeof (value as { sourceUrl?: unknown }).sourceUrl === "string"
+  );
+}
+
+function isServicesResponse(value: unknown): value is ServicesResponse {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { version?: unknown }).version === "number" &&
+    Array.isArray((value as { services?: unknown }).services)
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function log(message: string, fields: Record<string, unknown>): void {
+  console.warn(JSON.stringify({ message, ...fields }));
+}

--- a/workers/mcp-services/src/discovery.test.ts
+++ b/workers/mcp-services/src/discovery.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  findService,
+  listServiceSummaries,
+  offersForService,
+  registryOpenApiView,
+  searchServices,
+} from "./discovery.js";
+import type { Service } from "./types.js";
+
+const services: Service[] = [
+  {
+    id: "agentmail",
+    name: "AgentMail",
+    url: "https://mpp.api.agentmail.to",
+    description: "Email inboxes for AI agents.",
+    categories: ["ai", "social"],
+    integration: "first-party",
+    tags: ["email", "inboxes"],
+    status: "active",
+    methods: { tempo: { intents: ["charge"] } },
+    endpoints: [
+      { method: "GET", path: "/v0/inboxes", payment: null },
+      {
+        method: "POST",
+        path: "/v0/inboxes",
+        description: "Create inbox",
+        payment: {
+          intent: "charge",
+          method: "tempo",
+          amount: "2000000",
+        },
+      },
+    ],
+  },
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    url: "https://api.anthropic.com",
+    description: "Claude chat completions.",
+    categories: ["ai"],
+    integration: "third-party",
+    tags: ["llm", "claude"],
+    status: "active",
+    docs: { openapi: "https://example.com/openapi.json" },
+    methods: { tempo: { intents: ["session"] } },
+    endpoints: [
+      {
+        method: "POST",
+        path: "/v1/messages",
+        payment: {
+          intent: "session",
+          method: "tempo",
+          dynamic: true,
+        },
+      },
+    ],
+  },
+  {
+    id: "legacy",
+    name: "Legacy",
+    url: "https://legacy.example.com",
+    categories: ["data"],
+    integration: "third-party",
+    tags: ["archive"],
+    status: "deprecated",
+    methods: {},
+    endpoints: [],
+  },
+];
+
+describe("discovery helpers", () => {
+  it("lists compact service summaries", () => {
+    expect(listServiceSummaries(services)).toEqual([
+      expect.objectContaining({
+        id: "agentmail",
+        name: "AgentMail",
+        categories: ["ai", "social"],
+        status: "active",
+      }),
+      expect.objectContaining({ id: "anthropic" }),
+      expect.objectContaining({ id: "legacy", status: "deprecated" }),
+    ]);
+  });
+
+  it("searches by query and exact filters", () => {
+    expect(
+      searchServices(services, {
+        query: "claude",
+        category: "ai",
+        method: "tempo",
+        integration: "third-party",
+        status: "active",
+      }).map((service) => service.id),
+    ).toEqual(["anthropic"]);
+  });
+
+  it("finds services by id or exact name", () => {
+    expect(findService(services, "agentmail")?.name).toBe("AgentMail");
+    expect(findService(services, "Anthropic")?.id).toBe("anthropic");
+  });
+
+  it("returns only paid offers and supports route filtering", () => {
+    const service = findService(services, "agentmail");
+    if (!service) throw new Error("missing fixture");
+    expect(offersForService(service)).toHaveLength(1);
+    expect(offersForService(service, "POST /v0/inboxes")).toEqual([
+      expect.objectContaining({
+        method: "POST",
+        path: "/v0/inboxes",
+        payment: expect.objectContaining({ amount: "2000000" }),
+      }),
+    ]);
+  });
+
+  it("builds a registry fallback view for services without openapi", () => {
+    const service = findService(services, "agentmail");
+    if (!service) throw new Error("missing fixture");
+    expect(registryOpenApiView(service)).toEqual(
+      expect.objectContaining({
+        source: "registry",
+        service: expect.objectContaining({ id: "agentmail" }),
+        endpoints: expect.arrayContaining([
+          expect.objectContaining({ path: "/v0/inboxes" }),
+        ]),
+      }),
+    );
+  });
+});

--- a/workers/mcp-services/src/discovery.ts
+++ b/workers/mcp-services/src/discovery.ts
@@ -1,0 +1,163 @@
+import type {
+  Category,
+  Endpoint,
+  EndpointPayment,
+  Integration,
+  Service,
+  Status,
+} from "./types.js";
+
+export type ServiceSummary = {
+  id: string;
+  name: string;
+  url: string;
+  categories: Category[];
+  integration?: Integration;
+  status: Status;
+  description?: string;
+};
+
+export type SearchServicesArgs = {
+  query?: string;
+  category?: Category;
+  method?: string;
+  integration?: Integration;
+  status?: Status;
+};
+
+export type Offer = {
+  method: string;
+  path: string;
+  description?: string;
+  docs?: string;
+  payment: EndpointPayment;
+};
+
+export function listServiceSummaries(services: Service[]): ServiceSummary[] {
+  return services.map((service) => ({
+    id: service.id,
+    name: service.name,
+    url: service.url,
+    categories: service.categories ?? [],
+    ...(service.integration ? { integration: service.integration } : {}),
+    status: service.status ?? "active",
+    ...(service.description ? { description: service.description } : {}),
+  }));
+}
+
+export function searchServices(
+  services: Service[],
+  filters: SearchServicesArgs,
+): ServiceSummary[] {
+  return listServiceSummaries(
+    services.filter((service) => serviceMatches(service, filters)),
+  );
+}
+
+export function findService(
+  services: Service[],
+  idOrName: string,
+): Service | undefined {
+  const wanted = normalize(idOrName);
+  if (!wanted) return undefined;
+  return (
+    services.find((service) => normalize(service.id) === wanted) ??
+    services.find((service) => normalize(service.name) === wanted)
+  );
+}
+
+export function offersForService(service: Service, route?: string): Offer[] {
+  return service.endpoints
+    .filter((endpoint): endpoint is Endpoint & { payment: EndpointPayment } =>
+      Boolean(endpoint.payment),
+    )
+    .filter((endpoint) => endpointMatchesRoute(endpoint, route))
+    .map((endpoint) => ({
+      method: endpoint.method,
+      path: endpoint.path,
+      ...(endpoint.description ? { description: endpoint.description } : {}),
+      ...(endpoint.docs ? { docs: endpoint.docs } : {}),
+      payment: endpoint.payment,
+    }));
+}
+
+export function registryOpenApiView(service: Service) {
+  return {
+    source: "registry",
+    service: {
+      id: service.id,
+      name: service.name,
+      url: service.url,
+      ...(service.serviceUrl ? { serviceUrl: service.serviceUrl } : {}),
+      ...(service.description ? { description: service.description } : {}),
+      ...(service.docs ? { docs: service.docs } : {}),
+    },
+    endpoints: service.endpoints.map((endpoint) => ({
+      method: endpoint.method,
+      path: endpoint.path,
+      ...(endpoint.description ? { description: endpoint.description } : {}),
+      ...(endpoint.payment !== undefined ? { payment: endpoint.payment } : {}),
+      ...(endpoint.docs ? { docs: endpoint.docs } : {}),
+    })),
+  };
+}
+
+function serviceMatches(
+  service: Service,
+  filters: SearchServicesArgs,
+): boolean {
+  if (filters.query && !queryMatches(service, filters.query)) return false;
+  if (
+    filters.category &&
+    !(service.categories ?? []).includes(filters.category)
+  ) {
+    return false;
+  }
+  if (filters.integration && service.integration !== filters.integration) {
+    return false;
+  }
+  if (filters.status && (service.status ?? "active") !== filters.status) {
+    return false;
+  }
+  if (filters.method && !serviceHasMethod(service, filters.method)) {
+    return false;
+  }
+  return true;
+}
+
+function queryMatches(service: Service, query: string): boolean {
+  const needle = normalize(query);
+  if (!needle) return true;
+  const haystack = normalize(
+    [service.name, service.description, ...(service.tags ?? [])]
+      .filter(Boolean)
+      .join(" "),
+  );
+  return haystack.includes(needle);
+}
+
+function serviceHasMethod(service: Service, method: string): boolean {
+  const wanted = normalize(method);
+  if (!wanted) return true;
+  if (
+    Object.keys(service.methods ?? {}).some((key) => normalize(key) === wanted)
+  ) {
+    return true;
+  }
+  return service.endpoints.some(
+    (endpoint) => normalize(endpoint.payment?.method ?? "") === wanted,
+  );
+}
+
+function endpointMatchesRoute(endpoint: Endpoint, route?: string): boolean {
+  const wanted = normalize(route ?? "");
+  if (!wanted) return true;
+  const fullRoute = normalize(`${endpoint.method} ${endpoint.path}`);
+  return (
+    fullRoute.includes(wanted) || normalize(endpoint.path).includes(wanted)
+  );
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}

--- a/workers/mcp-services/src/index.test.ts
+++ b/workers/mcp-services/src/index.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { CachedCatalog } from "./cache.js";
+import worker from "./index.js";
+import type { Service, WorkerEnv } from "./types.js";
+
+const services: Service[] = [
+  {
+    id: "agentmail",
+    name: "AgentMail",
+    url: "https://mpp.api.agentmail.to",
+    categories: ["ai"],
+    integration: "first-party",
+    tags: ["email"],
+    status: "active",
+    methods: { tempo: { intents: ["charge"] } },
+    endpoints: [],
+  },
+];
+
+describe("worker routes", () => {
+  it("serves the services MCP card from /mcp/services", async () => {
+    const response = await worker.fetch(
+      new Request("https://worker.example.com/mcp/services"),
+      envWithCatalog(),
+      testContext(),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual(
+      expect.objectContaining({
+        serverInfo: expect.objectContaining({ name: "mpp-services-mcp" }),
+        transport: {
+          type: "streamable-http",
+          endpoint: "https://mpp.dev/mcp/services",
+        },
+      }),
+    );
+  });
+
+  it("handles MCP JSON-RPC at /mcp/services", async () => {
+    const response = await worker.fetch(
+      new Request("https://worker.example.com/mcp/services", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {},
+        }),
+      }),
+      envWithCatalog(),
+      testContext(),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      result: { serverInfo: { name: string }; instructions: string };
+    };
+    expect(body.result.serverInfo.name).toBe("mpp-services-mcp");
+    expect(body.result.instructions).toContain("runtime 402 Challenge");
+  });
+
+  it("keeps the docs MCP well-known path out of this Worker", async () => {
+    const response = await worker.fetch(
+      new Request("https://worker.example.com/.well-known/mcp.json"),
+      envWithCatalog(),
+      testContext(),
+    );
+
+    expect(response.status).toBe(404);
+  });
+});
+
+function envWithCatalog(): WorkerEnv {
+  const catalog: CachedCatalog = {
+    version: 1,
+    services,
+    fetchedAt: new Date().toISOString(),
+    sourceUrl: "https://mpp.dev/api/services",
+  };
+  return {
+    MPP_SERVICES_URL: "https://mpp.dev/api/services",
+    PUBLIC_MCP_ENDPOINT: "https://mpp.dev/mcp/services",
+    MPP_CATALOG_CACHE: {
+      async get() {
+        return catalog;
+      },
+      async put() {},
+    } as unknown as KVNamespace,
+  } as WorkerEnv;
+}
+
+function testContext(): ExecutionContext {
+  return {
+    waitUntil() {},
+    passThroughOnException() {},
+    props: {},
+  } as unknown as ExecutionContext;
+}

--- a/workers/mcp-services/src/index.ts
+++ b/workers/mcp-services/src/index.ts
@@ -1,0 +1,84 @@
+import { refreshCatalog } from "./cache.js";
+import { handleMcp, jsonHeaders, optionsResponse, serverCard } from "./mcp.js";
+import type { WorkerEnv } from "./types.js";
+
+export default {
+  async fetch(
+    request: Request,
+    env: WorkerEnv,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
+    const url = new URL(request.url);
+    const publicEndpoint = publicMcpEndpoint(url, env);
+
+    if (request.method === "OPTIONS") return optionsResponse();
+
+    if (
+      (url.pathname === "/mcp/services" ||
+        url.pathname === "/mcp" ||
+        url.pathname === "/") &&
+      request.method === "POST"
+    ) {
+      return handleMcp(request, env, ctx);
+    }
+
+    if (url.pathname === "/" && request.method === "GET") {
+      return Response.json(
+        {
+          name: "mpp-services-mcp",
+          mcp: publicEndpoint,
+          serverCard: publicEndpoint,
+          description:
+            "Read-only MCP server for the MPP service discovery catalog.",
+        },
+        { headers: jsonHeaders() },
+      );
+    }
+
+    if (url.pathname === "/mcp/services" && request.method === "GET") {
+      return Response.json(serverCard(publicEndpoint), {
+        headers: jsonHeaders(),
+      });
+    }
+
+    return Response.json(
+      { error: "not found" },
+      { status: 404, headers: jsonHeaders() },
+    );
+  },
+
+  async scheduled(event: ScheduledController, env: Env, ctx: ExecutionContext) {
+    const startedAt = Date.now();
+    ctx.waitUntil(
+      refreshCatalog(env)
+        .then((catalog) => {
+          console.log(
+            JSON.stringify({
+              message: "catalog.refresh_complete",
+              cron: event.cron,
+              scheduledTime: new Date(event.scheduledTime).toISOString(),
+              durationMs: Date.now() - startedAt,
+              version: catalog.version,
+              services: catalog.services.length,
+              fetchedAt: catalog.fetchedAt,
+            }),
+          );
+        })
+        .catch((error) => {
+          console.error(
+            JSON.stringify({
+              message: "catalog.refresh_failed",
+              cron: event.cron,
+              scheduledTime: new Date(event.scheduledTime).toISOString(),
+              durationMs: Date.now() - startedAt,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+          );
+        }),
+    );
+  },
+} satisfies ExportedHandler<Env>;
+
+function publicMcpEndpoint(url: URL, env: WorkerEnv): string {
+  return env.PUBLIC_MCP_ENDPOINT || `${url.origin}/mcp/services`;
+}

--- a/workers/mcp-services/src/mcp.test.ts
+++ b/workers/mcp-services/src/mcp.test.ts
@@ -1,0 +1,454 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CachedCatalog } from "./cache.js";
+import { handleMcp, serverCard } from "./mcp.js";
+import type { Service } from "./types.js";
+
+const services: Service[] = [
+  {
+    id: "agentmail",
+    name: "AgentMail",
+    url: "https://mpp.api.agentmail.to",
+    description: "Email inboxes for AI agents.",
+    categories: ["ai", "social"],
+    integration: "first-party",
+    tags: ["email", "fax"],
+    status: "active",
+    methods: { tempo: { intents: ["charge"] } },
+    endpoints: [
+      { method: "GET", path: "/v0/inboxes", payment: null },
+      {
+        method: "POST",
+        path: "/v0/inboxes",
+        description: "Create inbox",
+        payment: {
+          intent: "charge",
+          method: "tempo",
+          amount: "2000000",
+        },
+      },
+    ],
+  },
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    url: "https://api.anthropic.com",
+    description: "Claude chat completions.",
+    categories: ["ai"],
+    integration: "third-party",
+    tags: ["llm", "claude"],
+    status: "active",
+    docs: { openapi: "https://example.com/openapi.json" },
+    methods: { tempo: { intents: ["session"] } },
+    endpoints: [
+      {
+        method: "POST",
+        path: "/v1/messages",
+        payment: {
+          intent: "session",
+          method: "tempo",
+          dynamic: true,
+        },
+      },
+    ],
+  },
+  {
+    id: "legacy",
+    name: "Legacy",
+    url: "https://legacy.example.com",
+    categories: ["data"],
+    integration: "third-party",
+    tags: ["archive"],
+    status: "deprecated",
+    methods: {},
+    endpoints: [],
+  },
+];
+
+describe("mcp handler", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("advertises outputSchema for every tool", async () => {
+    const body = await mcp("tools/list", {}, envWithCatalog());
+    const tools = body.result.tools ?? [];
+    expect(tools).toHaveLength(5);
+    for (const tool of tools) {
+      expect(tool.outputSchema).toEqual(
+        expect.objectContaining({ type: "object" }),
+      );
+    }
+    expect(
+      tools.find((tool) => tool.name === "get_openapi")?.inputSchema,
+    ).toEqual(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          raw: expect.objectContaining({ type: "boolean" }),
+        }),
+      }),
+    );
+  });
+
+  it("rejects invalid enum filters instead of silently dropping them", async () => {
+    for (const args of [
+      { category: "boguscat" },
+      { integration: "bogusint" },
+      { status: "bogusstatus" },
+    ]) {
+      const body = await callTool("search_services", args);
+      expect(body.result.isError).toBe(true);
+      expect(body.result.structuredContent).toEqual(
+        expect.objectContaining({
+          success: false,
+          error: expect.stringContaining("Allowed values:"),
+        }),
+      );
+    }
+  });
+
+  it("paginates list and search responses and echoes applied filters", async () => {
+    const listBody = await callTool("list_services", { limit: 2, offset: 1 });
+    expect(listBody.result.structuredContent).toEqual(
+      expect.objectContaining({
+        total: 3,
+        returned: 2,
+        offset: 1,
+        limit: 2,
+      }),
+    );
+    expect(listBody.result.structuredContent).not.toHaveProperty("count");
+    expect(listBody.result.structuredContent).not.toHaveProperty("filters");
+    expect(listBody.result.content[0]?.text).toContain("Returned 2 of 3");
+    expect(listBody.result.structuredContent.services.map(serviceId)).toEqual([
+      "anthropic",
+      "legacy",
+    ]);
+
+    const searchBody = await callTool("search_services", {
+      category: "ai",
+      method: "tempo",
+      limit: 1,
+    });
+    expect(searchBody.result.structuredContent).toEqual(
+      expect.objectContaining({
+        appliedFilters: { category: "ai", method: "tempo" },
+        total: 2,
+        returned: 1,
+      }),
+    );
+    expect(searchBody.result.structuredContent).not.toHaveProperty("count");
+    expect(searchBody.result.structuredContent).not.toHaveProperty("filters");
+    expect(searchBody.result.content[0]?.text).toContain("Returned 1 of 2");
+    expect(searchBody.result.structuredContent.services.map(serviceId)).toEqual(
+      ["agentmail"],
+    );
+  });
+
+  it("returns a summary by default from a valid OpenAPI candidate", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        expect(String(input)).toBe("https://mpp.api.agentmail.to/openapi.json");
+        return Response.json(
+          openApiDocument({
+            paths: {
+              "/v0/inboxes": {
+                get: { description: "List inboxes" },
+                post: {
+                  summary: "Create inbox",
+                  "x-payment-info": {
+                    offers: [{ method: "tempo", amount: "2000000" }],
+                  },
+                },
+              },
+            },
+          }),
+        );
+      }),
+    );
+
+    const body = await callTool("get_openapi", { service: "agentmail" });
+    expect(body.result.structuredContent).toEqual(
+      expect.objectContaining({
+        source: "well-known",
+        openapi: expect.objectContaining({
+          source: "well-known",
+          url: "https://mpp.api.agentmail.to/openapi.json",
+          raw: false,
+          summary: true,
+          openapiVersion: "3.1.0",
+          info: { title: "AgentMail", version: "1.0.0" },
+          "x-service-info": { name: "AgentMail" },
+          paths: expect.arrayContaining([
+            {
+              method: "GET",
+              path: "/v0/inboxes",
+              summary: "List inboxes",
+            },
+            {
+              method: "POST",
+              path: "/v0/inboxes",
+              summary: "Create inbox",
+              offers: {
+                offers: [{ method: "tempo", amount: "2000000" }],
+              },
+            },
+          ]),
+        }),
+      }),
+    );
+    expect(body.result.structuredContent.openapi).not.toHaveProperty(
+      "document",
+    );
+  });
+
+  it("returns the raw OpenAPI document when requested and under the cap", async () => {
+    const document = openApiDocument();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        expect(String(input)).toBe("https://example.com/openapi.json");
+        return Response.json(document);
+      }),
+    );
+
+    const body = await callTool("get_openapi", {
+      service: "anthropic",
+      raw: true,
+    });
+    expect(body.result.structuredContent.openapi).toEqual(
+      expect.objectContaining({
+        source: "docs.openapi",
+        raw: true,
+        summary: false,
+        document,
+      }),
+    );
+  });
+
+  it("returns a summary with a note when raw OpenAPI exceeds the cap", async () => {
+    const document = openApiDocument({
+      paths: {
+        "/large": {
+          get: {
+            summary: "Large operation",
+            description: "x".repeat(270 * 1024),
+          },
+        },
+      },
+    });
+    const bodyText = JSON.stringify(document);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(bodyText, {
+            headers: {
+              "content-type": "application/json",
+              "content-length": String(bodyText.length),
+            },
+          }),
+      ),
+    );
+
+    const body = await callTool("get_openapi", {
+      service: "anthropic",
+      raw: true,
+    });
+    expect(body.result.structuredContent.openapi).toEqual(
+      expect.objectContaining({
+        source: "docs.openapi",
+        raw: false,
+        summary: true,
+        note: expect.stringContaining("returning summary"),
+        paths: [{ method: "GET", path: "/large", summary: "Large operation" }],
+      }),
+    );
+    expect(body.result.structuredContent.openapi).not.toHaveProperty(
+      "document",
+    );
+  });
+
+  it("rejects HTML and non-OpenAPI JSON candidates before registry fallback", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input) === "https://example.com/openapi.json") {
+        return Response.json({ ok: true });
+      }
+      if (String(input) === "https://api.anthropic.com/openapi.json") {
+        return new Response("<html>not an OpenAPI document</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      }
+      throw new Error(`Unexpected fetch ${String(input)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const body = await callTool("get_openapi", { service: "anthropic" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(body.result.structuredContent).toEqual(
+      expect.objectContaining({
+        source: "registry",
+        openapi: expect.objectContaining({
+          source: "registry",
+          endpoints: expect.arrayContaining([
+            expect.objectContaining({ path: "/v1/messages" }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("rejects non-HTTPS candidates and over-long redirect chains", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "/next-openapi.json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const body = await mcp(
+      "tools/call",
+      { name: "get_openapi", arguments: { service: "http-only" } },
+      envWithCatalogFor([
+        {
+          ...services[0],
+          id: "http-only",
+          name: "HTTP Only",
+          url: "http://example.com",
+          docs: { openapi: "http://example.com/openapi.json" },
+        },
+      ]),
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "http://example.com/openapi.json",
+    );
+    expect(body.result.structuredContent.source).toBe("registry");
+
+    const redirectBody = await callTool("get_openapi", {
+      service: "agentmail",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(redirectBody.result.structuredContent.source).toBe("registry");
+  });
+
+  it("falls back to the registry view when OpenAPI fetch candidates fail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("missing", { status: 404 })),
+    );
+
+    const body = await callTool("get_openapi", { service: "agentmail" });
+    expect(body.result.structuredContent).toEqual(
+      expect.objectContaining({
+        source: "registry",
+        openapi: expect.objectContaining({
+          source: "registry",
+          endpoints: expect.arrayContaining([
+            expect.objectContaining({ path: "/v0/inboxes" }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it("uses the advanced discovery documentation URL in the server card", () => {
+    expect(serverCard("https://mpp.dev/mcp/services")).toEqual(
+      expect.objectContaining({
+        documentationUrl: "https://mpp.dev/advanced/discovery",
+        serverInfo: expect.objectContaining({ name: "mpp-services-mcp" }),
+        transport: {
+          type: "streamable-http",
+          endpoint: "https://mpp.dev/mcp/services",
+        },
+      }),
+    );
+  });
+});
+
+async function callTool(name: string, args: Record<string, unknown>) {
+  return mcp("tools/call", { name, arguments: args }, envWithCatalog());
+}
+
+async function mcp(method: string, params: Record<string, unknown>, env: Env) {
+  const response = await handleMcp(
+    new Request("https://example.com/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    }),
+    env,
+    testContext(),
+  );
+  return response.json() as Promise<{
+    result: {
+      tools?: Array<{
+        name?: string;
+        inputSchema?: unknown;
+        outputSchema?: unknown;
+      }>;
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+      structuredContent: {
+        count?: number;
+        total?: number;
+        returned?: number;
+        offset?: number;
+        limit?: number;
+        source?: string;
+        services: Array<{ id: string }>;
+        openapi?: unknown;
+      };
+    };
+  }>;
+}
+
+function envWithCatalog(): Env {
+  return envWithCatalogFor(services);
+}
+
+function envWithCatalogFor(catalogServices: Service[]): Env {
+  const catalog: CachedCatalog = {
+    version: 1,
+    services: catalogServices,
+    fetchedAt: new Date().toISOString(),
+    sourceUrl: "https://mpp.dev/api/services",
+  };
+  return {
+    MPP_SERVICES_URL: "https://mpp.dev/api/services",
+    MPP_CATALOG_CACHE: {
+      async get() {
+        return catalog;
+      },
+      async put() {},
+    } as unknown as KVNamespace,
+  } as Env;
+}
+
+function openApiDocument(overrides: Record<string, unknown> = {}) {
+  return {
+    openapi: "3.1.0",
+    info: { title: "AgentMail", version: "1.0.0" },
+    "x-service-info": { name: "AgentMail" },
+    paths: {
+      "/v0/inboxes": {
+        post: { summary: "Create inbox" },
+      },
+    },
+    ...overrides,
+  };
+}
+
+function testContext(): ExecutionContext {
+  return {
+    waitUntil() {},
+    passThroughOnException() {},
+    props: {},
+  } as unknown as ExecutionContext;
+}
+
+function serviceId(service: { id: string }): string {
+  return service.id;
+}

--- a/workers/mcp-services/src/mcp.ts
+++ b/workers/mcp-services/src/mcp.ts
@@ -1,0 +1,1140 @@
+import { getCatalog } from "./cache.js";
+import {
+  findService,
+  listServiceSummaries,
+  offersForService,
+  registryOpenApiView,
+  type SearchServicesArgs,
+  searchServices,
+} from "./discovery.js";
+import { CATEGORIES, INTEGRATIONS, type Service, STATUSES } from "./types.js";
+
+const PROTOCOL_VERSION = "2025-06-18";
+const SERVER_VERSION = "1.0.0";
+const ADVISORY =
+  "Discovery is advisory; the runtime 402 Challenge is authoritative.";
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const OPENAPI_FETCH_TIMEOUT_MS = 3000;
+const MAX_OPENAPI_RAW_BYTES = 256 * 1024;
+const MAX_OPENAPI_FETCH_BYTES = 1024 * 1024;
+const MAX_OPENAPI_REDIRECTS = 3;
+const HTTP_METHODS = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "patch",
+  "head",
+  "options",
+  "trace",
+] as const;
+
+const INITIALIZE_INSTRUCTIONS = [
+  "Use this read-only MCP server to discover MPP paid API services and payment terms from https://mpp.dev/api/services.",
+  "Call list_services for a catalog overview, search_services to filter by query/category/payment method/integration/status, get_service for a full service record, get_offers for endpoint payment offers, and get_openapi for a service OpenAPI document or registry-derived endpoint view.",
+  ADVISORY,
+  "This server does not register services, execute payments, authorize requests, or replace runtime 402 Challenge validation.",
+].join(" ");
+
+type JsonRpcId = string | number | null;
+
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: JsonRpcId;
+  method?: string;
+  params?: unknown;
+};
+
+type ToolCallParams = {
+  name?: unknown;
+  arguments?: unknown;
+};
+
+type JsonRpcResponsePayload =
+  | { jsonrpc: "2.0"; id: JsonRpcId; result: unknown }
+  | { jsonrpc: "2.0"; id: JsonRpcId; error: { code: number; message: string } };
+
+type Pagination = {
+  limit: number;
+  offset: number;
+};
+
+type OpenApiSource =
+  | "docs.openapi"
+  | "well-known"
+  | "apiReference"
+  | "registry";
+
+type OpenApiCandidate = {
+  source: Exclude<OpenApiSource, "registry">;
+  url: string;
+};
+
+type OpenApiRequestOptions = {
+  raw: boolean;
+};
+
+type JsonObject = Record<string, unknown>;
+
+type OpenApiDocument = JsonObject & {
+  openapi?: unknown;
+  info?: unknown;
+  paths?: unknown;
+};
+
+type FetchedOpenApi = {
+  source: Exclude<OpenApiSource, "registry">;
+  url: string;
+  contentType: string;
+  bytes: number;
+  document: OpenApiDocument;
+};
+
+export async function handleMcp(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return jsonResponse(jsonRpcError(null, -32700, "Parse error"));
+  }
+
+  if (Array.isArray(payload)) {
+    const responses: JsonRpcResponsePayload[] = [];
+    for (const item of payload) {
+      const response = await handleMessage(asRequest(item), env, ctx);
+      if (response) responses.push(response);
+    }
+    if (responses.length === 0) return emptyAcceptedResponse();
+    return jsonResponse(responses);
+  }
+
+  const response = await handleMessage(asRequest(payload), env, ctx);
+  if (!response) return emptyAcceptedResponse();
+  return jsonResponse(response);
+}
+
+export function serverCard(endpoint: string) {
+  return {
+    $schema:
+      "https://static.modelcontextprotocol.io/schemas/mcp-server-card/v1.json",
+    version: "1.0",
+    protocolVersion: PROTOCOL_VERSION,
+    serverInfo: serverInfo(),
+    description:
+      "Read-only MCP server exposing the MPP service discovery catalog and payment terms as advisory MCP tools.",
+    documentationUrl: "https://mpp.dev/advanced/discovery",
+    iconUrl: "https://mpp.dev/favicon.svg",
+    transport: {
+      type: "streamable-http",
+      endpoint,
+    },
+    capabilities: {
+      tools: {},
+    },
+    authentication: {
+      required: false,
+      schemes: [],
+    },
+    instructions: INITIALIZE_INSTRUCTIONS,
+    tools: "dynamic",
+  };
+}
+
+export function jsonHeaders(extra?: HeadersInit): Headers {
+  const headers = new Headers(extra);
+  headers.set("content-type", "application/json");
+  headers.set("access-control-allow-origin", "*");
+  headers.set("access-control-allow-methods", "GET,POST,OPTIONS");
+  headers.set(
+    "access-control-allow-headers",
+    "content-type,mcp-protocol-version",
+  );
+  headers.set("mcp-protocol-version", PROTOCOL_VERSION);
+  return headers;
+}
+
+export function optionsResponse(): Response {
+  return new Response(null, { status: 204, headers: jsonHeaders() });
+}
+
+async function handleMessage(
+  request: JsonRpcRequest | undefined,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<JsonRpcResponsePayload | undefined> {
+  if (request?.jsonrpc !== "2.0" || typeof request.method !== "string") {
+    return jsonRpcError(request?.id ?? null, -32600, "Invalid Request");
+  }
+
+  switch (request.method) {
+    case "initialize":
+      return jsonRpcResult(
+        request.id ?? null,
+        initializeResult(request.params),
+      );
+    case "notifications/initialized":
+      return undefined;
+    case "ping":
+      return jsonRpcResult(request.id ?? null, {});
+    case "tools/list":
+      return jsonRpcResult(request.id ?? null, { tools: toolSchemas() });
+    case "tools/call":
+      return jsonRpcResult(
+        request.id ?? null,
+        await handleToolCall(toolCallParams(request.params), env, ctx),
+      );
+    case "resources/list":
+      return jsonRpcResult(request.id ?? null, { resources: [] });
+    case "resources/templates/list":
+      return jsonRpcResult(request.id ?? null, { resourceTemplates: [] });
+    case "prompts/list":
+      return jsonRpcResult(request.id ?? null, { prompts: [] });
+    default:
+      return jsonRpcError(
+        request.id ?? null,
+        -32601,
+        `Method not found: ${request.method}`,
+      );
+  }
+}
+
+async function handleToolCall(
+  params: ToolCallParams,
+  env: Env,
+  ctx: ExecutionContext,
+) {
+  const name = typeof params.name === "string" ? params.name : "";
+  const args = objectArgs(params.arguments);
+
+  try {
+    const catalog = await getCatalog(env, ctx);
+    const meta = {
+      advisory: ADVISORY,
+      catalogVersion: catalog.version,
+      cacheStatus: catalog.cacheStatus,
+      fetchedAt: catalog.fetchedAt,
+      sourceUrl: catalog.sourceUrl,
+    };
+
+    if (name === "list_services") {
+      const pagination = paginationArgs(args);
+      const services = listServiceSummaries(catalog.services);
+      const page = paginate(services, pagination);
+      return toolResult(
+        {
+          ...meta,
+          appliedFilters: {},
+          total: services.length,
+          returned: page.length,
+          offset: pagination.offset,
+          limit: pagination.limit,
+          services: page,
+        },
+        `Returned ${page.length} of ${services.length} MPP services. ${ADVISORY}`,
+      );
+    }
+
+    if (name === "search_services") {
+      const filters = searchArgs(args);
+      const pagination = paginationArgs(args);
+      const services = searchServices(catalog.services, filters);
+      const page = paginate(services, pagination);
+      return toolResult(
+        {
+          ...meta,
+          appliedFilters: filters,
+          total: services.length,
+          returned: page.length,
+          offset: pagination.offset,
+          limit: pagination.limit,
+          services: page,
+        },
+        `Returned ${page.length} of ${services.length} MPP services. ${ADVISORY}`,
+      );
+    }
+
+    if (name === "get_service") {
+      const idOrName = requiredString(args, "id_or_name");
+      const service = requireService(catalog.services, idOrName);
+      return toolResult(
+        {
+          ...meta,
+          appliedFilters: { id_or_name: idOrName },
+          count: 1,
+          service,
+        },
+        `Returned service ${service.id}. ${ADVISORY}`,
+      );
+    }
+
+    if (name === "get_offers") {
+      const serviceName = requiredString(args, "service");
+      const service = requireService(catalog.services, serviceName);
+      const route = optionalString(args, "route");
+      const offers = offersForService(service, route);
+      return toolResult(
+        {
+          ...meta,
+          appliedFilters: { service: serviceName, ...(route ? { route } : {}) },
+          service: serviceRef(service),
+          ...(route ? { route } : {}),
+          count: offers.length,
+          offers,
+        },
+        `Returned ${offers.length} payment offers for ${service.id}. ${ADVISORY}`,
+      );
+    }
+
+    if (name === "get_openapi") {
+      const serviceName = requiredString(args, "service");
+      const raw = booleanArg(args, "raw", false);
+      const service = requireService(catalog.services, serviceName);
+      const openapi = await openApiFor(service, { raw });
+      return toolResult(
+        {
+          ...meta,
+          appliedFilters: { service: serviceName, ...(raw ? { raw } : {}) },
+          service: serviceRef(service),
+          count: 1,
+          source: openapi.source,
+          openapi,
+        },
+        `${openapi.source === "registry" ? "Returned registry endpoint view" : `Fetched ${openapi.source} OpenAPI candidate`} for ${service.id}. ${ADVISORY}`,
+      );
+    }
+
+    return toolError(`Unknown tool: ${name || "(missing)"}`);
+  } catch (error) {
+    return toolError(errorMessage(error));
+  }
+}
+
+async function openApiFor(service: Service, options: OpenApiRequestOptions) {
+  for (const candidate of openApiCandidates(service)) {
+    const fetched = await fetchOpenApiCandidate(candidate, options);
+    if (fetched) return fetched;
+  }
+
+  return registryOpenApiView(service);
+}
+
+function openApiCandidates(service: Service): OpenApiCandidate[] {
+  return [
+    ...(service.docs?.openapi
+      ? [{ source: "docs.openapi" as const, url: service.docs.openapi }]
+      : []),
+    { source: "well-known" as const, url: openApiConventionUrl(service.url) },
+    ...(service.docs?.apiReference
+      ? [{ source: "apiReference" as const, url: service.docs.apiReference }]
+      : []),
+  ];
+}
+
+function openApiConventionUrl(serviceUrl: string): string {
+  return `${serviceUrl.replace(/\/+$/, "")}/openapi.json`;
+}
+
+async function fetchOpenApiCandidate(
+  candidate: OpenApiCandidate,
+  options: OpenApiRequestOptions,
+) {
+  let url = httpsUrl(candidate.url);
+  if (!url) return undefined;
+
+  for (
+    let redirectCount = 0;
+    redirectCount <= MAX_OPENAPI_REDIRECTS;
+    redirectCount += 1
+  ) {
+    const response = await fetchOpenApiResponse(url);
+    if (!response) return undefined;
+
+    if (isRedirectStatus(response.status)) {
+      if (redirectCount === MAX_OPENAPI_REDIRECTS) return undefined;
+      const nextUrl = httpsRedirectUrl(response.headers.get("location"), url);
+      if (!nextUrl) return undefined;
+      url = nextUrl;
+      continue;
+    }
+
+    if (response.status !== 200) return undefined;
+
+    const contentType = response.headers.get("content-type") ?? "unknown";
+    const body = await readTextWithLimit(response, MAX_OPENAPI_FETCH_BYTES);
+    if (!body) return undefined;
+
+    const document = parseOpenApiDocument(body.text);
+    if (!document) return undefined;
+
+    return formatOpenApiDocument(
+      {
+        source: candidate.source,
+        url: url.toString(),
+        contentType,
+        bytes: body.bytes,
+        document,
+      },
+      options,
+    );
+  }
+
+  return undefined;
+}
+
+async function fetchOpenApiResponse(url: URL): Promise<Response | undefined> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    OPENAPI_FETCH_TIMEOUT_MS,
+  );
+  try {
+    return await fetch(url.toString(), {
+      headers: { accept: "application/json, */*" },
+      redirect: "manual",
+      cf: { cacheTtl: 300 },
+      signal: controller.signal,
+    });
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function formatOpenApiDocument(
+  fetched: FetchedOpenApi,
+  options: OpenApiRequestOptions,
+) {
+  if (options.raw && fetched.bytes <= MAX_OPENAPI_RAW_BYTES) {
+    return {
+      source: fetched.source,
+      url: fetched.url,
+      sourceUrl: fetched.url,
+      contentType: fetched.contentType,
+      bytes: fetched.bytes,
+      raw: true,
+      summary: false,
+      document: fetched.document,
+    };
+  }
+
+  return {
+    source: fetched.source,
+    url: fetched.url,
+    sourceUrl: fetched.url,
+    contentType: fetched.contentType,
+    bytes: fetched.bytes,
+    raw: false,
+    summary: true,
+    ...summarizeOpenApiDocument(fetched.document),
+    ...(options.raw && fetched.bytes > MAX_OPENAPI_RAW_BYTES
+      ? {
+          note: `Raw OpenAPI document is ${fetched.bytes} bytes, above the ${MAX_OPENAPI_RAW_BYTES} byte cap; returning summary instead.`,
+        }
+      : {}),
+  };
+}
+
+function summarizeOpenApiDocument(document: OpenApiDocument) {
+  return {
+    ...(typeof document.openapi === "string"
+      ? { openapiVersion: document.openapi }
+      : {}),
+    info: openApiInfo(document.info),
+    ...(document["x-service-info"] !== undefined
+      ? { "x-service-info": document["x-service-info"] }
+      : {}),
+    paths: summarizeOpenApiPaths(document.paths),
+  };
+}
+
+function openApiInfo(value: unknown) {
+  if (!isRecord(value)) return {};
+  return {
+    ...(typeof value.title === "string" ? { title: value.title } : {}),
+    ...(typeof value.version === "string" ? { version: value.version } : {}),
+  };
+}
+
+function summarizeOpenApiPaths(paths: unknown) {
+  if (!isRecord(paths)) return [];
+
+  const summaries: Array<Record<string, unknown>> = [];
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (!isRecord(pathItem)) continue;
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (!isRecord(operation)) continue;
+      const summary =
+        typeof operation.summary === "string"
+          ? operation.summary
+          : typeof operation.description === "string"
+            ? operation.description
+            : undefined;
+      const offers = operation["x-payment-info"] ?? pathItem["x-payment-info"];
+      summaries.push({
+        method: method.toUpperCase(),
+        path,
+        ...(summary ? { summary } : {}),
+        ...(offers !== undefined ? { offers } : {}),
+      });
+    }
+  }
+  return summaries;
+}
+
+async function readTextWithLimit(
+  response: Response,
+  maxBytes: number,
+): Promise<{ text: string; bytes: number } | undefined> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const parsedLength = Number(contentLength);
+    if (Number.isFinite(parsedLength) && parsedLength > maxBytes) {
+      return undefined;
+    }
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = await response.text();
+    const bytes = utf8Bytes(text);
+    return bytes <= maxBytes ? { text, bytes } : undefined;
+  }
+
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let bytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    bytes += value.byteLength;
+    if (bytes > maxBytes) {
+      await reader.cancel();
+      return undefined;
+    }
+    chunks.push(decoder.decode(value, { stream: true }));
+  }
+  chunks.push(decoder.decode());
+  return { text: chunks.join(""), bytes };
+}
+
+function parseOpenApiDocument(text: string): OpenApiDocument | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(parsed)) return undefined;
+  if (typeof parsed.openapi === "string" || isRecord(parsed.paths)) {
+    return parsed as OpenApiDocument;
+  }
+  return undefined;
+}
+
+function httpsUrl(value: string): URL | undefined {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function httpsRedirectUrl(
+  location: string | null,
+  baseUrl: URL,
+): URL | undefined {
+  if (!location) return undefined;
+  try {
+    const url = new URL(location, baseUrl);
+    return url.protocol === "https:" ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRedirectStatus(status: number): boolean {
+  return [301, 302, 303, 307, 308].includes(status);
+}
+
+function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function initializeResult(params: unknown) {
+  const requested =
+    typeof params === "object" && params !== null
+      ? (params as { protocolVersion?: unknown }).protocolVersion
+      : undefined;
+  const protocolVersion =
+    typeof requested === "string" && requested.length > 0
+      ? requested
+      : PROTOCOL_VERSION;
+
+  return {
+    protocolVersion:
+      protocolVersion === PROTOCOL_VERSION
+        ? PROTOCOL_VERSION
+        : PROTOCOL_VERSION,
+    capabilities: {
+      tools: {},
+    },
+    serverInfo: serverInfo(),
+    instructions: INITIALIZE_INSTRUCTIONS,
+  };
+}
+
+function serverInfo() {
+  return {
+    name: "mpp-services-mcp",
+    title: "MPP Services MCP server",
+    version: SERVER_VERSION,
+  };
+}
+
+function toolSchemas() {
+  const advisory = ` ${ADVISORY}`;
+  return [
+    {
+      name: "list_services",
+      description:
+        "List MPP discovery catalog services with id, name, URL, categories, integration, status, and description." +
+        advisory,
+      inputSchema: {
+        type: "object",
+        properties: paginationInputProperties(),
+        additionalProperties: false,
+      },
+      outputSchema: paginatedServicesOutputSchema(),
+      execution: { taskSupport: "forbidden" },
+    },
+    {
+      name: "search_services",
+      description:
+        "Search MPP services by simple substring query over name, description, and tags, plus exact filters for category, payment method, integration, and status." +
+        advisory,
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Substring query." },
+          category: {
+            type: "string",
+            enum: CATEGORIES,
+            description: "Exact category filter.",
+          },
+          method: {
+            type: "string",
+            description: "Exact payment method filter, for example tempo.",
+          },
+          integration: {
+            type: "string",
+            enum: INTEGRATIONS,
+            description: "Exact integration filter.",
+          },
+          status: {
+            type: "string",
+            enum: STATUSES,
+            description: "Exact status filter.",
+          },
+          ...paginationInputProperties(),
+        },
+        additionalProperties: false,
+      },
+      outputSchema: paginatedServicesOutputSchema(),
+      execution: { taskSupport: "forbidden" },
+    },
+    {
+      name: "get_service",
+      description: `Get the full MPP Service record by id or name.${advisory}`,
+      inputSchema: {
+        type: "object",
+        properties: {
+          id_or_name: {
+            type: "string",
+            description: "Service id or exact service name.",
+          },
+        },
+        required: ["id_or_name"],
+        additionalProperties: false,
+      },
+      outputSchema: serviceOutputSchema(),
+      execution: { taskSupport: "forbidden" },
+    },
+    {
+      name: "get_offers",
+      description:
+        "Return endpoint payment offers for a service, optionally filtered by route substring." +
+        advisory,
+      inputSchema: {
+        type: "object",
+        properties: {
+          service: { type: "string", description: "Service id or name." },
+          route: {
+            type: "string",
+            description: "Optional route substring such as POST /v1/messages.",
+          },
+        },
+        required: ["service"],
+        additionalProperties: false,
+      },
+      outputSchema: offersOutputSchema(),
+      execution: { taskSupport: "forbidden" },
+    },
+    {
+      name: "get_openapi",
+      description:
+        "Fetch and summarize OpenAPI data using service.docs.openapi, service.url/openapi.json, service.docs.apiReference, then a registry-derived endpoint view; set raw true for the full document when it is under the raw byte cap." +
+        advisory,
+      inputSchema: {
+        type: "object",
+        properties: {
+          service: { type: "string", description: "Service id or name." },
+          raw: {
+            type: "boolean",
+            default: false,
+            description: `Return the full fetched OpenAPI document when it is at or below ${MAX_OPENAPI_RAW_BYTES} bytes; larger documents return a summary with a note.`,
+          },
+        },
+        required: ["service"],
+        additionalProperties: false,
+      },
+      outputSchema: openApiOutputSchema(),
+      execution: { taskSupport: "forbidden" },
+    },
+  ] as const;
+}
+
+function paginationInputProperties() {
+  return {
+    limit: {
+      type: "integer",
+      minimum: 1,
+      maximum: MAX_LIMIT,
+      default: DEFAULT_LIMIT,
+      description: `Maximum number of services to return, up to ${MAX_LIMIT}.`,
+    },
+    offset: {
+      type: "integer",
+      minimum: 0,
+      default: 0,
+      description:
+        "Number of matching services to skip before returning results.",
+    },
+  };
+}
+
+function paginatedServicesOutputSchema() {
+  return oneOfSuccessOrError({
+    type: "object",
+    properties: {
+      ...commonEnvelopeProperties(),
+      appliedFilters: { type: "object", additionalProperties: true },
+      total: { type: "integer", minimum: 0 },
+      returned: { type: "integer", minimum: 0 },
+      offset: { type: "integer", minimum: 0 },
+      limit: { type: "integer", minimum: 1, maximum: MAX_LIMIT },
+      services: {
+        type: "array",
+        items: serviceSummarySchema(),
+      },
+    },
+    required: [
+      "advisory",
+      "catalogVersion",
+      "cacheStatus",
+      "fetchedAt",
+      "sourceUrl",
+      "appliedFilters",
+      "total",
+      "returned",
+      "offset",
+      "limit",
+      "services",
+    ],
+    additionalProperties: false,
+  });
+}
+
+function serviceOutputSchema() {
+  return oneOfSuccessOrError({
+    type: "object",
+    properties: {
+      ...commonEnvelopeProperties(),
+      appliedFilters: { type: "object", additionalProperties: true },
+      count: { type: "integer", const: 1 },
+      service: serviceSchema(),
+    },
+    required: [
+      "advisory",
+      "catalogVersion",
+      "cacheStatus",
+      "fetchedAt",
+      "sourceUrl",
+      "appliedFilters",
+      "count",
+      "service",
+    ],
+    additionalProperties: false,
+  });
+}
+
+function offersOutputSchema() {
+  return oneOfSuccessOrError({
+    type: "object",
+    properties: {
+      ...commonEnvelopeProperties(),
+      appliedFilters: { type: "object", additionalProperties: true },
+      service: serviceRefSchema(),
+      route: { type: "string" },
+      count: { type: "integer", minimum: 0 },
+      offers: {
+        type: "array",
+        items: offerSchema(),
+      },
+    },
+    required: [
+      "advisory",
+      "catalogVersion",
+      "cacheStatus",
+      "fetchedAt",
+      "sourceUrl",
+      "appliedFilters",
+      "service",
+      "count",
+      "offers",
+    ],
+    additionalProperties: false,
+  });
+}
+
+function openApiOutputSchema() {
+  return oneOfSuccessOrError({
+    type: "object",
+    properties: {
+      ...commonEnvelopeProperties(),
+      appliedFilters: { type: "object", additionalProperties: true },
+      service: serviceRefSchema(),
+      count: { type: "integer", const: 1 },
+      source: {
+        type: "string",
+        enum: ["docs.openapi", "well-known", "apiReference", "registry"],
+      },
+      openapi: {
+        type: "object",
+        properties: {
+          source: {
+            type: "string",
+            enum: ["docs.openapi", "well-known", "apiReference", "registry"],
+          },
+          url: { type: "string" },
+          sourceUrl: { type: "string" },
+          contentType: { type: "string" },
+          bytes: { type: "integer", minimum: 0 },
+          raw: { type: "boolean" },
+          summary: { type: "boolean" },
+          openapiVersion: { type: "string" },
+          info: { type: "object", additionalProperties: true },
+          "x-service-info": {
+            additionalProperties: true,
+          },
+          paths: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                method: { type: "string" },
+                path: { type: "string" },
+                summary: { type: "string" },
+                offers: {},
+              },
+              required: ["method", "path"],
+              additionalProperties: true,
+            },
+          },
+          document: { type: "object", additionalProperties: true },
+          note: { type: "string" },
+        },
+        additionalProperties: true,
+      },
+    },
+    required: [
+      "advisory",
+      "catalogVersion",
+      "cacheStatus",
+      "fetchedAt",
+      "sourceUrl",
+      "appliedFilters",
+      "service",
+      "count",
+      "source",
+      "openapi",
+    ],
+    additionalProperties: false,
+  });
+}
+
+function commonEnvelopeProperties() {
+  return {
+    advisory: { type: "string", const: ADVISORY },
+    catalogVersion: { type: "integer" },
+    cacheStatus: { type: "string", enum: ["fresh", "stale", "refreshed"] },
+    fetchedAt: { type: "string" },
+    sourceUrl: { type: "string" },
+  };
+}
+
+function serviceSummarySchema() {
+  return {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      url: { type: "string" },
+      categories: {
+        type: "array",
+        items: { type: "string", enum: CATEGORIES },
+      },
+      integration: { type: "string", enum: INTEGRATIONS },
+      status: { type: "string", enum: STATUSES },
+      description: { type: "string" },
+    },
+    required: ["id", "name", "url", "categories", "status"],
+    additionalProperties: false,
+  };
+}
+
+function serviceSchema() {
+  return {
+    type: "object",
+    required: ["id", "name", "url", "methods", "endpoints"],
+    additionalProperties: true,
+  };
+}
+
+function serviceRefSchema() {
+  return {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      url: { type: "string" },
+      serviceUrl: { type: "string" },
+    },
+    required: ["id", "name", "url"],
+    additionalProperties: false,
+  };
+}
+
+function offerSchema() {
+  return {
+    type: "object",
+    properties: {
+      method: { type: "string" },
+      path: { type: "string" },
+      description: { type: "string" },
+      docs: { type: "string" },
+      payment: { type: "object", additionalProperties: true },
+    },
+    required: ["method", "path", "payment"],
+    additionalProperties: false,
+  };
+}
+
+function oneOfSuccessOrError(successSchema: Record<string, unknown>) {
+  return {
+    type: "object",
+    oneOf: [
+      successSchema,
+      {
+        type: "object",
+        properties: {
+          success: { type: "boolean", const: false },
+          error: { type: "string" },
+          advisory: { type: "string", const: ADVISORY },
+        },
+        required: ["success", "error", "advisory"],
+        additionalProperties: false,
+      },
+    ],
+  };
+}
+
+function toolResult(structuredContent: unknown, text: string) {
+  return {
+    content: [{ type: "text", text }],
+    structuredContent,
+  };
+}
+
+function toolError(message: string) {
+  return {
+    content: [{ type: "text", text: `${message}. ${ADVISORY}` }],
+    structuredContent: { success: false, error: message, advisory: ADVISORY },
+    isError: true,
+  };
+}
+
+function searchArgs(args: Record<string, unknown>): SearchServicesArgs {
+  const query = optionalString(args, "query");
+  const method = optionalString(args, "method");
+  const category = optionalEnumArg(args, "category", CATEGORIES);
+  const integration = optionalEnumArg(args, "integration", INTEGRATIONS);
+  const status = optionalEnumArg(args, "status", STATUSES);
+
+  return {
+    ...(query ? { query } : {}),
+    ...(category ? { category } : {}),
+    ...(method ? { method } : {}),
+    ...(integration ? { integration } : {}),
+    ...(status ? { status } : {}),
+  };
+}
+
+function paginationArgs(args: Record<string, unknown>): Pagination {
+  return {
+    limit: integerArg(args, "limit", DEFAULT_LIMIT, 1, MAX_LIMIT),
+    offset: integerArg(args, "offset", 0, 0),
+  };
+}
+
+function booleanArg(
+  args: Record<string, unknown>,
+  key: string,
+  defaultValue: boolean,
+): boolean {
+  if (!(key in args)) return defaultValue;
+  const value = args[key];
+  if (typeof value !== "boolean") throw new Error(`${key} must be a boolean`);
+  return value;
+}
+
+function paginate<T>(items: T[], pagination: Pagination): T[] {
+  return items.slice(pagination.offset, pagination.offset + pagination.limit);
+}
+
+function requireService(services: Service[], idOrName: string): Service {
+  const service = findService(services, idOrName);
+  if (!service) throw new Error(`Unknown service: ${idOrName}`);
+  return service;
+}
+
+function serviceRef(service: Service) {
+  return {
+    id: service.id,
+    name: service.name,
+    url: service.url,
+    ...(service.serviceUrl ? { serviceUrl: service.serviceUrl } : {}),
+  };
+}
+
+function requiredString(args: Record<string, unknown>, key: string): string {
+  const value = optionalString(args, key);
+  if (!value) throw new Error(`${key} must be a non-empty string`);
+  return value;
+}
+
+function optionalString(
+  args: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = args[key];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function optionalEnumArg<const T extends readonly string[]>(
+  args: Record<string, unknown>,
+  key: string,
+  values: T,
+): T[number] | undefined {
+  if (!(key in args)) return undefined;
+  const value = args[key];
+  if (typeof value !== "string" || !values.includes(value)) {
+    throw new Error(
+      `Invalid ${key}: ${String(value)}. Allowed values: ${values.join(", ")}`,
+    );
+  }
+  return value as T[number];
+}
+
+function integerArg(
+  args: Record<string, unknown>,
+  key: string,
+  defaultValue: number,
+  minimum: number,
+  maximum = Number.MAX_SAFE_INTEGER,
+): number {
+  if (!(key in args)) return defaultValue;
+  const value = args[key];
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim() !== ""
+        ? Number(value)
+        : Number.NaN;
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    const range =
+      maximum === Number.MAX_SAFE_INTEGER
+        ? `at least ${minimum}`
+        : `between ${minimum} and ${maximum}`;
+    throw new Error(`${key} must be an integer ${range}`);
+  }
+  return parsed;
+}
+
+function objectArgs(value: unknown): Record<string, unknown> {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function toolCallParams(value: unknown): ToolCallParams {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as ToolCallParams;
+  }
+  return {};
+}
+
+function asRequest(value: unknown): JsonRpcRequest | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as JsonRpcRequest;
+}
+
+function jsonRpcResult(id: JsonRpcId, result: unknown): JsonRpcResponsePayload {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function jsonRpcError(
+  id: JsonRpcId,
+  code: number,
+  message: string,
+): JsonRpcResponsePayload {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), { headers: jsonHeaders() });
+}
+
+function emptyAcceptedResponse(): Response {
+  return new Response(null, { status: 202, headers: jsonHeaders() });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/workers/mcp-services/src/types.ts
+++ b/workers/mcp-services/src/types.ts
@@ -1,0 +1,77 @@
+export const CATEGORIES = [
+  "ai",
+  "blockchain",
+  "compute",
+  "data",
+  "media",
+  "search",
+  "social",
+  "storage",
+  "web",
+] as const;
+
+export type Category = (typeof CATEGORIES)[number];
+
+export const INTEGRATIONS = ["first-party", "third-party"] as const;
+export type Integration = (typeof INTEGRATIONS)[number];
+
+export const STATUSES = [
+  "active",
+  "beta",
+  "deprecated",
+  "maintenance",
+] as const;
+export type Status = (typeof STATUSES)[number];
+
+export interface EndpointPayment {
+  intent: string;
+  method: string;
+  amount?: string;
+  currency?: string;
+  decimals?: number;
+  recipient?: string;
+  unitType?: string;
+  description?: string;
+  dynamic?: true;
+  amountHint?: string;
+}
+
+export interface Endpoint {
+  method: string;
+  path: string;
+  description?: string;
+  payment?: EndpointPayment | null;
+  docs?: string;
+}
+
+export interface Service {
+  id: string;
+  name: string;
+  url: string;
+  serviceUrl?: string;
+  description?: string;
+  icon?: string;
+  categories?: Category[];
+  integration?: Integration;
+  tags?: string[];
+  status?: Status;
+  docs?: {
+    homepage?: string;
+    llmsTxt?: string;
+    openapi?: string;
+    apiReference?: string;
+  };
+  methods: Record<string, { intents: string[]; assets?: string[] }>;
+  realm?: string;
+  endpoints: Endpoint[];
+  provider?: { name?: string; url?: string; icon?: string };
+}
+
+export interface ServicesResponse {
+  version: number;
+  services: Service[];
+}
+
+export type WorkerEnv = Env & {
+  PUBLIC_MCP_ENDPOINT?: string;
+};

--- a/workers/mcp-services/tsconfig.json
+++ b/workers/mcp-services/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts", "worker-configuration.d.ts"]
+}

--- a/workers/mcp-services/vitest.config.ts
+++ b/workers/mcp-services/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/workers/mcp-services/wrangler.jsonc
+++ b/workers/mcp-services/wrangler.jsonc
@@ -1,0 +1,33 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "mpp-services-mcp",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-06-17",
+  "compatibility_flags": ["nodejs_compat"],
+  "account_id": "ba6ee3674b03f08481e57ff9992c601e",
+  "workers_dev": true,
+  "preview_urls": true,
+  "keep_vars": true,
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "invocation_logs": true
+    }
+  },
+  "triggers": {
+    "crons": ["0 * * * *"]
+  },
+  "kv_namespaces": [
+    {
+      "binding": "MPP_CATALOG_CACHE",
+      "id": "REPLACE_WITH_PRODUCTION_KV_NAMESPACE_ID"
+    }
+  ],
+  "vars": {
+    "MPP_SERVICES_URL": "https://mpp.dev/api/services",
+    "PUBLIC_MCP_ENDPOINT": "https://mpp.dev/mcp/services"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `workers/mcp-services`, a read-only Cloudflare Worker MCP server for the MPP services catalog.
- Exposes production routing through a Vercel rewrite at `/mcp/services` when `MPP_SERVICES_MCP_WORKER_ORIGIN` is set.
- Keeps `/.well-known/mcp.json` and `/api/mcp` unchanged for the existing docs MCP.
- Adds Worker CI coverage and a main-branch deploy workflow using `CLOUDFLARE_API_TOKEN`.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter mpp-services-mcp check`
- `pnpm --filter mpp-services-mcp deploy:dry-run`
- `pnpm check:ci`
- `node scripts/generate-discovery.ts`
- `pnpm check:types`
- `pnpm test`
- `pnpm check:generated`
- `pnpm build`

## Rollout before merge
- Deploy `mpp-services-mcp` once to Tempo Production Resources so the production workers.dev origin is confirmed.
- Set Vercel production env var `MPP_SERVICES_MCP_WORKER_ORIGIN` on the `tempoxyz/mpp` project to that Worker origin.
- Confirm `https://mpp.dev/.well-known/mcp.json` still points to `https://mpp.dev/api/mcp` after the Vercel deployment.
