### PR TITLE
fix: guard Stripe SPT helper test mode

### DIFF
--- a/src/create-spt.test.ts
+++ b/src/create-spt.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./pages/_api/api/demo/create-spt";
+
+const originalSecretKey = process.env.STRIPE_SECRET_KEY;
+
+describe("demo/create-spt", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ id: "spt_test_123" }),
+    );
+    Reflect.deleteProperty(process.env, "STRIPE_SECRET_KEY");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreEnv("STRIPE_SECRET_KEY", originalSecretKey);
+  });
+
+  it("rejects live-mode keys before calling Stripe", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_live_123";
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error:
+        "Stripe SPT test-helper endpoint requires STRIPE_SECRET_KEY=sk_test_...",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses the test-mode key for the Stripe test-helper endpoint", async () => {
+    process.env.STRIPE_SECRET_KEY = "sk_test_123";
+
+    const response = await POST(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ spt: "spt_test_123" });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://api.stripe.com/v1/test_helpers/shared_payment/granted_tokens",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(`Basic ${btoa("sk_test_123:")}`);
+  });
+});
+
+function createRequest() {
+  return new Request("https://mpp.dev/api/demo/create-spt", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      amount: "100",
+      currency: "usd",
+      expiresAt: 1782279932,
+      paymentMethod: "pm_card_visa",
+    }),
+  });
+}
+
+function restoreEnv(key: "STRIPE_SECRET_KEY", value: string | undefined) {
+  if (value === undefined) Reflect.deleteProperty(process.env, key);
+  else process.env[key] = value;
+}

--- a/src/pages/_api/api/demo/create-spt.ts
+++ b/src/pages/_api/api/demo/create-spt.ts
@@ -7,6 +7,18 @@ export async function POST(request: Request) {
       { status: 500 },
     );
   }
+  if (!isTestModeSecretKey(secretKey)) {
+    console.error(
+      "[demo/create-spt] Stripe test-helper endpoint requires a test-mode secret key",
+    );
+    return Response.json(
+      {
+        error:
+          "Stripe SPT test-helper endpoint requires STRIPE_SECRET_KEY=sk_test_...",
+      },
+      { status: 500 },
+    );
+  }
 
   const params = (await request.json()) as {
     amount: string;
@@ -48,4 +60,8 @@ export async function POST(request: Request) {
 
   const { id } = (await response.json()) as { id: string };
   return Response.json({ spt: id });
+}
+
+function isTestModeSecretKey(secretKey: string) {
+  return secretKey.startsWith("sk_test_") || secretKey.startsWith("rk_test_");
 }


### PR DESCRIPTION
## Summary

- Add a test-mode key guard before the demo SPT helper calls Stripe's test-helper endpoint
- Add regression coverage to ensure live-mode keys fail before any Stripe request

## Motivation

The demo SPT helper uses Stripe's test-only Shared Payment Token endpoint. Guarding `STRIPE_SECRET_KEY` prevents accidental livemode calls when the docs sandbox is configured with a live key.

## Key design considerations

- Keep the existing `STRIPE_SECRET_KEY` environment variable
- Allow Stripe test and restricted test secret key prefixes
- Fail before sending a request to Stripe when the key is not test-mode