### PR TITLE
chore: remove no-op protocol-version negotiation in MCP initialize

### DIFF
--- a/workers/mcp-services/src/mcp.ts
+++ b/workers/mcp-services/src/mcp.ts
@@ -207,10 +207,7 @@ async function handleMessage(
 
   switch (request.method) {
     case "initialize":
-      return jsonRpcResult(
-        request.id ?? null,
-        initializeResult(request.params),
-      );
+      return jsonRpcResult(request.id ?? null, initializeResult());
     case "notifications/initialized":
       return undefined;
     case "ping":
@@ -727,21 +724,12 @@ function isRecord(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function initializeResult(params: unknown) {
-  const requested =
-    typeof params === "object" && params !== null
-      ? (params as { protocolVersion?: unknown }).protocolVersion
-      : undefined;
-  const protocolVersion =
-    typeof requested === "string" && requested.length > 0
-      ? requested
-      : PROTOCOL_VERSION;
-
+function initializeResult() {
+  // This server supports exactly one protocol version, so the response always
+  // advertises PROTOCOL_VERSION. Per the MCP spec this is the correct reply
+  // whether or not the client requested that same version.
   return {
-    protocolVersion:
-      protocolVersion === PROTOCOL_VERSION
-        ? PROTOCOL_VERSION
-        : PROTOCOL_VERSION,
+    protocolVersion: PROTOCOL_VERSION,
     capabilities: {
       tools: {},
     },


### PR DESCRIPTION
# Remove no-op protocol-version negotiation in MCP initialize

**Problem**

`initializeResult` read the client's requested `protocolVersion` from `params`, computed a `protocolVersion` local, then returned it through a ternary whose two branches are identical:

```ts
protocolVersion:
  protocolVersion === PROTOCOL_VERSION
    ? PROTOCOL_VERSION
    : PROTOCOL_VERSION,
```

The result is always `PROTOCOL_VERSION` regardless of input, so the entire `requested` / `protocolVersion` computation is dead code. It reads as if the server negotiates the version, but it never does.

**Fix**

This server supports exactly one protocol version, so always advertising `PROTOCOL_VERSION` is the correct MCP reply — whether or not the client asked for that same version. The behavior is unchanged; the dead computation and the now-unused `params` argument are removed, and the call site is updated.

```ts
function initializeResult() {
  // This server supports exactly one protocol version, so the response always
  // advertises PROTOCOL_VERSION. Per the MCP spec this is the correct reply
  // whether or not the client requested that same version.
  return {
    protocolVersion: PROTOCOL_VERSION,
    capabilities: { tools: {} },
    serverInfo: serverInfo(),
    instructions: INITIALIZE_INSTRUCTIONS,
  };
}
```

The existing `initialize` test (`index.test.ts`) sends `params: {}` and asserts only `serverInfo` and `instructions`, so it continues to pass.