### PR TITLE
Add Ando MPP inference service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -557,6 +557,49 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Ando ───────────────────────────────────────────────────────────────
+  {
+    id: "ando",
+    name: "Ando",
+    url: "https://andoai.xyz",
+    serviceUrl: "https://inference.andoai.xyz",
+    description:
+      "First-party accountless LLM inference through Tempo MPP session payments. Agents can pay for inference without an Ando API key.",
+
+    categories: ["ai"],
+    integration: "first-party",
+    tags: [
+      "llm",
+      "inference",
+      "chat",
+      "agents",
+      "tempo",
+      "mpp",
+      "openai-compatible",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://docs.andoai.xyz/docs/agents/tempo-mpp-inference",
+      llmsTxt: "https://docs.andoai.xyz/llms.txt",
+      apiReference:
+        "https://docs.andoai.xyz/docs/developers/api-reference/mpp-chat-completions",
+    },
+    provider: { name: "Ando", url: "https://andoai.xyz" },
+    realm: "inference.andoai.xyz",
+    intent: "session",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/mpp/chat/completions",
+        desc: "Buffered chat completions with token-metered Tempo MPP session billing",
+        dynamic: true,
+        amountHint:
+          "Token-metered; 1 USDC.e cumulative voucher bucket with 5 USDC.e suggested reusable session deposit",
+        unitType: "token",
+      },
+    ],
+  },
+
   // ── Anthropic ──────────────────────────────────────────────────────────
   {
     id: "anthropic",


### PR DESCRIPTION
## Summary

Add Ando to the curated MPP services directory as a first-party Tempo MPP
`session` inference service.

The entry points agents at `https://inference.andoai.xyz` and documents the
live `POST /v1/mpp/chat/completions` endpoint with dynamic token-metered
pricing, a 1 USDC.e cumulative voucher bucket, and a 5 USDC.e suggested
reusable session deposit.

## Required checklist

- [x] Service is live and accepting MPP payment challenges
- [x] Added service entry to `schemas/services.ts`
- [x] Types pass: `pnpm check:types`
- [x] Build succeeds: `pnpm build`

## Validation

- `pnpm generate:discovery`
- `pnpm check:types`
- `pnpm test schemas/services.test.ts`
- `pnpm build`
- `git diff --check`

Local notes:

- Ando is not currently present in `https://mpp.dev/api/services`.
- Unpaid probe to `POST https://inference.andoai.xyz/v1/mpp/chat/completions`
  returned `402` with `WWW-Authenticate: Payment`, `realm="inference.andoai.xyz"`,
  `method="tempo"`, and `intent="session"`.
- Public docs links return `200`:
  - `https://docs.andoai.xyz/docs/agents/tempo-mpp-inference`
  - `https://docs.andoai.xyz/docs/developers/api-reference/mpp-chat-completions`

Environment note:

This local environment did not have global `pnpm` or Node 24 on PATH. Validation
used the repo-pinned `pnpm@10.22.0` and ephemeral Node 24 via `npx`, with
caches redirected to `/tmp`.
