### PR TITLE
fix: Propagate upstream RPC status code in proxy

### DIFF
--- a/src/pages/_api/api/rpc.ts
+++ b/src/pages/_api/api/rpc.ts
@@ -42,7 +42,7 @@ export async function POST(request: Request) {
         result,
       );
     }
-    return Response.json(result);
+    return Response.json(result, { status: response.status });
   } catch (error) {
     console.error("[rpc] proxy request failed:", error);
     return Response.json(


### PR DESCRIPTION
### Title
Propagate upstream RPC status code in proxy

### Description

**Problem**

The RPC proxy route checks for non-OK upstream responses and logs them via `console.error`, but then returns the parsed body with `Response.json(result)` — which always responds with HTTP `200`. When the upstream RPC endpoint returns a `4xx`/`5xx` (auth failure, rate limit, upstream outage), the proxy masked it as a successful `200` response carrying the error body.

Any client that branches on the HTTP status code — retry logic, monitoring, generic fetch error handling — incorrectly treats a transport-level upstream failure as success. The author clearly anticipated non-OK responses (the `!response.ok` log branch exists), but the status was never forwarded.

**Fix**

Forward the upstream status code:

```ts
return Response.json(result, { status: response.status });
```

This mirrors the existing `catch` branch, which already returns `500` on proxy errors, so the proxy now faithfully reflects the upstream response status in all paths. The JSON body is unchanged, so clients that read the JSON-RPC `error` object keep working.