### PR TITLE
Add Code Mode helper to MPP discovery MCP

### DIFF
--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -51,6 +51,7 @@ Use it when an agent needs to:
   Challenge
 - inspect catalog facets before narrowing a search
 - fetch a live OpenAPI summary or registry-derived endpoint view
+- fetch a compact TypeScript Code Mode helper for programmatic catalog queries
 
 ```json
 {
@@ -64,6 +65,11 @@ Use it when an agent needs to:
 
 The MCP server is advisory and read-only. After discovery, clients call the
 target service directly and treat the runtime `402` Challenge as authoritative.
+
+For agents that prefer Code Mode, call `get_codemode()` to retrieve a small
+TypeScript module that fetches `https://mpp.dev/api/services` and filters paid
+offers locally by query, category, payment method, currency, amount, or
+recipient.
 
 ## Quick start
 

--- a/workers/mcp-services/README.md
+++ b/workers/mcp-services/README.md
@@ -61,12 +61,19 @@ paid API remains authoritative.
 - `get_service(id_or_name)`
 - `get_offers(service, route?)`
 - `get_openapi(service, raw?)`
+- `get_codemode()`
 
 `search_offers` is the preferred tool when an agent needs to choose a payable
 endpoint rather than a provider. It returns endpoint-level offers with service
 metadata, normalized display pricing where possible, match metadata, and
 ranking signals such as active status, first-party integration, fixed pricing,
 and OpenAPI availability.
+
+`get_codemode` returns a compact TypeScript helper module for agents that work
+better by writing code. The helper fetches `https://mpp.dev/api/services` and
+filters endpoint-level payment offers locally. It is still advisory; callers
+must treat the runtime `402 Challenge` from the target paid API as
+authoritative before paying.
 
 ## MCP client config
 

--- a/workers/mcp-services/src/mcp.test.ts
+++ b/workers/mcp-services/src/mcp.test.ts
@@ -81,7 +81,7 @@ describe("mcp handler", () => {
   it("advertises outputSchema for every tool", async () => {
     const body = await mcp("tools/list", {}, envWithCatalog());
     const tools = body.result.tools ?? [];
-    expect(tools).toHaveLength(9);
+    expect(tools).toHaveLength(10);
     expect(tools.map((tool) => tool.name)).toEqual([
       "list_services",
       "search_services",
@@ -92,6 +92,7 @@ describe("mcp handler", () => {
       "get_service",
       "get_offers",
       "get_openapi",
+      "get_codemode",
     ]);
     for (const tool of tools) {
       expect(tool.outputSchema).toEqual(
@@ -106,6 +107,26 @@ describe("mcp handler", () => {
           raw: expect.objectContaining({ type: "boolean" }),
         }),
       }),
+    );
+  });
+
+  it("returns a compact Code Mode helper for programmatic discovery", async () => {
+    const body = await callTool("get_codemode", {});
+
+    expect(body.result.structuredContent).toEqual(
+      expect.objectContaining({
+        language: "typescript",
+        catalogEndpoint: "https://mpp.dev/api/services",
+        module: expect.stringContaining(
+          "export async function fetchMppServices",
+        ),
+        usage: expect.arrayContaining([
+          "const catalog = await fetchMppServices()",
+        ]),
+      }),
+    );
+    expect(String(body.result.structuredContent.module)).toContain(
+      "findPaidOffers",
     );
   });
 
@@ -546,6 +567,10 @@ async function mcp(method: string, params: Record<string, unknown>, env: Env) {
         offset?: number;
         limit?: number;
         source?: string;
+        language?: string;
+        catalogEndpoint?: string;
+        module?: string;
+        usage?: string[];
         services: Array<{ id: string }>;
         offers: unknown[];
         openapi?: unknown;

--- a/workers/mcp-services/src/mcp.ts
+++ b/workers/mcp-services/src/mcp.ts
@@ -24,6 +24,89 @@ const OPENAPI_FETCH_TIMEOUT_MS = 3000;
 const MAX_OPENAPI_RAW_BYTES = 256 * 1024;
 const MAX_OPENAPI_FETCH_BYTES = 1024 * 1024;
 const MAX_OPENAPI_REDIRECTS = 3;
+const CODEMODE_HELPER = `type MppService = {
+  id: string;
+  name: string;
+  url: string;
+  categories?: string[];
+  integration?: string;
+  status?: string;
+  endpoints: Array<{
+    method: string;
+    path: string;
+    description?: string;
+    payment?: {
+      intent: string;
+      method: string;
+      amount?: string;
+      currency?: string;
+      decimals?: number;
+      recipient?: string;
+      unitType?: string;
+      dynamic?: true;
+      amountHint?: string;
+    } | null;
+  }>;
+};
+
+type ServicesResponse = { version: number; services: MppService[] };
+
+const MPP_SERVICES_URL = "https://mpp.dev/api/services";
+
+export async function fetchMppServices(): Promise<ServicesResponse> {
+  const response = await fetch(MPP_SERVICES_URL, {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error("MPP catalog fetch failed: " + response.status);
+  }
+  return response.json() as Promise<ServicesResponse>;
+}
+
+export function findPaidOffers(
+  catalog: ServicesResponse,
+  filters: {
+    query?: string;
+    category?: string;
+    method?: string;
+    currency?: string;
+    maxAmount?: bigint;
+    recipient?: string;
+  } = {},
+) {
+  const query = filters.query?.toLowerCase();
+  return catalog.services.flatMap((service) =>
+    service.endpoints
+      .filter((endpoint) => endpoint.payment)
+      .map((endpoint) => ({ service, endpoint, payment: endpoint.payment! }))
+      .filter(({ service, endpoint, payment }) => {
+        if (filters.category && !service.categories?.includes(filters.category)) return false;
+        if (filters.method && payment.method !== filters.method) return false;
+        if (filters.currency && payment.currency !== filters.currency) return false;
+        if (filters.recipient && payment.recipient !== filters.recipient) return false;
+        if (filters.maxAmount !== undefined) {
+          if (payment.dynamic || !payment.amount) return false;
+          if (BigInt(payment.amount) > filters.maxAmount) return false;
+        }
+        if (!query) return true;
+        return [
+          service.id,
+          service.name,
+          service.url,
+          endpoint.method,
+          endpoint.path,
+          endpoint.description,
+          payment.description,
+          payment.unitType,
+        ]
+          .filter(Boolean)
+          .some((value) => String(value).toLowerCase().includes(query));
+      }),
+  );
+}
+
+// Discovery is advisory. Before paying, call the target endpoint and treat its
+// runtime 402 Challenge as the authoritative payment terms.`;
 const HTTP_METHODS = [
   "get",
   "put",
@@ -379,6 +462,22 @@ async function handleToolCall(
           openapi,
         },
         `${openapi.source === "registry" ? "Returned registry endpoint view" : `Fetched ${openapi.source} OpenAPI candidate`} for ${service.id}. ${ADVISORY}`,
+      );
+    }
+
+    if (name === "get_codemode") {
+      return toolResult(
+        {
+          ...meta,
+          language: "typescript",
+          catalogEndpoint: "https://mpp.dev/api/services",
+          module: CODEMODE_HELPER,
+          usage: [
+            "const catalog = await fetchMppServices()",
+            "const offers = findPaidOffers(catalog, { query: 'email', method: 'tempo' })",
+          ],
+        },
+        `Returned TypeScript Code Mode helper for the MPP services catalog. ${ADVISORY}`,
       );
     }
 
@@ -894,6 +993,19 @@ function toolSchemas() {
       outputSchema: openApiOutputSchema(),
       execution: { taskSupport: "forbidden" },
     },
+    {
+      name: "get_codemode",
+      description:
+        "Return a compact TypeScript helper module for Code Mode agents to fetch and filter the MPP services catalog programmatically." +
+        advisory,
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      outputSchema: codemodeOutputSchema(),
+      execution: { taskSupport: "forbidden" },
+    },
   ] as const;
 }
 
@@ -1218,6 +1330,34 @@ function openApiOutputSchema() {
       "count",
       "source",
       "openapi",
+    ],
+    additionalProperties: false,
+  });
+}
+
+function codemodeOutputSchema() {
+  return oneOfSuccessOrError({
+    type: "object",
+    properties: {
+      ...commonEnvelopeProperties(),
+      language: { type: "string", const: "typescript" },
+      catalogEndpoint: { type: "string" },
+      module: { type: "string" },
+      usage: {
+        type: "array",
+        items: { type: "string" },
+      },
+    },
+    required: [
+      "advisory",
+      "catalogVersion",
+      "cacheStatus",
+      "fetchedAt",
+      "sourceUrl",
+      "language",
+      "catalogEndpoint",
+      "module",
+      "usage",
     ],
     additionalProperties: false,
   });


### PR DESCRIPTION
## Summary
- add get_codemode to the MPP services MCP tool list
- return a compact TypeScript helper for fetching/filtering the services catalog
- document the Code Mode path in the worker README and discovery docs

## Tests
- pnpm check:ci
- pnpm --filter mpp-services-mcp run check

Prompted by: @gakonst