### PR TITLE
Use environment Cloudflare config for MCP services

### DIFF
--- a/.github/workflows/mcp-services-deploy.yml
+++ b/.github/workflows/mcp-services-deploy.yml
@@ -24,7 +24,10 @@ jobs:
   deploy:
     name: mpp-services-mcp
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 20
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -35,6 +38,18 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm mcp-services:check
+      - name: Check Cloudflare deploy environment
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          test -n "$CLOUDFLARE_ACCOUNT_ID" || {
+            echo "CLOUDFLARE_ACCOUNT_ID GitHub Environment variable is required"
+            exit 1
+          }
+          test -n "$CLOUDFLARE_API_TOKEN" || {
+            echo "CLOUDFLARE_API_TOKEN GitHub Environment secret is required"
+            exit 1
+          }
       - name: Deploy Worker
         run: pnpm mcp-services:deploy
         env:

--- a/src/pages/_api/mcp/services.ts
+++ b/src/pages/_api/mcp/services.ts
@@ -1,7 +1,3 @@
-const DEFAULT_WORKER_ORIGIN = "https://mpp-services-mcp.porto.workers.dev";
-const WORKER_ORIGIN = (
-  process.env.MPP_SERVICES_MCP_WORKER_ORIGIN || DEFAULT_WORKER_ORIGIN
-).replace(/\/+$/, "");
 const WORKER_PATH = "/mcp/services";
 
 export function OPTIONS() {
@@ -20,8 +16,16 @@ export async function POST(request: Request) {
 }
 
 async function proxyToWorker(request: Request) {
+  const workerOrigin = getWorkerOrigin();
+  if (!workerOrigin) {
+    return new Response("MPP_SERVICES_MCP_WORKER_ORIGIN is required", {
+      status: 500,
+      headers: corsHeaders(),
+    });
+  }
+
   const requestUrl = new URL(request.url);
-  const upstreamUrl = `${WORKER_ORIGIN}${WORKER_PATH}${requestUrl.search}`;
+  const upstreamUrl = `${workerOrigin}${WORKER_PATH}${requestUrl.search}`;
   const upstreamHeaders = new Headers(request.headers);
   upstreamHeaders.delete("host");
 
@@ -49,6 +53,18 @@ async function proxyToWorker(request: Request) {
     statusText: upstream.statusText,
     headers: responseHeaders,
   });
+}
+
+function getWorkerOrigin() {
+  const value = process.env.MPP_SERVICES_MCP_WORKER_ORIGIN?.trim();
+  if (!value) return undefined;
+
+  const url = new URL(value);
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("MPP_SERVICES_MCP_WORKER_ORIGIN must be an HTTP(S) origin");
+  }
+
+  return url.origin.replace(/\/+$/, "");
 }
 
 function corsHeaders() {

--- a/vercel.ts
+++ b/vercel.ts
@@ -12,12 +12,17 @@ const OPENAPI_DISCOVERY_LINK_VALUE = [
   '</.well-known/agent-skills/index.json>; rel="describedby"; type="application/json"',
 ].join(", ");
 
-const DEFAULT_MPP_SERVICES_MCP_WORKER_ORIGIN =
-  "https://mpp-services-mcp.porto.workers.dev";
-const MPP_SERVICES_MCP_WORKER_ORIGIN = (
-  process.env.MPP_SERVICES_MCP_WORKER_ORIGIN ||
-  DEFAULT_MPP_SERVICES_MCP_WORKER_ORIGIN
-).replace(/\/+$/, "");
+const MPP_SERVICES_MCP_WORKER_ORIGIN =
+  process.env.MPP_SERVICES_MCP_WORKER_ORIGIN?.replace(/\/+$/, "");
+
+if (
+  !MPP_SERVICES_MCP_WORKER_ORIGIN &&
+  process.env.VERCEL_ENV === "production"
+) {
+  throw new Error(
+    "MPP_SERVICES_MCP_WORKER_ORIGIN is required for production Vercel builds",
+  );
+}
 
 const CONTENT_NEGOTIATION_HEADERS = [header("Vary", "Accept, User-Agent")];
 

--- a/workers/mcp-services/README.md
+++ b/workers/mcp-services/README.md
@@ -8,8 +8,8 @@ Production endpoint:
 https://mpp.dev/mcp/services
 ```
 
-The production URL is served by the `mpp.dev` Vercel app through a rewrite to
-this Worker. Set the Vercel environment variable
+The production URL is served by the `mpp.dev` Vercel app through its MCP
+services proxy route. Set the Vercel environment variable
 `MPP_SERVICES_MCP_WORKER_ORIGIN` to the production Worker origin.
 
 Dev mirror:
@@ -78,20 +78,28 @@ pnpm --filter mpp-services-mcp check
 pnpm --filter mpp-services-mcp dev
 ```
 
-Deploys are pinned to the Tempo Production Cloudflare account:
+Production deploys run from the `production` GitHub Environment. Configure:
 
 ```text
-Tempo Production Resources / ba6ee3674b03f08481e57ff9992c601e
+CLOUDFLARE_ACCOUNT_ID=<production-account-id>  # GitHub Environment variable
+CLOUDFLARE_API_TOKEN=<deploy-token>            # GitHub Environment secret
 ```
 
-Deploy:
+The token is provisioned through `tempoxyz/secrets`; request `account: prd`
+with `account_settings_read`, `workers_scripts_write`, and
+`workers_kv_storage_write`.
+
+Local deployments use the same environment variables:
 
 ```bash
+export CLOUDFLARE_ACCOUNT_ID=<account-id>
+export CLOUDFLARE_API_TOKEN=<deploy-token>
 pnpm --filter mpp-services-mcp deploy:dry-run
 pnpm --filter mpp-services-mcp deploy
 ```
 
 The deploy script creates `wrangler.deploy.jsonc` locally, resolving or creating
 the production `MPP_CATALOG_CACHE` KV namespace before invoking Wrangler. It
-requires `CLOUDFLARE_API_TOKEN` with Account Read, Workers Scripts Write, and
-Workers KV Storage Write permissions. Zone permissions are not required.
+requires `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` with Account Read,
+Workers Scripts Write, and Workers KV Storage Write permissions. Zone
+permissions are not required.

--- a/workers/mcp-services/scripts/prepare-deploy-config.mjs
+++ b/workers/mcp-services/scripts/prepare-deploy-config.mjs
@@ -7,18 +7,15 @@ const DRY_RUN_PLACEHOLDER_ID = "00000000000000000000000000000000";
 const dryRun = process.argv.includes("--dry-run");
 
 const config = JSON.parse(await readFile(CONFIG_PATH, "utf8"));
-const accountId = config.account_id;
-const envAccountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+const accountId = expectAccountId();
 
-if (!accountId) {
-  throw new Error("wrangler.jsonc must include the production account_id");
-}
-
-if (envAccountId && envAccountId !== accountId) {
+if (config.account_id) {
   throw new Error(
-    `CLOUDFLARE_ACCOUNT_ID (${envAccountId}) does not match wrangler.jsonc account_id (${accountId})`,
+    "wrangler.jsonc must not include account_id; set CLOUDFLARE_ACCOUNT_ID in the deploy environment",
   );
 }
+
+config.account_id = accountId;
 
 const namespace = config.kv_namespaces?.find(
   (binding) => binding.binding === "MPP_CATALOG_CACHE",
@@ -44,6 +41,20 @@ await writeFile(DEPLOY_CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`);
 
 console.log(`Prepared ${DEPLOY_CONFIG_PATH.pathname}`);
 console.log(`Using KV namespace ${namespace.binding} (${namespaceId})`);
+
+function expectAccountId() {
+  const value = process.env.CLOUDFLARE_ACCOUNT_ID;
+
+  if (!value) {
+    throw new Error("CLOUDFLARE_ACCOUNT_ID is required");
+  }
+
+  if (!/^[0-9a-f]{32}$/i.test(value)) {
+    throw new Error("CLOUDFLARE_ACCOUNT_ID must be a 32-character hex id");
+  }
+
+  return value;
+}
 
 async function ensureKvNamespace(accountId, title) {
   const token = process.env.CLOUDFLARE_API_TOKEN;

--- a/workers/mcp-services/wrangler.jsonc
+++ b/workers/mcp-services/wrangler.jsonc
@@ -4,7 +4,6 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-06-17",
   "compatibility_flags": ["nodejs_compat"],
-  "account_id": "ba6ee3674b03f08481e57ff9992c601e",
   "workers_dev": true,
   "preview_urls": true,
   "keep_vars": true,


### PR DESCRIPTION
## Summary
- remove the committed Cloudflare account ID from the MCP services Wrangler config
- generate the deploy-only Wrangler config from `CLOUDFLARE_ACCOUNT_ID` at deploy time
- run the Worker deploy job in the `production` GitHub Environment and preflight the required variable/secret
- remove the committed workers.dev origin fallback from the Vercel config and MCP services proxy
- document the env-based deploy setup and `tempoxyz/secrets` token permissions

## Validation
- `pnpm mcp-services:check`
- `pnpm check:ci`
- `pnpm check:types`
- `CLOUDFLARE_ACCOUNT_ID=<production-account-id> pnpm --filter mpp-services-mcp run deploy:dry-run`
- `pnpm build`
- `pnpm test`

## Rollout
- `CLOUDFLARE_ACCOUNT_ID` is set as a `production` GitHub Environment variable on `tempoxyz/mpp`.
- `CLOUDFLARE_API_TOKEN` should be provisioned as a `production` GitHub Environment secret through `tempoxyz/secrets`.