### PR TITLE
Link MPP discovery docs to agent guide

### DIFF
--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -30,9 +30,9 @@ Registries aggregate discovery documents from multiple services, making it easy 
 
 Agents can query the curated services directory over MCP at
 `https://mpp.dev/mcp/services`. The server is read-only and exposes tools to
-list services, search by category or payment method, inspect endpoint offers,
-search offer-level payment terms, look up services by payment recipient, inspect
-available filters, and fetch advisory OpenAPI summaries.
+list services, rank services for an agent task, inspect endpoint offers, get
+usage recipes, look up services by payment recipient, inspect available filters,
+and fetch advisory OpenAPI summaries.
 
 ### Services MCP
 
@@ -45,7 +45,8 @@ https://mpp.dev/mcp/services
 
 Use it when an agent needs to:
 
-- find paid APIs by task, category, integration, or payment method
+- rank paid APIs by task, category, integration, or payment method
+- turn a selected service into a usage recipe with endpoint candidates
 - compare endpoint-level payment offers before constructing a request
 - identify which services publish offers for a payment recipient from a `402`
   Challenge
@@ -64,6 +65,9 @@ Use it when an agent needs to:
 
 The MCP server is advisory and read-only. After discovery, clients call the
 target service directly and treat the runtime `402` Challenge as authoritative.
+
+For agent setup, MCP Inspector smoke tests, example prompts, and recipes, see
+[Discover MPP services on Tempo docs](https://docs.tempo.xyz/guide/machine-payments/discover-services).
 
 ## Quick start
 

--- a/src/pages/services.mdx
+++ b/src/pages/services.mdx
@@ -19,9 +19,13 @@ Agents can use the MPP services catalog before choosing which paid API to call:
 | --- | --- | --- |
 | Web directory | [`https://mpp.dev/services`](https://mpp.dev/services) | Browse services, categories, providers, endpoints, and examples. |
 | Public catalog API | [`https://mpp.dev/api/services`](https://mpp.dev/api/services) | Fetch the JSON catalog directly from scripts, CLIs, or custom agents. |
-| Services MCP | [`https://mpp.dev/mcp/services`](https://mpp.dev/mcp/services) | Let an MCP-capable agent search services, search payment offers, inspect recipients, and fetch advisory OpenAPI summaries. |
+| Services MCP | [`https://mpp.dev/mcp/services`](https://mpp.dev/mcp/services) | Let an MCP-capable agent rank services, inspect payment offers, get usage recipes, and fetch advisory OpenAPI summaries. |
 
 The services MCP server is read-only. It does not register services, execute
 payments, sign transactions, or proxy paid API calls. Runtime `402` Challenges
 from the target service remain the authoritative source of current payment
 terms.
+
+For MCP client setup, Inspector smoke tests, agent prompts, and recommended
+tool-call recipes, see
+[Discover MPP services on Tempo docs](https://docs.tempo.xyz/guide/machine-payments/discover-services).


### PR DESCRIPTION
## Summary

- update mpp.dev discovery copy to mention service recommendations and usage recipes
- keep mpp.dev focused on the live catalog and provider/protocol discovery reference
- link agents to the Tempo docs Discover MPP services guide for MCP setup, Inspector smoke tests, examples, and prompts

## Notes

This is the mpp.dev side of the docs consolidation. The expanded agent-facing guide is in tempoxyz/docs#516. The new tool names depend on tempoxyz/mpp#723.

## Validation

- `pnpm check`
- `pnpm check:types`
- `pnpm build`