### PR TITLE
Improve MPP Discovery Service MCP message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - run: pnpm test
 
   mcp-services:
-    name: MCP Services Worker
+    name: MPP Discovery Service MCP Worker
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/mcp-services-deploy.yml
+++ b/.github/workflows/mcp-services-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy MPP Services MCP
+name: Deploy MPP Discovery Service MCP
 
 on:
   push:

--- a/.github/workflows/mpp-discovery-service-mcp.yml
+++ b/.github/workflows/mpp-discovery-service-mcp.yml
@@ -1,4 +1,4 @@
-name: MCP Services Smoke
+name: MPP Discovery Service MCP
 
 on:
   schedule:
@@ -9,15 +9,15 @@ permissions:
   contents: read
 
 concurrency:
-  group: mcp-services-smoke
+  group: mpp-discovery-service-mcp
   cancel-in-progress: false
 
 env:
-  MCP_SERVICES_URL: https://mpp.dev/mcp/services
+  MPP_DISCOVERY_MCP_URL: https://mpp.dev/mcp/services
 
 jobs:
-  smoke:
-    name: Production smoke
+  health:
+    name: Production health
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -39,7 +39,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_ENG_DEVELOPERS_MONITOR }}
 
-      - name: Run smoke test
-        run: node scripts/smoke-mcp-services.mjs
+      - name: Run health check
+        run: node scripts/check-mpp-discovery-service-mcp.mjs
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_ENG_DEVELOPERS_MONITOR }}

--- a/scripts/check-mpp-discovery-service-mcp.mjs
+++ b/scripts/check-mpp-discovery-service-mcp.mjs
@@ -4,12 +4,14 @@ import { appendFile } from "node:fs/promises";
 
 const DEFAULT_ENDPOINT = "https://mpp.dev/mcp/services";
 const endpoint = normalizeEndpoint(
-  process.env.MCP_SERVICES_URL ?? DEFAULT_ENDPOINT,
+  process.env.MPP_DISCOVERY_MCP_URL ?? DEFAULT_ENDPOINT,
 );
 const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL;
-const requestTimeoutMs = Number(process.env.MCP_SMOKE_TIMEOUT_MS ?? 30_000);
+const requestTimeoutMs = Number(
+  process.env.MPP_DISCOVERY_MCP_TIMEOUT_MS ?? 30_000,
+);
 const maxCacheAgeSeconds = Number(
-  process.env.MCP_SMOKE_MAX_CACHE_AGE_SECONDS ?? 3 * 60 * 60,
+  process.env.MPP_DISCOVERY_MCP_MAX_CACHE_AGE_SECONDS ?? 3 * 60 * 60,
 );
 
 const requiredTools = [
@@ -67,7 +69,7 @@ async function main() {
     const result = await rpc("initialize", {
       protocolVersion: "2025-06-18",
       capabilities: {},
-      clientInfo: { name: "mpp-services-smoke", version: "1.0.0" },
+      clientInfo: { name: "mpp-discovery-service-mcp-check", version: "1.0.0" },
     });
     expect(result?.serverInfo?.name === "mpp-services-mcp", "wrong serverInfo");
     const instructions = String(result?.instructions ?? "").toLowerCase();
@@ -457,7 +459,9 @@ function errorMessage(error) {
 function buildSummaryText() {
   const failed = results.filter((result) => !result.ok);
   const passed = results.length - failed.length;
-  const status = failed.length > 0 ? "unhealthy" : "healthy";
+  const healthy = failed.length === 0;
+  const statusIcon = healthy ? "✅" : "🚨";
+  const status = healthy ? "healthy" : "unhealthy";
   const catalog = state.catalogStatus;
   const runUrl =
     process.env.GITHUB_SERVER_URL &&
@@ -466,28 +470,28 @@ function buildSummaryText() {
       ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
       : undefined;
   const lines = [
-    `MPP services MCP smoke: ${status}`,
-    `Endpoint: ${endpoint}`,
-    `Checks: ${passed}/${results.length} passed`,
+    `${statusIcon} *MPP Discovery Service MCP is ${status}*`,
+    `🌐 Endpoint: ${endpoint}`,
+    `✅ Checks: ${passed}/${results.length} passed`,
   ];
   if (catalog) {
     lines.push(
-      `Catalog: ${catalog.serviceCount} services, ${catalog.offerCount} offers, cache age ${formatDuration(catalog.cacheAgeSeconds)}`,
+      `📚 Catalog: ${catalog.serviceCount} services, ${catalog.offerCount} offers, cache age ${formatDuration(catalog.cacheAgeSeconds)}`,
     );
   }
   if (state.tools) {
-    lines.push(`Tools: ${state.tools.length}`);
+    lines.push(`🧰 Tools advertised: ${state.tools.length}`);
   }
   if (failed.length > 0) {
     lines.push(
-      `Failures: ${failed
+      `❌ Failures: ${failed
         .slice(0, 5)
         .map((result) => `${result.name} (${result.detail})`)
         .join("; ")}`,
     );
   }
   if (runUrl) {
-    lines.push(`Run: ${runUrl}`);
+    lines.push(`🔎 Run: ${runUrl}`);
   }
   return lines.join("\n");
 }
@@ -506,7 +510,7 @@ async function writeStepSummary() {
     )
     .join("\n");
   const summary = [
-    "# MPP services MCP smoke",
+    "# MPP Discovery Service MCP",
     "",
     buildSummaryText(),
     "",


### PR DESCRIPTION
## Summary
- make the MPP Discovery Service MCP Slack/GitHub summary easier to scan with healthy/unhealthy emoji status
- add icons for endpoint, checks, catalog, tool count, failures, and run link
- rename the health workflow and script so they use the MPP Discovery Service MCP name consistently
- update visible CI/deploy labels and the health-check endpoint env var to match the service name

## Validation
- `node scripts/check-mpp-discovery-service-mcp.mjs` with Slack disabled
- `GITHUB_STEP_SUMMARY=$(mktemp) GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=tempoxyz/mpp GITHUB_RUN_ID=local-test node scripts/check-mpp-discovery-service-mcp.mjs`
- `node --check scripts/check-mpp-discovery-service-mcp.mjs`
- `pnpm exec biome check scripts/check-mpp-discovery-service-mcp.mjs .github/workflows/mpp-discovery-service-mcp.yml .github/workflows/ci.yml .github/workflows/mcp-services-deploy.yml`
- `pnpm check:types`