### PR TITLE
Improve MPP services MCP for agent discovery

### DIFF
--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -31,7 +31,39 @@ Registries aggregate discovery documents from multiple services, making it easy 
 Agents can query the curated services directory over MCP at
 `https://mpp.dev/mcp/services`. The server is read-only and exposes tools to
 list services, search by category or payment method, inspect endpoint offers,
-and fetch advisory OpenAPI summaries.
+search offer-level payment terms, look up services by payment recipient, inspect
+available filters, and fetch advisory OpenAPI summaries.
+
+### Services MCP
+
+The services MCP server is the agent-facing discovery surface for the curated
+MPP directory:
+
+```text
+https://mpp.dev/mcp/services
+```
+
+Use it when an agent needs to:
+
+- find paid APIs by task, category, integration, or payment method
+- compare endpoint-level payment offers before constructing a request
+- identify which services publish offers for a payment recipient from a `402`
+  Challenge
+- inspect catalog facets before narrowing a search
+- fetch a live OpenAPI summary or registry-derived endpoint view
+
+```json
+{
+  "mcpServers": {
+    "mpp-services": {
+      "url": "https://mpp.dev/mcp/services"
+    }
+  }
+}
+```
+
+The MCP server is advisory and read-only. After discovery, clients call the
+target service directly and treat the runtime `402` Challenge as authoritative.
 
 ## Quick start
 

--- a/src/pages/services.mdx
+++ b/src/pages/services.mdx
@@ -13,7 +13,15 @@ import { ServicesPage } from "../components/ServicesPage";
 
 ## Agent discovery
 
-Agents can query the read-only services MCP server at
-`https://mpp.dev/mcp/services` to list and search the catalog, inspect payment
-offers, and fetch advisory OpenAPI summaries. Runtime `402` Challenges remain
-the authoritative source of payment terms.
+Agents can use the MPP services catalog before choosing which paid API to call:
+
+| Surface | URL | Use it for |
+| --- | --- | --- |
+| Web directory | [`https://mpp.dev/services`](https://mpp.dev/services) | Browse services, categories, providers, endpoints, and examples. |
+| Public catalog API | [`https://mpp.dev/api/services`](https://mpp.dev/api/services) | Fetch the JSON catalog directly from scripts, CLIs, or custom agents. |
+| Services MCP | [`https://mpp.dev/mcp/services`](https://mpp.dev/mcp/services) | Let an MCP-capable agent search services, search payment offers, inspect recipients, and fetch advisory OpenAPI summaries. |
+
+The services MCP server is read-only. It does not register services, execute
+payments, sign transactions, or proxy paid API calls. Runtime `402` Challenges
+from the target service remain the authoritative source of current payment
+terms.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -5,7 +5,6 @@ import { shikiStyleToClass } from "./src/shiki-style-to-class.js";
 const baseUrl = (() => {
   if (process.env.VERCEL_ENV === "production")
     return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
   if (process.env.NODE_ENV !== "production") return "https://localhost:5173";
   return "";
 })();

--- a/workers/mcp-services/README.md
+++ b/workers/mcp-services/README.md
@@ -54,9 +54,19 @@ paid API remains authoritative.
 
 - `list_services(limit?, offset?)`
 - `search_services(query?, category?, method?, integration?, status?, limit?, offset?)`
+- `search_offers(query?, category?, method?, currency?, maxAmount?, unitType?, dynamic?, recipient?, integration?, status?, limit?, offset?)`
+- `get_facets()`
+- `get_services_by_recipient(recipient, limit?, offset?)`
+- `get_catalog_status()`
 - `get_service(id_or_name)`
 - `get_offers(service, route?)`
 - `get_openapi(service, raw?)`
+
+`search_offers` is the preferred tool when an agent needs to choose a payable
+endpoint rather than a provider. It returns endpoint-level offers with service
+metadata, normalized display pricing where possible, match metadata, and
+ranking signals such as active status, first-party integration, fixed pricing,
+and OpenAPI availability.
 
 ## MCP client config
 

--- a/workers/mcp-services/src/discovery.ts
+++ b/workers/mcp-services/src/discovery.ts
@@ -25,6 +25,14 @@ export type SearchServicesArgs = {
   status?: Status;
 };
 
+export type SearchOffersArgs = SearchServicesArgs & {
+  currency?: string;
+  maxAmount?: string;
+  unitType?: string;
+  dynamic?: boolean;
+  recipient?: string;
+};
+
 export type Offer = {
   method: string;
   path: string;
@@ -33,16 +41,46 @@ export type Offer = {
   payment: EndpointPayment;
 };
 
+export type OfferSearchResult = Offer & {
+  service: ServiceSummary;
+  price?: {
+    amount?: string;
+    currency?: string;
+    decimals?: number;
+    display?: string;
+    unitType?: string;
+    dynamic: boolean;
+    amountHint?: string;
+  };
+  matchedOn: string[];
+  rankingSignals: string[];
+};
+
+export type FacetValue = {
+  value: string | boolean;
+  count: number;
+};
+
+export type CatalogFacets = {
+  categories: FacetValue[];
+  integrations: FacetValue[];
+  statuses: FacetValue[];
+  paymentMethods: FacetValue[];
+  currencies: FacetValue[];
+  unitTypes: FacetValue[];
+  intents: FacetValue[];
+  recipients: FacetValue[];
+  dynamic: FacetValue[];
+};
+
+export type RecipientServiceMatch = {
+  service: ServiceSummary;
+  count: number;
+  offers: Offer[];
+};
+
 export function listServiceSummaries(services: Service[]): ServiceSummary[] {
-  return services.map((service) => ({
-    id: service.id,
-    name: service.name,
-    url: service.url,
-    categories: service.categories ?? [],
-    ...(service.integration ? { integration: service.integration } : {}),
-    status: service.status ?? "active",
-    ...(service.description ? { description: service.description } : {}),
-  }));
+  return services.map(serviceSummary);
 }
 
 export function searchServices(
@@ -51,6 +89,105 @@ export function searchServices(
 ): ServiceSummary[] {
   return listServiceSummaries(
     services.filter((service) => serviceMatches(service, filters)),
+  );
+}
+
+export function searchOffers(
+  services: Service[],
+  filters: SearchOffersArgs,
+): OfferSearchResult[] {
+  const maxAmount = parseIntegerAmount(filters.maxAmount);
+
+  return services
+    .flatMap((service) =>
+      offersForService(service).map((offer) =>
+        offerSearchResult(service, offer, filters),
+      ),
+    )
+    .filter((offer) => offerMatches(offer, filters, maxAmount))
+    .sort((a, b) => offerScore(b, filters) - offerScore(a, filters));
+}
+
+export function servicesByRecipient(
+  services: Service[],
+  recipient: string,
+): RecipientServiceMatch[] {
+  const offers = searchOffers(services, { recipient });
+  const grouped = new Map<string, RecipientServiceMatch>();
+
+  for (const offer of offers) {
+    const paymentOffer = {
+      method: offer.method,
+      path: offer.path,
+      ...(offer.description ? { description: offer.description } : {}),
+      ...(offer.docs ? { docs: offer.docs } : {}),
+      payment: offer.payment,
+    };
+    const existing = grouped.get(offer.service.id);
+    if (existing) {
+      existing.count += 1;
+      existing.offers.push(paymentOffer);
+    } else {
+      grouped.set(offer.service.id, {
+        service: offer.service,
+        count: 1,
+        offers: [paymentOffer],
+      });
+    }
+  }
+
+  return [...grouped.values()];
+}
+
+export function getFacets(services: Service[]): CatalogFacets {
+  const categories = new Map<string, number>();
+  const integrations = new Map<string, number>();
+  const statuses = new Map<string, number>();
+  const paymentMethods = new Map<string, number>();
+  const currencies = new Map<string, number>();
+  const unitTypes = new Map<string, number>();
+  const intents = new Map<string, number>();
+  const recipients = new Map<string, number>();
+  const dynamic = new Map<string, number>();
+
+  for (const service of services) {
+    for (const category of service.categories ?? []) {
+      increment(categories, category);
+    }
+    if (service.integration) increment(integrations, service.integration);
+    increment(statuses, service.status ?? "active");
+
+    for (const offer of offersForService(service)) {
+      increment(paymentMethods, offer.payment.method);
+      increment(intents, offer.payment.intent);
+      increment(dynamic, String(Boolean(offer.payment.dynamic)));
+      if (offer.payment.currency) increment(currencies, offer.payment.currency);
+      if (offer.payment.unitType) increment(unitTypes, offer.payment.unitType);
+      if (offer.payment.recipient)
+        increment(recipients, offer.payment.recipient);
+    }
+  }
+
+  return {
+    categories: sortedFacetValues(categories),
+    integrations: sortedFacetValues(integrations),
+    statuses: sortedFacetValues(statuses),
+    paymentMethods: sortedFacetValues(paymentMethods),
+    currencies: sortedFacetValues(currencies),
+    unitTypes: sortedFacetValues(unitTypes),
+    intents: sortedFacetValues(intents),
+    recipients: sortedFacetValues(recipients),
+    dynamic: sortedFacetValues(dynamic).map((facet) => ({
+      value: facet.value === "true",
+      count: facet.count,
+    })),
+  };
+}
+
+export function countPaymentOffers(services: Service[]): number {
+  return services.reduce(
+    (count, service) => count + offersForService(service).length,
+    0,
   );
 }
 
@@ -102,6 +239,20 @@ export function registryOpenApiView(service: Service) {
   };
 }
 
+function offerSearchResult(
+  service: Service,
+  offer: Offer,
+  filters: SearchOffersArgs,
+): OfferSearchResult {
+  return {
+    ...offer,
+    service: serviceSummary(service),
+    price: priceSummary(offer.payment),
+    matchedOn: offerMatchedOn(service, offer, filters),
+    rankingSignals: rankingSignals(service, offer.payment),
+  };
+}
+
 function serviceMatches(
   service: Service,
   filters: SearchServicesArgs,
@@ -125,6 +276,67 @@ function serviceMatches(
   return true;
 }
 
+function offerMatches(
+  offer: OfferSearchResult,
+  filters: SearchOffersArgs,
+  maxAmount?: bigint,
+): boolean {
+  if (
+    filters.query &&
+    !offerMatchedOnFields(offer.service, offer, filters.query).length
+  ) {
+    return false;
+  }
+  if (
+    filters.category &&
+    !offer.service.categories.includes(filters.category)
+  ) {
+    return false;
+  }
+  if (
+    filters.integration &&
+    offer.service.integration !== filters.integration
+  ) {
+    return false;
+  }
+  if (filters.status && offer.service.status !== filters.status) return false;
+  if (
+    filters.method &&
+    !equalsNormalized(offer.payment.method, filters.method)
+  ) {
+    return false;
+  }
+  if (
+    filters.currency &&
+    !equalsNormalized(offer.payment.currency ?? "", filters.currency)
+  ) {
+    return false;
+  }
+  if (
+    filters.unitType &&
+    !equalsNormalized(offer.payment.unitType ?? "", filters.unitType)
+  ) {
+    return false;
+  }
+  if (
+    filters.recipient &&
+    !equalsNormalized(offer.payment.recipient ?? "", filters.recipient)
+  ) {
+    return false;
+  }
+  if (
+    filters.dynamic !== undefined &&
+    Boolean(offer.payment.dynamic) !== filters.dynamic
+  ) {
+    return false;
+  }
+  if (maxAmount !== undefined) {
+    const offerAmount = parseIntegerAmount(offer.payment.amount);
+    if (offerAmount === undefined || offerAmount > maxAmount) return false;
+  }
+  return true;
+}
+
 function queryMatches(service: Service, query: string): boolean {
   const needle = normalize(query);
   if (!needle) return true;
@@ -134,6 +346,180 @@ function queryMatches(service: Service, query: string): boolean {
       .join(" "),
   );
   return haystack.includes(needle);
+}
+
+function offerMatchedOn(
+  service: Service,
+  offer: Offer,
+  filters: SearchOffersArgs,
+): string[] {
+  const matched = new Set<string>();
+  if (filters.query) {
+    for (const field of offerMatchedOnFields(
+      serviceSummary(service),
+      offer,
+      filters.query,
+    )) {
+      matched.add(field);
+    }
+  }
+  if (
+    filters.category &&
+    (service.categories ?? []).includes(filters.category)
+  ) {
+    matched.add("service.categories");
+  }
+  if (filters.integration && service.integration === filters.integration) {
+    matched.add("service.integration");
+  }
+  if (filters.status && (service.status ?? "active") === filters.status) {
+    matched.add("service.status");
+  }
+  if (
+    filters.method &&
+    equalsNormalized(offer.payment.method, filters.method)
+  ) {
+    matched.add("payment.method");
+  }
+  if (
+    filters.currency &&
+    equalsNormalized(offer.payment.currency ?? "", filters.currency)
+  ) {
+    matched.add("payment.currency");
+  }
+  if (
+    filters.unitType &&
+    equalsNormalized(offer.payment.unitType ?? "", filters.unitType)
+  ) {
+    matched.add("payment.unitType");
+  }
+  if (
+    filters.recipient &&
+    equalsNormalized(offer.payment.recipient ?? "", filters.recipient)
+  ) {
+    matched.add("payment.recipient");
+  }
+  if (
+    filters.dynamic !== undefined &&
+    Boolean(offer.payment.dynamic) === filters.dynamic
+  ) {
+    matched.add("payment.dynamic");
+  }
+  if (filters.maxAmount && parseIntegerAmount(offer.payment.amount)) {
+    matched.add("payment.amount");
+  }
+  return [...matched];
+}
+
+function offerMatchedOnFields(
+  service: ServiceSummary,
+  offer: Offer,
+  query: string,
+): string[] {
+  const needle = normalize(query);
+  if (!needle) return [];
+
+  const fields: Array<[string, unknown]> = [
+    ["service.id", service.id],
+    ["service.name", service.name],
+    ["service.description", service.description],
+    ["endpoint.method", offer.method],
+    ["endpoint.path", offer.path],
+    ["endpoint.description", offer.description],
+    ["endpoint.docs", offer.docs],
+    ["payment.intent", offer.payment.intent],
+    ["payment.method", offer.payment.method],
+    ["payment.currency", offer.payment.currency],
+    ["payment.recipient", offer.payment.recipient],
+    ["payment.unitType", offer.payment.unitType],
+    ["payment.description", offer.payment.description],
+    ["payment.amountHint", offer.payment.amountHint],
+  ];
+
+  return fields
+    .filter(([, value]) => typeof value === "string")
+    .filter(([, value]) => normalize(value as string).includes(needle))
+    .map(([field]) => field);
+}
+
+function priceSummary(payment: EndpointPayment): OfferSearchResult["price"] {
+  return {
+    ...(payment.amount ? { amount: payment.amount } : {}),
+    ...(payment.currency ? { currency: payment.currency } : {}),
+    ...(payment.decimals !== undefined ? { decimals: payment.decimals } : {}),
+    ...(payment.amount && payment.currency
+      ? {
+          display: displayAmount(
+            payment.amount,
+            payment.decimals,
+            payment.currency,
+          ),
+        }
+      : {}),
+    ...(payment.unitType ? { unitType: payment.unitType } : {}),
+    dynamic: Boolean(payment.dynamic),
+    ...(payment.amountHint ? { amountHint: payment.amountHint } : {}),
+  };
+}
+
+function displayAmount(
+  amount: string,
+  decimals: number | undefined,
+  currency: string,
+): string | undefined {
+  const parsed = parseIntegerAmount(amount);
+  if (parsed === undefined) return undefined;
+  const places = decimals ?? 0;
+  if (places <= 0) return `${parsed.toString()} ${currency}`;
+
+  const divisor = 10n ** BigInt(places);
+  const whole = parsed / divisor;
+  const fraction = (parsed % divisor).toString().padStart(places, "0");
+  const trimmedFraction = fraction.replace(/0+$/, "");
+  return `${whole.toString()}${trimmedFraction ? `.${trimmedFraction}` : ""} ${currency}`;
+}
+
+function rankingSignals(service: Service, payment: EndpointPayment): string[] {
+  return [
+    (service.status ?? "active") === "active" ? "active" : undefined,
+    service.integration === "first-party" ? "first_party" : undefined,
+    service.docs?.openapi || service.docs?.apiReference
+      ? "has_openapi"
+      : undefined,
+    payment.amount && !payment.dynamic ? "fixed_price" : undefined,
+    payment.dynamic ? "dynamic_price" : undefined,
+    "has_payment_offer",
+  ].filter((signal): signal is string => Boolean(signal));
+}
+
+function offerScore(
+  offer: OfferSearchResult,
+  filters: SearchOffersArgs,
+): number {
+  let score = 0;
+  if (offer.service.status === "active") score += 30;
+  if (offer.service.integration === "first-party") score += 10;
+  if (offer.rankingSignals.includes("has_openapi")) score += 5;
+  if (offer.rankingSignals.includes("fixed_price")) score += 5;
+  if (filters.query && offer.matchedOn.includes("service.name")) score += 40;
+  if (filters.query && offer.matchedOn.includes("service.id")) score += 30;
+  if (filters.query && offer.matchedOn.includes("endpoint.path")) score += 20;
+  if (filters.query && offer.matchedOn.includes("payment.description")) {
+    score += 10;
+  }
+  return score;
+}
+
+function serviceSummary(service: Service): ServiceSummary {
+  return {
+    id: service.id,
+    name: service.name,
+    url: service.url,
+    categories: service.categories ?? [],
+    ...(service.integration ? { integration: service.integration } : {}),
+    status: service.status ?? "active",
+    ...(service.description ? { description: service.description } : {}),
+  };
 }
 
 function serviceHasMethod(service: Service, method: string): boolean {
@@ -147,6 +533,32 @@ function serviceHasMethod(service: Service, method: string): boolean {
   return service.endpoints.some(
     (endpoint) => normalize(endpoint.payment?.method ?? "") === wanted,
   );
+}
+
+function parseIntegerAmount(value: string | undefined): bigint | undefined {
+  if (!value || !/^\d+$/.test(value)) return undefined;
+  try {
+    return BigInt(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function equalsNormalized(left: string, right: string): boolean {
+  return normalize(left) === normalize(right);
+}
+
+function increment(map: Map<string, number>, value: string): void {
+  map.set(value, (map.get(value) ?? 0) + 1);
+}
+
+function sortedFacetValues(map: Map<string, number>): FacetValue[] {
+  return [...map.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort(
+      (a, b) =>
+        b.count - a.count || String(a.value).localeCompare(String(b.value)),
+    );
 }
 
 function endpointMatchesRoute(endpoint: Endpoint, route?: string): boolean {

--- a/workers/mcp-services/src/mcp.test.ts
+++ b/workers/mcp-services/src/mcp.test.ts
@@ -24,6 +24,11 @@ const services: Service[] = [
           intent: "charge",
           method: "tempo",
           amount: "2000000",
+          currency: "USDG",
+          decimals: 6,
+          recipient: "0xagentmail",
+          unitType: "request",
+          description: "Create paid inbox",
         },
       },
     ],
@@ -47,6 +52,10 @@ const services: Service[] = [
           intent: "session",
           method: "tempo",
           dynamic: true,
+          currency: "USDG",
+          recipient: "0xanthropic",
+          unitType: "token",
+          amountHint: "Usage-based model billing",
         },
       },
     ],
@@ -72,7 +81,18 @@ describe("mcp handler", () => {
   it("advertises outputSchema for every tool", async () => {
     const body = await mcp("tools/list", {}, envWithCatalog());
     const tools = body.result.tools ?? [];
-    expect(tools).toHaveLength(5);
+    expect(tools).toHaveLength(9);
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "list_services",
+      "search_services",
+      "search_offers",
+      "get_facets",
+      "get_services_by_recipient",
+      "get_catalog_status",
+      "get_service",
+      "get_offers",
+      "get_openapi",
+    ]);
     for (const tool of tools) {
       expect(tool.outputSchema).toEqual(
         expect.objectContaining({ type: "object" }),
@@ -85,6 +105,134 @@ describe("mcp handler", () => {
         properties: expect.objectContaining({
           raw: expect.objectContaining({ type: "boolean" }),
         }),
+      }),
+    );
+  });
+
+  it("searches endpoint-level payment offers with matching and ranking metadata", async () => {
+    const body = await callTool("search_offers", {
+      query: "inbox",
+      category: "ai",
+      method: "tempo",
+      currency: "usdg",
+      maxAmount: "2000000",
+      dynamic: false,
+    });
+
+    expect(body.result.structuredContent).toEqual(
+      expect.objectContaining({
+        appliedFilters: {
+          query: "inbox",
+          category: "ai",
+          method: "tempo",
+          currency: "usdg",
+          maxAmount: "2000000",
+          dynamic: false,
+        },
+        searchMethod: "text",
+        partialResults: false,
+        total: 1,
+        returned: 1,
+      }),
+    );
+    expect(body.result.structuredContent.offers).toEqual([
+      expect.objectContaining({
+        method: "POST",
+        path: "/v0/inboxes",
+        service: expect.objectContaining({ id: "agentmail" }),
+        payment: expect.objectContaining({
+          amount: "2000000",
+          currency: "USDG",
+          recipient: "0xagentmail",
+        }),
+        price: {
+          amount: "2000000",
+          currency: "USDG",
+          decimals: 6,
+          display: "2 USDG",
+          unitType: "request",
+          dynamic: false,
+        },
+        matchedOn: expect.arrayContaining([
+          "endpoint.path",
+          "service.categories",
+          "payment.method",
+          "payment.currency",
+          "payment.dynamic",
+          "payment.amount",
+        ]),
+        rankingSignals: expect.arrayContaining([
+          "active",
+          "first_party",
+          "fixed_price",
+          "has_payment_offer",
+        ]),
+      }),
+    ]);
+  });
+
+  it("returns facets, recipient lookup, and catalog status for agent planning", async () => {
+    const facetsBody = await callTool("get_facets", {});
+    expect(facetsBody.result.structuredContent).toEqual(
+      expect.objectContaining({
+        serviceCount: 3,
+        offerCount: 2,
+        facets: expect.objectContaining({
+          categories: expect.arrayContaining([
+            { value: "ai", count: 2 },
+            { value: "data", count: 1 },
+          ]),
+          paymentMethods: [{ value: "tempo", count: 2 }],
+          currencies: [{ value: "USDG", count: 2 }],
+          unitTypes: expect.arrayContaining([
+            { value: "request", count: 1 },
+            { value: "token", count: 1 },
+          ]),
+          recipients: expect.arrayContaining([
+            { value: "0xagentmail", count: 1 },
+            { value: "0xanthropic", count: 1 },
+          ]),
+          dynamic: expect.arrayContaining([
+            { value: false, count: 1 },
+            { value: true, count: 1 },
+          ]),
+        }),
+      }),
+    );
+
+    const recipientBody = await callTool("get_services_by_recipient", {
+      recipient: "0xagentmail",
+    });
+    expect(recipientBody.result.structuredContent).toEqual(
+      expect.objectContaining({
+        appliedFilters: { recipient: "0xagentmail" },
+        total: 1,
+        returned: 1,
+        services: [
+          expect.objectContaining({
+            service: expect.objectContaining({ id: "agentmail" }),
+            count: 1,
+            offers: [
+              expect.objectContaining({
+                path: "/v0/inboxes",
+                payment: expect.objectContaining({ recipient: "0xagentmail" }),
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const statusBody = await callTool("get_catalog_status", {});
+    expect(statusBody.result.structuredContent).toEqual(
+      expect.objectContaining({
+        catalogVersion: 1,
+        serviceCount: 3,
+        offerCount: 2,
+        sourceUrl: "https://mpp.dev/api/services",
+        cacheStatus: "fresh",
+        lastSuccessfulRefreshAt: expect.any(String),
+        cacheAgeSeconds: expect.any(Number),
       }),
     );
   });
@@ -399,6 +547,7 @@ async function mcp(method: string, params: Record<string, unknown>, env: Env) {
         limit?: number;
         source?: string;
         services: Array<{ id: string }>;
+        offers: unknown[];
         openapi?: unknown;
       };
     };

--- a/workers/mcp-services/src/mcp.ts
+++ b/workers/mcp-services/src/mcp.ts
@@ -1,11 +1,16 @@
 import { getCatalog } from "./cache.js";
 import {
+  countPaymentOffers,
   findService,
+  getFacets,
   listServiceSummaries,
   offersForService,
   registryOpenApiView,
+  type SearchOffersArgs,
   type SearchServicesArgs,
+  searchOffers,
   searchServices,
+  servicesByRecipient,
 } from "./discovery.js";
 import { CATEGORIES, INTEGRATIONS, type Service, STATUSES } from "./types.js";
 
@@ -32,7 +37,7 @@ const HTTP_METHODS = [
 
 const INITIALIZE_INSTRUCTIONS = [
   "Use this read-only MCP server to discover MPP paid API services and payment terms from https://mpp.dev/api/services.",
-  "Call list_services for a catalog overview, search_services to filter by query/category/payment method/integration/status, get_service for a full service record, get_offers for endpoint payment offers, and get_openapi for a service OpenAPI document or registry-derived endpoint view.",
+  "Call list_services for a catalog overview, search_services to filter providers, search_offers to find payable endpoints, get_facets to inspect valid filters, get_services_by_recipient to map a payment recipient to services, get_catalog_status to inspect freshness, get_service for a full service record, get_offers for endpoint payment offers, and get_openapi for a service OpenAPI document or registry-derived endpoint view.",
   ADVISORY,
   "This server does not register services, execute payments, authorize requests, or replace runtime 402 Challenge validation.",
 ].join(" ");
@@ -255,6 +260,75 @@ async function handleToolCall(
           services: page,
         },
         `Returned ${page.length} of ${services.length} MPP services. ${ADVISORY}`,
+      );
+    }
+
+    if (name === "search_offers") {
+      const filters = searchOfferArgs(args);
+      const pagination = paginationArgs(args);
+      const offers = searchOffers(catalog.services, filters);
+      const page = paginate(offers, pagination);
+      return toolResult(
+        {
+          ...meta,
+          appliedFilters: filters,
+          searchMethod: searchMethod(filters),
+          partialResults: pagination.offset + page.length < offers.length,
+          total: offers.length,
+          returned: page.length,
+          offset: pagination.offset,
+          limit: pagination.limit,
+          offers: page,
+        },
+        `Returned ${page.length} of ${offers.length} MPP payment offers. ${ADVISORY}`,
+      );
+    }
+
+    if (name === "get_facets") {
+      const facets = getFacets(catalog.services);
+      return toolResult(
+        {
+          ...meta,
+          serviceCount: catalog.services.length,
+          offerCount: countPaymentOffers(catalog.services),
+          facets,
+        },
+        `Returned MPP catalog facets for ${catalog.services.length} services. ${ADVISORY}`,
+      );
+    }
+
+    if (name === "get_services_by_recipient") {
+      const recipient = requiredString(args, "recipient");
+      const pagination = paginationArgs(args);
+      const services = servicesByRecipient(catalog.services, recipient);
+      const page = paginate(services, pagination);
+      return toolResult(
+        {
+          ...meta,
+          appliedFilters: { recipient },
+          total: services.length,
+          returned: page.length,
+          offset: pagination.offset,
+          limit: pagination.limit,
+          services: page,
+        },
+        `Returned ${page.length} of ${services.length} services with payment offers for recipient ${recipient}. ${ADVISORY}`,
+      );
+    }
+
+    if (name === "get_catalog_status") {
+      return toolResult(
+        {
+          ...meta,
+          serviceCount: catalog.services.length,
+          offerCount: countPaymentOffers(catalog.services),
+          cacheAgeSeconds: cacheAgeSeconds(catalog.fetchedAt),
+          lastSuccessfulRefreshAt: catalog.fetchedAt,
+          ...(catalog.refreshError
+            ? { refreshError: catalog.refreshError }
+            : {}),
+        },
+        `Catalog has ${catalog.services.length} services and ${countPaymentOffers(catalog.services)} payment offers. ${ADVISORY}`,
       );
     }
 
@@ -655,6 +729,114 @@ function toolSchemas() {
       execution: { taskSupport: "forbidden" },
     },
     {
+      name: "search_offers",
+      description:
+        "Search endpoint-level MPP payment offers by task, category, payment method, currency, max amount, unit type, dynamic pricing, recipient, integration, and status." +
+        advisory,
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Substring query over service, endpoint, and payment metadata.",
+          },
+          category: {
+            type: "string",
+            enum: CATEGORIES,
+            description: "Exact service category filter.",
+          },
+          method: {
+            type: "string",
+            description: "Exact payment method filter, for example tempo.",
+          },
+          currency: {
+            type: "string",
+            description:
+              "Exact payment currency filter, such as a token address or currency code.",
+          },
+          maxAmount: {
+            type: "string",
+            pattern: "^[0-9]+$",
+            description:
+              "Maximum fixed payment amount in base units. Dynamic or non-numeric offers are excluded when this is set.",
+          },
+          unitType: {
+            type: "string",
+            description: "Exact payment unit type filter.",
+          },
+          dynamic: {
+            type: "boolean",
+            description: "Filter dynamic pricing offers.",
+          },
+          recipient: {
+            type: "string",
+            description: "Exact payment recipient/payee filter.",
+          },
+          integration: {
+            type: "string",
+            enum: INTEGRATIONS,
+            description: "Exact integration filter.",
+          },
+          status: {
+            type: "string",
+            enum: STATUSES,
+            description: "Exact service status filter.",
+          },
+          ...paginationInputProperties(),
+        },
+        additionalProperties: false,
+      },
+      outputSchema: offerSearchOutputSchema(),
+      execution: { taskSupport: "forbidden" },
+    },
+    {
+      name: "get_facets",
+      description:
+        "Return valid filter values and counts for service categories, integrations, statuses, payment methods, currencies, unit types, intents, recipients, and dynamic pricing." +
+        advisory,
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      outputSchema: facetsOutputSchema(),
+      execution: { taskSupport: "forbidden" },
+    },
+    {
+      name: "get_services_by_recipient",
+      description:
+        "Find services that publish payment offers for a recipient/payee address or identifier from discovery metadata." +
+        advisory,
+      inputSchema: {
+        type: "object",
+        properties: {
+          recipient: {
+            type: "string",
+            description: "Payment recipient or payee identifier.",
+          },
+          ...paginationInputProperties(),
+        },
+        required: ["recipient"],
+        additionalProperties: false,
+      },
+      outputSchema: recipientServicesOutputSchema(),
+      execution: { taskSupport: "forbidden" },
+    },
+    {
+      name: "get_catalog_status",
+      description:
+        "Return MPP catalog source, version, service count, offer count, cache status, cache age, and last successful refresh time." +
+        advisory,
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      outputSchema: catalogStatusOutputSchema(),
+      execution: { taskSupport: "forbidden" },
+    },
+    {
       name: "get_service",
       description: `Get the full MPP Service record by id or name.${advisory}`,
       inputSchema: {
@@ -761,6 +943,163 @@ function paginatedServicesOutputSchema() {
       "offset",
       "limit",
       "services",
+    ],
+    additionalProperties: false,
+  });
+}
+
+function offerSearchOutputSchema() {
+  return oneOfSuccessOrError({
+    type: "object",
+    properties: {
+      ...commonEnvelopeProperties(),
+      appliedFilters: { type: "object", additionalProperties: true },
+      searchMethod: {
+        type: "string",
+        enum: ["all", "text", "filter", "recipient"],
+      },
+      partialResults: { type: "boolean" },
+      total: { type: "integer", minimum: 0 },
+      returned: { type: "integer", minimum: 0 },
+      offset: { type: "integer", minimum: 0 },
+      limit: { type: "integer", minimum: 1, maximum: MAX_LIMIT },
+      offers: {
+        type: "array",
+        items: offerSearchResultSchema(),
+      },
+    },
+    required: [
+      "advisory",
+      "catalogVersion",
+      "cacheStatus",
+      "fetchedAt",
+      "sourceUrl",
+      "appliedFilters",
+      "searchMethod",
+      "partialResults",
+      "total",
+      "returned",
+      "offset",
+      "limit",
+      "offers",
+    ],
+    additionalProperties: false,
+  });
+}
+
+function facetsOutputSchema() {
+  return oneOfSuccessOrError({
+    type: "object",
+    properties: {
+      ...commonEnvelopeProperties(),
+      serviceCount: { type: "integer", minimum: 0 },
+      offerCount: { type: "integer", minimum: 0 },
+      facets: {
+        type: "object",
+        properties: {
+          categories: facetValuesSchema(),
+          integrations: facetValuesSchema(),
+          statuses: facetValuesSchema(),
+          paymentMethods: facetValuesSchema(),
+          currencies: facetValuesSchema(),
+          unitTypes: facetValuesSchema(),
+          intents: facetValuesSchema(),
+          recipients: facetValuesSchema(),
+          dynamic: facetValuesSchema(),
+        },
+        required: [
+          "categories",
+          "integrations",
+          "statuses",
+          "paymentMethods",
+          "currencies",
+          "unitTypes",
+          "intents",
+          "recipients",
+          "dynamic",
+        ],
+        additionalProperties: false,
+      },
+    },
+    required: [
+      "advisory",
+      "catalogVersion",
+      "cacheStatus",
+      "fetchedAt",
+      "sourceUrl",
+      "serviceCount",
+      "offerCount",
+      "facets",
+    ],
+    additionalProperties: false,
+  });
+}
+
+function recipientServicesOutputSchema() {
+  return oneOfSuccessOrError({
+    type: "object",
+    properties: {
+      ...commonEnvelopeProperties(),
+      appliedFilters: { type: "object", additionalProperties: true },
+      total: { type: "integer", minimum: 0 },
+      returned: { type: "integer", minimum: 0 },
+      offset: { type: "integer", minimum: 0 },
+      limit: { type: "integer", minimum: 1, maximum: MAX_LIMIT },
+      services: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            service: serviceSummarySchema(),
+            count: { type: "integer", minimum: 0 },
+            offers: {
+              type: "array",
+              items: offerSchema(),
+            },
+          },
+          required: ["service", "count", "offers"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: [
+      "advisory",
+      "catalogVersion",
+      "cacheStatus",
+      "fetchedAt",
+      "sourceUrl",
+      "appliedFilters",
+      "total",
+      "returned",
+      "offset",
+      "limit",
+      "services",
+    ],
+    additionalProperties: false,
+  });
+}
+
+function catalogStatusOutputSchema() {
+  return oneOfSuccessOrError({
+    type: "object",
+    properties: {
+      ...commonEnvelopeProperties(),
+      serviceCount: { type: "integer", minimum: 0 },
+      offerCount: { type: "integer", minimum: 0 },
+      cacheAgeSeconds: { type: "integer", minimum: 0 },
+      lastSuccessfulRefreshAt: { type: "string" },
+      refreshError: { type: "string" },
+    },
+    required: [
+      "advisory",
+      "catalogVersion",
+      "cacheStatus",
+      "fetchedAt",
+      "sourceUrl",
+      "serviceCount",
+      "offerCount",
+      "cacheAgeSeconds",
+      "lastSuccessfulRefreshAt",
     ],
     additionalProperties: false,
   });
@@ -951,6 +1290,63 @@ function offerSchema() {
   };
 }
 
+function offerSearchResultSchema() {
+  return {
+    type: "object",
+    properties: {
+      ...offerSchema().properties,
+      service: serviceSummarySchema(),
+      price: {
+        type: "object",
+        properties: {
+          amount: { type: "string" },
+          currency: { type: "string" },
+          decimals: { type: "integer", minimum: 0 },
+          display: { type: "string" },
+          unitType: { type: "string" },
+          dynamic: { type: "boolean" },
+          amountHint: { type: "string" },
+        },
+        required: ["dynamic"],
+        additionalProperties: false,
+      },
+      matchedOn: {
+        type: "array",
+        items: { type: "string" },
+      },
+      rankingSignals: {
+        type: "array",
+        items: { type: "string" },
+      },
+    },
+    required: [
+      "method",
+      "path",
+      "payment",
+      "service",
+      "price",
+      "matchedOn",
+      "rankingSignals",
+    ],
+    additionalProperties: false,
+  };
+}
+
+function facetValuesSchema() {
+  return {
+    type: "array",
+    items: {
+      type: "object",
+      properties: {
+        value: {},
+        count: { type: "integer", minimum: 0 },
+      },
+      required: ["value", "count"],
+      additionalProperties: false,
+    },
+  };
+}
+
 function oneOfSuccessOrError(successSchema: Record<string, unknown>) {
   return {
     type: "object",
@@ -1001,11 +1397,54 @@ function searchArgs(args: Record<string, unknown>): SearchServicesArgs {
   };
 }
 
+function searchOfferArgs(args: Record<string, unknown>): SearchOffersArgs {
+  const query = optionalString(args, "query");
+  const method = optionalString(args, "method");
+  const currency = optionalString(args, "currency");
+  const maxAmount = optionalAmountString(args, "maxAmount");
+  const unitType = optionalString(args, "unitType");
+  const recipient = optionalString(args, "recipient");
+  const dynamic = optionalBoolean(args, "dynamic");
+  const category = optionalEnumArg(args, "category", CATEGORIES);
+  const integration = optionalEnumArg(args, "integration", INTEGRATIONS);
+  const status = optionalEnumArg(args, "status", STATUSES);
+
+  return {
+    ...(query ? { query } : {}),
+    ...(category ? { category } : {}),
+    ...(method ? { method } : {}),
+    ...(currency ? { currency } : {}),
+    ...(maxAmount ? { maxAmount } : {}),
+    ...(unitType ? { unitType } : {}),
+    ...(dynamic !== undefined ? { dynamic } : {}),
+    ...(recipient ? { recipient } : {}),
+    ...(integration ? { integration } : {}),
+    ...(status ? { status } : {}),
+  };
+}
+
+function searchMethod(filters: SearchOffersArgs): string {
+  if (filters.recipient) return "recipient";
+  if (filters.query) return "text";
+  if (Object.keys(filters).length > 0) return "filter";
+  return "all";
+}
+
 function paginationArgs(args: Record<string, unknown>): Pagination {
   return {
     limit: integerArg(args, "limit", DEFAULT_LIMIT, 1, MAX_LIMIT),
     offset: integerArg(args, "offset", 0, 0),
   };
+}
+
+function optionalBoolean(
+  args: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  if (!(key in args)) return undefined;
+  const value = args[key];
+  if (typeof value !== "boolean") throw new Error(`${key} must be a boolean`);
+  return value;
 }
 
 function booleanArg(
@@ -1019,8 +1458,32 @@ function booleanArg(
   return value;
 }
 
+function optionalAmountString(
+  args: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  if (!(key in args)) return undefined;
+  const value = args[key];
+  const parsed =
+    typeof value === "string"
+      ? value.trim()
+      : typeof value === "number" && Number.isInteger(value) && value >= 0
+        ? String(value)
+        : "";
+  if (!parsed || !/^\d+$/.test(parsed)) {
+    throw new Error(`${key} must be a non-negative integer string`);
+  }
+  return parsed;
+}
+
 function paginate<T>(items: T[], pagination: Pagination): T[] {
   return items.slice(pagination.offset, pagination.offset + pagination.limit);
+}
+
+function cacheAgeSeconds(fetchedAt: string): number {
+  const timestamp = Date.parse(fetchedAt);
+  if (!Number.isFinite(timestamp)) return 0;
+  return Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
 }
 
 function requireService(services: Service[], idOrName: string): Service {


### PR DESCRIPTION
## Summary
- add offer-level search, catalog facets, recipient lookup, and catalog status tools to the MPP services MCP
- include structured output schemas, richer initialize/tool descriptions, and tests for the new tools
- expand mpp.dev services/discovery docs and the Worker README around agent discovery

## Validation
- pnpm check:ci
- pnpm check:types
- pnpm test
- pnpm build
- pnpm check:generated
- pnpm --filter mpp-services-mcp check