### PR TITLE
Add crawler analytics instrumentation

### DIFF
--- a/src/middleware/posthog.ts
+++ b/src/middleware/posthog.ts
@@ -1,0 +1,72 @@
+import type { MiddlewareHandler } from "vocs/server";
+
+const CRAWLERS = [
+  "GPTBot",
+  "OAI-SearchBot",
+  "ChatGPT-User",
+  "anthropic-ai",
+  "ClaudeBot",
+  "claude-web",
+  "PerplexityBot",
+  "Perplexity-User",
+  "Google-Extended",
+  "Googlebot",
+  "Bingbot",
+  "Amazonbot",
+  "Applebot",
+  "Applebot-Extended",
+  "FacebookBot",
+  "meta-externalagent",
+  "LinkedInBot",
+  "Bytespider",
+  "DuckAssistBot",
+  "cohere-ai",
+  "AI2Bot",
+  "CCBot",
+  "Diffbot",
+  "omgili",
+  "Timpibot",
+  "YouBot",
+  "MistralAI-User",
+  "GoogleAgent-Mariner",
+];
+
+export default function posthogCrawlerAnalytics(): MiddlewareHandler {
+  return async (c, next) => {
+    const userAgent = c.req.header("user-agent") || "";
+    const crawlerName = CRAWLERS.find((crawler) => userAgent.includes(crawler));
+    if (!crawlerName) return next();
+
+    const posthogKey = import.meta.env.VITE_POSTHOG_KEY;
+    if (!posthogKey) return next();
+
+    const posthogHost =
+      import.meta.env.VITE_POSTHOG_HOST || "https://us.i.posthog.com";
+    const url = new URL(c.req.url);
+    const ip = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+
+    const event = {
+      api_key: posthogKey,
+      event: "crawler_pageview",
+      distinct_id: `crawler_${crawlerName}`,
+      properties: {
+        crawler_name: crawlerName,
+        user_agent: userAgent,
+        path: url.pathname,
+        site: "mpp",
+        tempo_app_id: "mpp",
+        $current_url: c.req.url,
+        $host: url.hostname,
+        $ip: ip,
+      },
+    };
+
+    fetch(`${posthogHost}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+    }).catch(() => {});
+
+    await next();
+  };
+}

--- a/workers/mcp-services/src/crawler-analytics.ts
+++ b/workers/mcp-services/src/crawler-analytics.ts
@@ -1,0 +1,73 @@
+import type { WorkerEnv } from "./types.js";
+
+const CRAWLERS = [
+  "GPTBot",
+  "OAI-SearchBot",
+  "ChatGPT-User",
+  "anthropic-ai",
+  "ClaudeBot",
+  "claude-web",
+  "PerplexityBot",
+  "Perplexity-User",
+  "Google-Extended",
+  "Googlebot",
+  "Bingbot",
+  "Amazonbot",
+  "Applebot",
+  "Applebot-Extended",
+  "FacebookBot",
+  "meta-externalagent",
+  "LinkedInBot",
+  "Bytespider",
+  "DuckAssistBot",
+  "cohere-ai",
+  "AI2Bot",
+  "CCBot",
+  "Diffbot",
+  "omgili",
+  "Timpibot",
+  "YouBot",
+  "MistralAI-User",
+  "GoogleAgent-Mariner",
+];
+
+export function trackCrawlerPageview(
+  request: Request,
+  env: WorkerEnv,
+  ctx: ExecutionContext,
+): void {
+  const userAgent = request.headers.get("user-agent") ?? "";
+  const crawlerName = CRAWLERS.find((crawler) => userAgent.includes(crawler));
+  const posthogKey = env.POSTHOG_KEY || env.VITE_POSTHOG_KEY;
+  if (!crawlerName || !posthogKey) return;
+
+  const url = new URL(request.url);
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  const ip = forwardedFor?.split(",")[0]?.trim();
+  const posthogHost =
+    env.POSTHOG_HOST || env.VITE_POSTHOG_HOST || "https://us.i.posthog.com";
+
+  const event = {
+    api_key: posthogKey,
+    event: "crawler_pageview",
+    distinct_id: `crawler_${crawlerName}`,
+    properties: {
+      crawler_name: crawlerName,
+      user_agent: userAgent,
+      path: url.pathname,
+      site: "mpp-services-mcp",
+      tempo_app_id: "mpp-services-mcp",
+      $current_url: request.url,
+      $host: url.hostname,
+      $ip: ip,
+    },
+  };
+
+  ctx.waitUntil(
+    fetch(`${posthogHost}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+    }).catch(() => undefined),
+  );
+}

--- a/workers/mcp-services/src/index.ts
+++ b/workers/mcp-services/src/index.ts
@@ -4,6 +4,7 @@ import {
   datadogMetrics,
 } from "../../../src/lib/datadog.js";
 import { refreshCatalog } from "./cache.js";
+import { trackCrawlerPageview } from "./crawler-analytics.js";
 import { countPaymentOffers } from "./discovery.js";
 import { healthMetrics } from "./health.js";
 import { handleMcp, jsonHeaders, optionsResponse, serverCard } from "./mcp.js";
@@ -18,6 +19,7 @@ export default {
     const url = new URL(request.url);
     const publicEndpoint = publicMcpEndpoint(url, env);
     configureDatadogFromEnv(env);
+    trackCrawlerPageview(request, env, ctx);
 
     return trackRequest(
       request,

--- a/workers/mcp-services/src/types.ts
+++ b/workers/mcp-services/src/types.ts
@@ -85,5 +85,9 @@ export type WorkerEnv = Omit<
   DATADOG_ENV?: string;
   DATADOG_SERVICE?: string;
   DATADOG_SITE?: string;
+  POSTHOG_HOST?: string;
+  POSTHOG_KEY?: string;
   PUBLIC_MCP_ENDPOINT?: string;
+  VITE_POSTHOG_HOST?: string;
+  VITE_POSTHOG_KEY?: string;
 };

--- a/workers/mcp-services/wrangler.jsonc
+++ b/workers/mcp-services/wrangler.jsonc
@@ -31,6 +31,8 @@
     "DATADOG_SERVICE": "mpp-discovery-service-mcp",
     "DATADOG_SITE": "us5.datadoghq.com",
     "MPP_SERVICES_URL": "https://mpp.dev/api/services",
+    "POSTHOG_HOST": "https://us.i.posthog.com",
+    "POSTHOG_KEY": "phc_aNlTw2xAUQKd9zTovXeYheEUpQpEhplehCK5r1e31HR",
     "PUBLIC_MCP_ENDPOINT": "https://mpp.dev/mcp/services"
   }
 }


### PR DESCRIPTION
## Summary
- add Vocs middleware to emit PostHog `crawler_pageview` events for mpp.dev page requests
- add Cloudflare Worker crawler capture for the MPP services MCP endpoint
- tag events with `site=mpp` or `site=mpp-services-mcp` plus host/path/user-agent metadata

Prompted by: @brendanjryan

## Verification
- `pnpm check:types`
- `pnpm --filter mpp-services-mcp run gen:types && pnpm --filter mpp-services-mcp run check:types`
- `pnpm exec biome check src/middleware/posthog.ts workers/mcp-services/src/crawler-analytics.ts workers/mcp-services/src/index.ts workers/mcp-services/src/types.ts workers/mcp-services/wrangler.jsonc`

Note: root `pnpm build` started successfully and generated derived assets, but Vite/RSC stayed silent for several minutes, so I stopped it after the passing type/lint checks.