### PR TITLE
fix: handle upstream photo fetch failures in demo endpoints

### DIFF
--- a/src/pages/_api/api/payment-link/photo-stripe.ts
+++ b/src/pages/_api/api/payment-link/photo-stripe.ts
@@ -10,8 +10,15 @@ export async function GET(request: Request) {
 
   if (result.status === 402) return result.challenge;
 
-  const res = await fetch("https://picsum.photos/1024/1024");
-  const imageUrl = res.url;
+  let imageUrl: string;
+  try {
+    const res = await fetch("https://picsum.photos/1024/1024");
+    if (!res.ok) throw new Error(`upstream responded ${res.status}`);
+    imageUrl = res.url;
+  } catch (error) {
+    console.error("[payment-link/photo-stripe] upstream fetch failed:", error);
+    return new Response("Failed to load photo from upstream", { status: 502 });
+  }
 
   const html = `<!doctype html>
   <html lang="en">

--- a/src/pages/_api/api/payment-link/photo.ts
+++ b/src/pages/_api/api/payment-link/photo.ts
@@ -8,8 +8,15 @@ export async function GET(request: Request) {
 
   if (result.status === 402) return result.challenge;
 
-  const res = await fetch("https://picsum.photos/1024/1024");
-  const imageUrl = res.url;
+  let imageUrl: string;
+  try {
+    const res = await fetch("https://picsum.photos/1024/1024");
+    if (!res.ok) throw new Error(`upstream responded ${res.status}`);
+    imageUrl = res.url;
+  } catch (error) {
+    console.error("[payment-link/photo] upstream fetch failed:", error);
+    return new Response("Failed to load photo from upstream", { status: 502 });
+  }
 
   const html = `<!doctype html>
   <html lang="en">

--- a/src/pages/_api/api/photo.ts
+++ b/src/pages/_api/api/photo.ts
@@ -8,8 +8,18 @@ export async function GET(request: Request) {
 
   if (result.status === 402) return result.challenge;
 
-  const res = await fetch("https://picsum.photos/1024/1024");
-  const url = res.url;
+  let url: string;
+  try {
+    const res = await fetch("https://picsum.photos/1024/1024");
+    if (!res.ok) throw new Error(`upstream responded ${res.status}`);
+    url = res.url;
+  } catch (error) {
+    console.error("[photo] upstream fetch failed:", error);
+    return Response.json(
+      { error: "Failed to load photo from upstream" },
+      { status: 502 },
+    );
+  }
 
   return result.withReceipt(Response.json({ url }));
 }

--- a/src/pages/_api/api/sessions/photo.ts
+++ b/src/pages/_api/api/sessions/photo.ts
@@ -8,8 +8,18 @@ export async function GET(request: Request) {
 
   if (result.status === 402) return result.challenge;
 
-  const res = await fetch("https://picsum.photos/200/200");
-  const url = res.url;
+  let url: string;
+  try {
+    const res = await fetch("https://picsum.photos/200/200");
+    if (!res.ok) throw new Error(`upstream responded ${res.status}`);
+    url = res.url;
+  } catch (error) {
+    console.error("[sessions/photo] upstream fetch failed:", error);
+    return Response.json(
+      { error: "Failed to load photo from upstream" },
+      { status: 502 },
+    );
+  }
 
   return result.withReceipt(Response.json({ url }));
 }


### PR DESCRIPTION
# Handle upstream photo fetch failures in demo endpoints

### Description

**Problem**

The photo demo endpoints fetch `picsum.photos` *after* the MPP payment gate passes, but the fetch is never guarded:

```ts
if (result.status === 402) return result.challenge;

const res = await fetch("https://picsum.photos/1024/1024");
const url = res.url;

return result.withReceipt(Response.json({ url }));
```

If the upstream image host fails (timeout, `5xx`, DNS/network error), the unhandled rejection surfaces as an opaque `500`. Because the failure happens *before* `withReceipt`, no receipt is issued either, leaving a paid request in an ambiguous state with no actionable error.

**Fix**

Wrap the upstream fetch in `try/catch`, also checking `res.ok`. On failure, log and return a clear `502 Bad Gateway` **without** issuing a receipt — so payment is not finalized for content that could not be delivered:

```ts
let url: string;
try {
  const res = await fetch("https://picsum.photos/1024/1024");
  if (!res.ok) throw new Error(`upstream responded ${res.status}`);
  url = res.url;
} catch (error) {
  console.error("[photo] upstream fetch failed:", error);
  return Response.json(
    { error: "Failed to load photo from upstream" },
    { status: 502 },
  );
}
```

The same guard is applied to all four photo endpoints (`api/photo.ts`, `api/sessions/photo.ts`, `api/payment-link/photo.ts`, `api/payment-link/photo-stripe.ts`). The HTML endpoints return a plain-text `502` body instead of JSON.
