### PR TITLE
docs: clarify payment method wording

### DIFF
--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -9,13 +9,13 @@ imageDescription: "Answers to common MPP questions"
 
 No. MPP is payment-method agnostic—the protocol works with any payment rail.
 
-Today, [Tempo](/payment-methods/tempo) stablecoin payments, [Stripe](/payment-methods/stripe) (Visa, Mastercard, and other card networks), and [Lightning](/payment-methods/lightning) (Bitcoin over the Lightning Network) are in production. Anyone can build a [custom payment method](/payment-methods/custom) by implementing the core control flow for their payment rail. See the full list of payment methods and specifications at [paymentauth.org](https://paymentauth.org).
+Today, [Tempo](/payment-methods/tempo) stablecoin payments, card payments through [Card](/payment-methods/card) or [Stripe](/payment-methods/stripe), and [Lightning](/payment-methods/lightning) payments are in production. Anyone can build a [custom payment method](/payment-methods/custom) by implementing the core control flow for their payment rail. See the full list of payment methods and specifications at [paymentauth.org](https://paymentauth.org).
 
 ## Do I need a stablecoin wallet?
 
-No. With Stripe, you can pay with cards without stablecoins. With Lightning, you can pay with Bitcoin.
+No. With Card or Stripe, you can pay with cards without stablecoins. With Lightning, you can pay with Bitcoin.
 
-For Tempo payments, you need a stablecoin wallet to sign transactions. The SDK and the `tempo wallet` CLI handle key management for you.
+For stablecoin payments, you need a wallet to sign transactions. SDKs and wallet CLIs can handle key management for you.
 
 ## How is MPP different from x402?
 
@@ -35,7 +35,7 @@ Yes. The core x402 "exact" flows map directly onto MPP's charge intent. `mppx` c
 
 ## Why build MPP on Tempo?
 
-MPP works with any payment rail—Stripe for cards, Lightning for Bitcoin, or any custom method. You don't have to use Tempo.
+MPP works with any payment rail—cards, Lightning, stablecoins, or any custom method. You don't have to use Tempo.
 
 That said, high-throughput, low-value transactions benefit from specific properties that Tempo provides:
 
@@ -62,7 +62,7 @@ The protocol itself is free and open. There are no licensing fees for implementi
 
 MPP requires TLS 1.2+ for all connections. Challenge IDs are cryptographically bound to prevent replay attacks. The protocol never performs side effects on unpaid requests—your client only pays after verifying what it is paying for.
 
-Payments use the same security model as the underlying payment method. For Tempo, that means cryptographic signatures over every transaction. For Stripe, it means Stripe's existing fraud and dispute infrastructure.
+Payments use the same security model as the underlying payment method. Stablecoin methods typically use cryptographic signatures over every transaction. Card methods typically use the provider's existing fraud and dispute infrastructure.
 
 For operational guidance on `MPP_SECRET_KEY`, logging, and rotation, see [Security](/advanced/security).
 

--- a/src/pages/guides/accept-card-payments.mdx
+++ b/src/pages/guides/accept-card-payments.mdx
@@ -1,6 +1,6 @@
 ---
-description: "Accept card payments via Stripe on your MPP-enabled API. Charge Visa, Mastercard, and other card networks—no stablecoin wallet required."
-imageDescription: "Accept card payments on your API via Stripe"
+description: "Accept card payments with Stripe on your MPP-enabled API. Charge Visa, Mastercard, and other card networks—no stablecoin wallet required."
+imageDescription: "Accept card payments on your API with Stripe"
 ---
 
 import { Cards } from 'vocs'
@@ -8,7 +8,7 @@ import { OneTimePaymentsCard, PaymentMethodsCard, StripeMethodCard } from '../..
 import { PromptBlock } from '../../components/PromptBlock'
 import { MermaidDiagram } from '../../components/MermaidDiagram'
 
-# Accept card payments [Charge Visa and Mastercard via Stripe]
+# Accept card payments [Accept card payments with Stripe]
 
 Accept card payments on your MPP-enabled API using [Stripe](/payment-methods/stripe). Clients pay with Visa, Mastercard, and other card networks—no stablecoin wallet required. The server uses Stripe's [Shared Payment Tokens (SPTs)](https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens) to process payments through Stripe's existing rails.
 

--- a/src/pages/protocol/receipts.mdx
+++ b/src/pages/protocol/receipts.mdx
@@ -61,10 +61,11 @@ Receipts enable:
 
 ## Payment method references
 
-| Payment Method | Reference Format |
-|----------------|------------------|
-| Tempo | Transaction hash (`0xtx789...`) |
-| Stripe | PaymentIntent ID (`pi_1234...`) |
+| Settlement type | Reference format |
+|-----------------|------------------|
+| On-chain transfer | Transaction hash (`0xtx789...`) |
+| Card authorization | Authorization reference (`auth_1234...`) |
+| Invoice payment | Invoice ID (`inv_1234...`) |
 
 ## Learn more
 

--- a/src/pages/sdk/typescript/server/Mppx.compose.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.compose.mdx
@@ -4,7 +4,7 @@ Combines multiple method handlers into a single route handler that presents all 
 
 ## Usage
 
-Present both stablecoin and card payment options for a single endpoint. The client picks whichever method it supports.
+Present both stablecoin and Stripe card payment options for a single endpoint. The client picks whichever method it supports.
 
 ```ts twoslash
 import { Mppx, stripe, tempo } from 'mppx/server'


### PR DESCRIPTION
## Summary

- Clarify generic payment method references in FAQ and receipt docs
- Label Stripe-specific card payment docs and compose example more explicitly

## Motivation

Make generic protocol explanations less tied to a single provider while keeping Stripe-specific guide content clearly identified.

## Key design considerations

- Keep the Stripe card guide provider-specific, with clearer title and preview copy
- Use neutral settlement reference examples for Receipts
- Preserve the existing protocol method table wording