### PR TITLE
Harden services MCP production readiness

### DIFF
--- a/src/mcp-services-proxy.test.ts
+++ b/src/mcp-services-proxy.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HEAD, OPTIONS } from "./pages/_api/mcp/services.ts";
+
+describe("/mcp/services proxy route", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("proxies HEAD requests to the services MCP Worker", async () => {
+    vi.stubEnv(
+      "MPP_SERVICES_MCP_WORKER_ORIGIN",
+      "https://mpp-services-mcp.example.workers.dev/",
+    );
+
+    let requestedUrl: string | undefined;
+    let requestInit: RequestInit | undefined;
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        requestedUrl = String(input);
+        requestInit = init;
+
+        return new Response(null, {
+          status: 200,
+          headers: {
+            "content-encoding": "gzip",
+            "content-length": "42",
+            "content-type": "application/json",
+          },
+        });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await HEAD(
+      new Request("https://mpp.dev/mcp/services?probe=1", {
+        method: "HEAD",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-methods")).toBe(
+      "GET,HEAD,POST,OPTIONS",
+    );
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(requestedUrl).toBe(
+      "https://mpp-services-mcp.example.workers.dev/mcp/services?probe=1",
+    );
+    expect(requestInit).toEqual(
+      expect.objectContaining({
+        method: "HEAD",
+        redirect: "manual",
+      }),
+    );
+    expect(requestInit).not.toHaveProperty("body");
+  });
+
+  it("advertises HEAD support in CORS preflight responses", () => {
+    const response = OPTIONS();
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-methods")).toBe(
+      "GET,HEAD,POST,OPTIONS",
+    );
+  });
+});

--- a/src/pages/_api/mcp/services.ts
+++ b/src/pages/_api/mcp/services.ts
@@ -11,6 +11,10 @@ export async function GET(request: Request) {
   return proxyToWorker(request);
 }
 
+export async function HEAD(request: Request) {
+  return proxyToWorker(request);
+}
+
 export async function POST(request: Request) {
   return proxyToWorker(request);
 }
@@ -70,7 +74,7 @@ function getWorkerOrigin() {
 function corsHeaders() {
   return new Headers({
     "Access-Control-Allow-Headers": "content-type,mcp-protocol-version",
-    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+    "Access-Control-Allow-Methods": "GET,HEAD,POST,OPTIONS",
     "Access-Control-Allow-Origin": "*",
   });
 }

--- a/workers/mcp-services/src/discovery.test.ts
+++ b/workers/mcp-services/src/discovery.test.ts
@@ -31,6 +31,16 @@ const services: Service[] = [
           amount: "2000000",
         },
       },
+      {
+        method: "POST",
+        path: "/v0/inboxes/:inbox_id/messages/send",
+        description: "Send message",
+        payment: {
+          intent: "charge",
+          method: "tempo",
+          amount: "10000",
+        },
+      },
     ],
   },
   {
@@ -103,7 +113,7 @@ describe("discovery helpers", () => {
   it("returns only paid offers and supports route filtering", () => {
     const service = findService(services, "agentmail");
     if (!service) throw new Error("missing fixture");
-    expect(offersForService(service)).toHaveLength(1);
+    expect(offersForService(service)).toHaveLength(2);
     expect(offersForService(service, "POST /v0/inboxes")).toEqual([
       expect.objectContaining({
         method: "POST",
@@ -111,6 +121,7 @@ describe("discovery helpers", () => {
         payment: expect.objectContaining({ amount: "2000000" }),
       }),
     ]);
+    expect(offersForService(service, "inboxes")).toHaveLength(2);
   });
 
   it("builds a registry fallback view for services without openapi", () => {

--- a/workers/mcp-services/src/discovery.ts
+++ b/workers/mcp-services/src/discovery.ts
@@ -204,18 +204,29 @@ export function findService(
 }
 
 export function offersForService(service: Service, route?: string): Offer[] {
-  return service.endpoints
+  const paidEndpoints = service.endpoints
     .filter((endpoint): endpoint is Endpoint & { payment: EndpointPayment } =>
       Boolean(endpoint.payment),
     )
-    .filter((endpoint) => endpointMatchesRoute(endpoint, route))
-    .map((endpoint) => ({
-      method: endpoint.method,
-      path: endpoint.path,
-      ...(endpoint.description ? { description: endpoint.description } : {}),
-      ...(endpoint.docs ? { docs: endpoint.docs } : {}),
-      payment: endpoint.payment,
-    }));
+    .filter((endpoint) => endpointMatchesRoute(endpoint, route));
+
+  const exactEndpoints =
+    route &&
+    paidEndpoints.some((endpoint) =>
+      endpointExactlyMatchesRoute(endpoint, route),
+    )
+      ? paidEndpoints.filter((endpoint) =>
+          endpointExactlyMatchesRoute(endpoint, route),
+        )
+      : paidEndpoints;
+
+  return exactEndpoints.map((endpoint) => ({
+    method: endpoint.method,
+    path: endpoint.path,
+    ...(endpoint.description ? { description: endpoint.description } : {}),
+    ...(endpoint.docs ? { docs: endpoint.docs } : {}),
+    payment: endpoint.payment,
+  }));
 }
 
 export function registryOpenApiView(service: Service) {
@@ -567,6 +578,17 @@ function endpointMatchesRoute(endpoint: Endpoint, route?: string): boolean {
   const fullRoute = normalize(`${endpoint.method} ${endpoint.path}`);
   return (
     fullRoute.includes(wanted) || normalize(endpoint.path).includes(wanted)
+  );
+}
+
+function endpointExactlyMatchesRoute(
+  endpoint: Endpoint,
+  route: string,
+): boolean {
+  const wanted = normalize(route);
+  return (
+    normalize(`${endpoint.method} ${endpoint.path}`) === wanted ||
+    normalize(endpoint.path) === wanted
   );
 }
 

--- a/workers/mcp-services/src/mcp.test.ts
+++ b/workers/mcp-services/src/mcp.test.ts
@@ -587,10 +587,11 @@ describe("mcp handler", () => {
     );
   });
 
-  it("uses the advanced discovery documentation URL in the server card", () => {
+  it("uses the agent-facing documentation URL in the server card", () => {
     expect(serverCard("https://mpp.dev/mcp/services")).toEqual(
       expect.objectContaining({
-        documentationUrl: "https://mpp.dev/advanced/discovery",
+        documentationUrl:
+          "https://docs.tempo.xyz/guide/machine-payments/discover-services",
         serverInfo: expect.objectContaining({ name: "mpp-services-mcp" }),
         transport: {
           type: "streamable-http",

--- a/workers/mcp-services/src/mcp.ts
+++ b/workers/mcp-services/src/mcp.ts
@@ -160,7 +160,8 @@ export function serverCard(endpoint: string) {
     serverInfo: serverInfo(),
     description:
       "Read-only MCP server exposing the MPP service discovery catalog and payment terms as advisory MCP tools.",
-    documentationUrl: "https://mpp.dev/advanced/discovery",
+    documentationUrl:
+      "https://docs.tempo.xyz/guide/machine-payments/discover-services",
     iconUrl: "https://mpp.dev/favicon.svg",
     transport: {
       type: "streamable-http",
@@ -1231,7 +1232,8 @@ function toolSchemas() {
           service: { type: "string", description: "Service id or name." },
           route: {
             type: "string",
-            description: "Optional route substring such as POST /v1/messages.",
+            description:
+              "Optional route filter such as POST /v1/messages. Exact METHOD /path matches are preferred; otherwise substring matching is used.",
           },
         },
         required: ["service"],
@@ -1306,7 +1308,7 @@ function toolSchemas() {
     {
       name: "get_offers",
       description:
-        "Return endpoint payment offers for a service, optionally filtered by route substring." +
+        "Return endpoint payment offers for a service, optionally filtered by exact route or route substring." +
         advisory,
       inputSchema: {
         type: "object",
@@ -1314,7 +1316,8 @@ function toolSchemas() {
           service: { type: "string", description: "Service id or name." },
           route: {
             type: "string",
-            description: "Optional route substring such as POST /v1/messages.",
+            description:
+              "Optional route filter such as POST /v1/messages. Exact METHOD /path matches are preferred; otherwise substring matching is used.",
           },
         },
         required: ["service"],


### PR DESCRIPTION
## Summary

- add explicit `HEAD` support to the `/mcp/services` Vercel proxy route and cover it with a focused proxy test
- make service route filtering exact-match first, with substring fallback for fuzzy queries
- point the services MCP server card at the agent-facing discovery docs

## Why

Production `curl -I https://mpp.dev/mcp/services` currently returns `500` through the Vercel hostname even though the Worker supports `HEAD`. This makes common health checks fail on the advertised production endpoint.

The route-filter change also makes `get_offers` and `get_usage_recipe` more predictable for agents that already know a route like `POST /v0/inboxes`; exact route filters now narrow to that endpoint instead of returning every nested route under the same prefix.

## Validation

- `pnpm exec biome check src/pages/_api/mcp/services.ts src/mcp-services-proxy.test.ts workers/mcp-services/src/discovery.ts workers/mcp-services/src/discovery.test.ts workers/mcp-services/src/mcp.ts workers/mcp-services/src/mcp.test.ts`
- `pnpm check:types`
- `pnpm test -- src/mcp-services-proxy.test.ts`
- `pnpm mcp-services:check`
- `MPP_SECRET_KEY=ci-placeholder-key pnpm build`