### PR TITLE
ci: harden code scanning workflows

### DIFF
--- a/.github/workflows/changed-services.yml
+++ b/.github/workflows/changed-services.yml
@@ -16,25 +16,24 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
-
       - name: Diff services and comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const { execSync } = require('child_process');
-
-            // --- helpers ---
-            function git(cmd) {
-              return execSync(`git ${cmd}`, { encoding: 'utf8' });
-            }
-
-            function fileAt(ref, path) {
-              try { return git(`show ${ref}:${path}`); } catch { return null; }
+            async function fileAt({ owner, path, ref, repo }) {
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner,
+                  path,
+                  ref,
+                  repo,
+                });
+                if (Array.isArray(data) || data.type !== 'file') return null;
+                return Buffer.from(data.content, data.encoding || 'base64').toString('utf8');
+              } catch (error) {
+                if (error.status === 404) return null;
+                throw error;
+              }
             }
 
             function parseServicesTsIds(raw) {
@@ -47,11 +46,21 @@ jobs:
             }
 
             // --- main ---
-            const base = context.payload.pull_request.base.sha;
-            const head = 'HEAD';
+            const pr = context.payload.pull_request;
+            const path = 'schemas/services.ts';
 
-            const baseTs = parseServicesTsIds(fileAt(base, 'schemas/services.ts'));
-            const headTs = parseServicesTsIds(fileAt(head, 'schemas/services.ts'));
+            const baseTs = parseServicesTsIds(await fileAt({
+              owner: pr.base.repo.owner.login,
+              path,
+              ref: pr.base.sha,
+              repo: pr.base.repo.name,
+            }));
+            const headTs = parseServicesTsIds(await fileAt({
+              owner: pr.head.repo.owner.login,
+              path,
+              ref: pr.head.sha,
+              repo: pr.head.repo.name,
+            }));
 
             const allIds = new Set([...baseTs, ...headTs]);
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci-gate:
     name: CI Gate

--- a/.github/workflows/sdk-drift-check.yml
+++ b/.github/workflows/sdk-drift-check.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: "latest"
 
+permissions:
+  contents: read
+
 jobs:
   drift-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-logos.yml
+++ b/.github/workflows/sync-logos.yml
@@ -8,6 +8,9 @@ on:
     - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     name: Sync


### PR DESCRIPTION
## Summary

- Add explicit read-only workflow permissions to CI, SDK drift, and logo sync workflows
- Remove the privileged PR checkout from changed-services and fetch compared files through the GitHub API

## Motivation

Code scanning flagged missing workflow permissions and a `pull_request_target` checkout of untrusted PR code. These changes restrict token scope and avoid checking out forked PR content in a privileged workflow.

## Key design considerations

- Keep existing pinned action versions
- Preserve changed-services comment behavior while reading file contents by ref
- Limit the change to workflow hardening
