### PR TITLE
fix: Clean up temp mermaid config when a diagram build fails

### DIFF
--- a/scripts/build-diagrams.ts
+++ b/scripts/build-diagrams.ts
@@ -187,11 +187,12 @@ async function buildDiagrams() {
       fs.writeFileSync(outputPath, processedSvg);
     } catch (error) {
       console.error(`  Error building ${file}:`, error);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
+    } finally {
+      // Always clean up the temp config, even when a build fails
+      fs.unlinkSync(configPath);
     }
-
-    // Clean up temp config
-    fs.unlinkSync(configPath);
   }
 
   console.log("Diagrams built successfully!");


### PR DESCRIPTION
For each diagram, `build-diagrams.ts` writes a temporary `.mermaid-config.json` into the output directory, runs `mmdc`, then deletes the temp file. The deletion happens *after* the `try/catch`, but the `catch` block calls `process.exit(1)`. So whenever a diagram build fails, the process terminates before the cleanup line runs, leaving an orphaned `.mermaid-config.json` in the output directory — which can be accidentally committed.

**Fix**

- Move the cleanup into a `finally` block so it runs on both the success and failure paths.
- Replace `process.exit(1)` with `process.exitCode = 1` followed by `return`, so the `finally` block actually executes before the process exits (an immediate `process.exit()` skips pending `finally` blocks). The build still stops on the first failure and still exits non-zero.

```ts
try {
  execSync(...);
  // post-process
} catch (error) {
  console.error(`  Error building ${file}:`, error);
  process.exitCode = 1;
  return;
} finally {
  // Always clean up the temp config, even when a build fails
  fs.unlinkSync(configPath);
}
```