### PR TITLE
Expand TypeScript SDK sidebar by default

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -478,7 +478,6 @@ export default defineConfig({
           { text: "SDK features", link: "/sdk/features" },
           {
             text: "TypeScript",
-            collapsed: true,
             items: [
               { text: "Getting started", link: "/sdk/typescript" },
               {


### PR DESCRIPTION
## Summary

- Expand the TypeScript SDK sidebar section by default.
- Keep nested TypeScript reference groups collapsed.

## Motivation

Make TypeScript SDK pages easier to browse from the SDK navigation without requiring an extra expand click.

## Key design considerations

- Uses the existing Vocs sidebar configuration behavior.
- Limits the change to the top-level TypeScript SDK group.