### PR TITLE
Support HEAD checks for services MCP

### DIFF
--- a/workers/mcp-services/src/index.test.ts
+++ b/workers/mcp-services/src/index.test.ts
@@ -38,6 +38,22 @@ describe("worker routes", () => {
     );
   });
 
+  it("serves HEAD health checks from /mcp/services", async () => {
+    const response = await worker.fetch(
+      new Request("https://worker.example.com/mcp/services", {
+        method: "HEAD",
+      }),
+      envWithCatalog(),
+      testContext(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-methods")).toContain(
+      "HEAD",
+    );
+    expect(await response.text()).toBe("");
+  });
+
   it("handles MCP JSON-RPC at /mcp/services", async () => {
     const response = await worker.fetch(
       new Request("https://worker.example.com/mcp/services", {

--- a/workers/mcp-services/src/index.ts
+++ b/workers/mcp-services/src/index.ts
@@ -41,6 +41,10 @@ export default {
       });
     }
 
+    if (url.pathname === "/mcp/services" && request.method === "HEAD") {
+      return new Response(null, { status: 200, headers: jsonHeaders() });
+    }
+
     return Response.json(
       { error: "not found" },
       { status: 404, headers: jsonHeaders() },

--- a/workers/mcp-services/src/mcp.ts
+++ b/workers/mcp-services/src/mcp.ts
@@ -154,7 +154,7 @@ export function jsonHeaders(extra?: HeadersInit): Headers {
   const headers = new Headers(extra);
   headers.set("content-type", "application/json");
   headers.set("access-control-allow-origin", "*");
-  headers.set("access-control-allow-methods", "GET,POST,OPTIONS");
+  headers.set("access-control-allow-methods", "GET,HEAD,POST,OPTIONS");
   headers.set(
     "access-control-allow-headers",
     "content-type,mcp-protocol-version",


### PR DESCRIPTION
## Summary

- return a no-body 200 response for `HEAD /mcp/services`
- include `HEAD` in the MCP service CORS allow-methods header
- add a focused route test for health-check behavior

## Why

Production uptime checks and `curl -I` commonly use `HEAD`. The MCP endpoint already works for `GET`, `POST`, and `OPTIONS`, but `HEAD /mcp/services` fell through to the not-found response.

## Validation

- `pnpm --dir workers/mcp-services test`
- `pnpm --dir workers/mcp-services check:types`
- `pnpm --dir workers/mcp-services check`