### PR TITLE
Add AnyAPI to the service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1138,6 +1138,60 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── AnyAPI ─────────────────────────────────────────────────────────────
+  {
+    id: "getanyapi",
+    name: "AnyAPI",
+    url: "https://api.getanyapi.com",
+    serviceUrl: "https://api.getanyapi.com",
+    description:
+      "Unified marketplace for scraping and data APIs. Reach hundreds of third-party data APIs through one key, pay per request in USD, with normalized schemas and automatic failover. Agents pay inline per call with no account.",
+
+    categories: ["data", "search", "web", "social"],
+    integration: "first-party",
+    tags: [
+      "data",
+      "scraping",
+      "web-scraping",
+      "search",
+      "social-media",
+      "ai-agents",
+      "api-gateway",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://getanyapi.com",
+      llmsTxt: "https://getanyapi.com/llms.txt",
+      apiReference: "https://api.getanyapi.com/openapi.json",
+    },
+    provider: { name: "AnyAPI", url: "https://getanyapi.com" },
+    realm: "api.getanyapi.com",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/run/web.scrape",
+        desc: "Scrape a URL",
+        amount: "1000",
+      },
+      {
+        route: "POST /v1/run/google.search",
+        desc: "Google web search results",
+        dynamic: true,
+      },
+      {
+        route: "POST /v1/run/youtube.video_transcript",
+        desc: "Fetch a YouTube video transcript",
+        dynamic: true,
+      },
+      {
+        route: "POST /v1/run/reddit.subreddit_posts",
+        desc: "List posts from a subreddit",
+        dynamic: true,
+      },
+    ],
+  },
+
   // ── GovLaws ────────────────────────────────────────────────────────────
   {
     id: "govlaws",


### PR DESCRIPTION
## Add AnyAPI to `schemas/services.ts`

**AnyAPI** ([getanyapi.com](https://getanyapi.com)) is a unified marketplace for scraping and data APIs: reach hundreds of third-party data APIs through one key, pay per request in USD, with normalized schemas and automatic failover. AI agents pay inline per call with no account.

### Checklist
- [x] **Live and accepting MPP payments** - the gateway serves real MPP/Tempo `402`s at `api.getanyapi.com`. A `POST https://api.getanyapi.com/v1/run/web.scrape` returns `402` with `WWW-Authenticate: Payment ... realm="api.getanyapi.com", method="tempo", intent="charge"`, currency `0x20c000000000000000000000b9537d11c60e8b50` (USDC.e), recipient `0x754BD2A6799e766B1E2b9f1Ae7fBdC0CeD96ef13`. (Also supports x402 on Base/USDC, same payTo.)
- [x] Added entry to `schemas/services.ts`
- [x] Types pass: `pnpm check:types` (clean after `generate-discovery`)
- [x] `schemas/services.test.ts` passes
- [x] `biome check` clean
- [x] Registered on [MPPScan](https://www.mppscan.com/register)

### Details
- `integration: "first-party"` - AnyAPI serves MPP `402`s directly on its own host (not proxied through `*.mpp.tempo.xyz`), so `realm`/`serviceUrl` use `api.getanyapi.com`.
- Categories: `data`, `search`, `web`, `social`.
- `web.scrape` is priced at `1000` base units ($0.001, verified live); other endpoints are dynamic per-request USD.
- Docs: [llms.txt](https://getanyapi.com/llms.txt), [OpenAPI](https://api.getanyapi.com/openapi.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)