### PR TITLE
Use supported Vercel config file

### DIFF
--- a/vercel.ts
+++ b/vercel.ts
@@ -12,17 +12,12 @@ const OPENAPI_DISCOVERY_LINK_VALUE = [
   '</.well-known/agent-skills/index.json>; rel="describedby"; type="application/json"',
 ].join(", ");
 
-const MPP_SERVICES_MCP_WORKER_ORIGIN =
-  process.env.MPP_SERVICES_MCP_WORKER_ORIGIN?.replace(/\/+$/, "");
-
-if (
-  process.env.VERCEL_ENV === "production" &&
-  !MPP_SERVICES_MCP_WORKER_ORIGIN
-) {
-  throw new Error(
-    "MPP_SERVICES_MCP_WORKER_ORIGIN must be set for production Vercel builds",
-  );
-}
+const DEFAULT_MPP_SERVICES_MCP_WORKER_ORIGIN =
+  "https://mpp-services-mcp.porto.workers.dev";
+const MPP_SERVICES_MCP_WORKER_ORIGIN = (
+  process.env.MPP_SERVICES_MCP_WORKER_ORIGIN ||
+  DEFAULT_MPP_SERVICES_MCP_WORKER_ORIGIN
+).replace(/\/+$/, "");
 
 const CONTENT_NEGOTIATION_HEADERS = [header("Vary", "Accept, User-Agent")];
 


### PR DESCRIPTION
## Summary
- Renames the Vercel project config from `vercel.mjs` to supported `vercel.ts` so Vercel applies headers and rewrites.
- Keeps `MPP_SERVICES_MCP_WORKER_ORIGIN` override support and falls back to the deployed production Worker origin.

## Verification
- `pnpm exec tsx -e "process.env.VERCEL_ENV='production'; delete process.env.MPP_SERVICES_MCP_WORKER_ORIGIN; import('./vercel.ts').then(({ config }) => console.log(JSON.stringify(config.rewrites)))"`
- `pnpm exec biome check vercel.ts`
- `pnpm exec vercel build --prod --scope tempoxyz` reached the app build after compiling `vercel.ts`; local build then failed on pulled encrypted private-key env, while cloud production builds have the real env.
