### PR TITLE
fix: fix PNG chunk header bounds check in logo decoder

### DIFF
--- a/scripts/sync-logos.ts
+++ b/scripts/sync-logos.ts
@@ -70,7 +70,9 @@ function decodePngPixels(buf: ArrayBuffer) {
     (bytes[20] << 24) | (bytes[21] << 16) | (bytes[22] << 8) | bytes[23];
   const idatChunks: Buffer[] = [];
   let offset = 8;
-  while (offset < bytes.length - 4) {
+  // A chunk header is 8 bytes (4-byte length + 4-byte type), so we need at
+  // least 8 bytes remaining to read one safely.
+  while (offset <= bytes.length - 8) {
     const len =
       (bytes[offset] << 24) |
       (bytes[offset + 1] << 16) |


### PR DESCRIPTION
### Summary

`decodePngPixels` could read past the end of the buffer on a truncated or malformed PNG, silently corrupting the decode.

### Problem

The chunk loop reads an 8-byte header — a 4-byte length followed by a 4-byte type (`bytes[offset]` through `bytes[offset + 7]`) — but the loop guard only guaranteed 4 bytes remained. Out-of-bounds `Uint8Array` reads return `undefined`, so the type field is decoded from garbage.

### Change

| Before | After |
|--------|-------|
| `while (offset < bytes.length - 4) {` | `while (offset <= bytes.length - 8) {` |

`offset <= bytes.length - 8` is the precise bound: it allows the last fully-present header (`offset = length - 8`, reading up to index `length - 1`) and rejects any position with fewer than 8 bytes left. Well-formed PNGs decode identically.