### PR TITLE
Refine MPP Discovery Service MCP metrics

### DIFF
--- a/src/lib/worker-metrics.ts
+++ b/src/lib/worker-metrics.ts
@@ -8,16 +8,27 @@ type HttpTags = {
   route: string;
   status_class: string;
 };
+type JsonRpcErrorTags = {
+  error_code: string;
+  mcp_method: string;
+  tool_name: string;
+};
+type ToolTags = {
+  outcome: string;
+  tool_name: string;
+};
 
 export type MppWorkerMetricRegistry = {
   mpp_discovery_mcp_http_request_count: HttpTags;
   mpp_discovery_mcp_http_response_duration_ms: HttpTags;
   mpp_discovery_mcp_http_error_count: HttpTags & { error_class: string };
   mpp_discovery_mcp_health_ok: EndpointTags;
-  mpp_discovery_mcp_health_failure_count: EndpointTags;
+  mpp_discovery_mcp_health_duration_ms: EndpointTags;
   mpp_discovery_mcp_health_check_ok: HealthCheckTags;
   mpp_discovery_mcp_health_check_duration_ms: HealthCheckTags;
-  mpp_discovery_mcp_tools_advertised: EndpointTags;
+  mpp_discovery_mcp_jsonrpc_error_count: JsonRpcErrorTags;
+  mpp_discovery_mcp_tool_call_count: ToolTags;
+  mpp_discovery_mcp_tool_duration_ms: ToolTags;
   mpp_discovery_mcp_catalog_services: EndpointTags;
   mpp_discovery_mcp_catalog_offers: EndpointTags;
   mpp_discovery_mcp_catalog_cache_age_seconds: EndpointTags;

--- a/workers/mcp-services/README.md
+++ b/workers/mcp-services/README.md
@@ -75,8 +75,12 @@ metrics include:
 - `mpp_discovery_mcp_http_response_duration_ms`
 - `mpp_discovery_mcp_http_error_count`
 - `mpp_discovery_mcp_health_ok`
+- `mpp_discovery_mcp_health_duration_ms`
 - `mpp_discovery_mcp_health_check_ok`
 - `mpp_discovery_mcp_health_check_duration_ms`
+- `mpp_discovery_mcp_jsonrpc_error_count`
+- `mpp_discovery_mcp_tool_call_count`
+- `mpp_discovery_mcp_tool_duration_ms`
 - `mpp_discovery_mcp_catalog_services`
 - `mpp_discovery_mcp_catalog_offers`
 - `mpp_discovery_mcp_catalog_cache_age_seconds`

--- a/workers/mcp-services/src/health.test.ts
+++ b/workers/mcp-services/src/health.test.ts
@@ -22,7 +22,9 @@ describe("public health check", () => {
       137,
     );
     expect(metricValue(metrics, "mpp_discovery_mcp_catalog_offers")).toBe(1200);
-    expect(metricValue(metrics, "mpp_discovery_mcp_tools_advertised")).toBe(11);
+    expect(
+      metricValue(metrics, "mpp_discovery_mcp_health_duration_ms"),
+    ).toBeDefined();
   });
 
   it("emits unhealthy metrics when a public check fails", async () => {
@@ -41,9 +43,6 @@ describe("public health check", () => {
     const metrics = await captureMetrics(() => healthMetrics(env()));
 
     expect(metricValue(metrics, "mpp_discovery_mcp_health_ok")).toBe(0);
-    expect(metricValue(metrics, "mpp_discovery_mcp_health_failure_count")).toBe(
-      1,
-    );
     expect(
       metrics.find(
         (metric) =>

--- a/workers/mcp-services/src/health.ts
+++ b/workers/mcp-services/src/health.ts
@@ -22,6 +22,7 @@ const REQUIRED_TOOLS = [
 ];
 
 export async function healthMetrics(env: WorkerEnv): Promise<void> {
+  const startedAt = Date.now();
   const endpoint = env.PUBLIC_MCP_ENDPOINT || DEFAULT_ENDPOINT;
   const checks = await runChecks(endpoint);
   const failures = checks.filter((check) => !check.ok);
@@ -30,12 +31,10 @@ export async function healthMetrics(env: WorkerEnv): Promise<void> {
     failures.length === 0 ? 1 : 0,
     { endpoint: "public" },
   );
-  workerMetrics.gauge(
-    "mpp_discovery_mcp_health_failure_count",
-    failures.length,
-    {
-      endpoint: "public",
-    },
+  workerMetrics.histogram(
+    "mpp_discovery_mcp_health_duration_ms",
+    Date.now() - startedAt,
+    { endpoint: "public" },
   );
 
   for (const check of checks) {
@@ -142,9 +141,6 @@ async function checkTools(endpoint: string): Promise<void> {
   for (const tool of REQUIRED_TOOLS) {
     if (!names.has(tool)) throw new Error(`missing tool ${tool}`);
   }
-  workerMetrics.gauge("mpp_discovery_mcp_tools_advertised", tools.length, {
-    endpoint: "public",
-  });
 }
 
 async function checkCatalog(endpoint: string): Promise<void> {

--- a/workers/mcp-services/src/index.test.ts
+++ b/workers/mcp-services/src/index.test.ts
@@ -144,6 +144,34 @@ describe("scheduled health", () => {
     expect(metricValue(loggedMetrics(log), "mpp_discovery_mcp_health_ok")).toBe(
       1,
     );
+    expect(
+      metricValue(loggedMetrics(log), "mpp_discovery_mcp_health_duration_ms"),
+    ).toBeDefined();
+  });
+
+  it("does not emit source cache-age metrics during catalog refresh", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          version: 1,
+          services,
+        }),
+      ),
+    );
+
+    const ctx = collectingContext();
+    await worker.scheduled?.(scheduled("0 * * * *"), envWithCatalog(), ctx);
+    await ctx.drain();
+
+    expect(
+      loggedMetrics(log).some(
+        (metric) =>
+          metric.n === "mpp_discovery_mcp_catalog_cache_age_seconds" &&
+          metric.tags.endpoint === "source",
+      ),
+    ).toBe(false);
   });
 });
 
@@ -267,6 +295,7 @@ function rpcResult(result: unknown): Response {
 type MetricEntry = {
   n: string;
   v: number;
+  tags: Record<string, string | number | boolean | null | undefined>;
 };
 
 function silenceMetricFlush(): void {

--- a/workers/mcp-services/src/index.ts
+++ b/workers/mcp-services/src/index.ts
@@ -227,9 +227,6 @@ function recordCatalogRefreshMetrics({
     workerMetrics.gauge("mpp_discovery_mcp_catalog_offers", offers, {
       endpoint: "source",
     });
-    workerMetrics.gauge("mpp_discovery_mcp_catalog_cache_age_seconds", 0, {
-      endpoint: "source",
-    });
   }
 }
 

--- a/workers/mcp-services/src/mcp.test.ts
+++ b/workers/mcp-services/src/mcp.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { flushWorkerMetrics } from "../../../src/lib/worker-metrics.js";
 import type { CachedCatalog } from "./cache.js";
 import { handleMcp, serverCard } from "./mcp.js";
 import type { Service } from "./types.js";
@@ -76,6 +77,7 @@ const services: Service[] = [
 describe("mcp handler", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    silenceMetricFlush();
   });
 
   it("advertises outputSchema for every tool", async () => {
@@ -337,6 +339,49 @@ describe("mcp handler", () => {
         }),
       );
     }
+  });
+
+  it("emits bounded tool and application-error metrics", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await callTool("get_catalog_status", {});
+    await callTool("search_services", { category: "boguscat" });
+    await mcp("missing/method", {}, envWithCatalog());
+    flushWorkerMetrics();
+
+    const metrics = loggedMetrics(log);
+    expect(
+      metricValue(metrics, "mpp_discovery_mcp_tool_call_count", {
+        outcome: "success",
+        tool_name: "get_catalog_status",
+      }),
+    ).toBe(1);
+    expect(
+      metricValue(metrics, "mpp_discovery_mcp_tool_duration_ms", {
+        outcome: "success",
+        tool_name: "get_catalog_status",
+      }),
+    ).toBeDefined();
+    expect(
+      metricValue(metrics, "mpp_discovery_mcp_tool_call_count", {
+        outcome: "error",
+        tool_name: "search_services",
+      }),
+    ).toBe(1);
+    expect(
+      metricValue(metrics, "mpp_discovery_mcp_jsonrpc_error_count", {
+        error_code: "tool_error",
+        mcp_method: "tools/call",
+        tool_name: "search_services",
+      }),
+    ).toBe(1);
+    expect(
+      metricValue(metrics, "mpp_discovery_mcp_jsonrpc_error_count", {
+        error_code: "-32601",
+        mcp_method: "other",
+        tool_name: "none",
+      }),
+    ).toBe(1);
   });
 
   it("paginates list and search responses and echoes applied filters", async () => {
@@ -689,4 +734,35 @@ function testContext(): ExecutionContext {
 
 function serviceId(service: { id: string }): string {
   return service.id;
+}
+
+type MetricEntry = {
+  n: string;
+  v: number;
+  tags: Record<string, string | number | boolean | null | undefined>;
+};
+
+function silenceMetricFlush(): void {
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  flushWorkerMetrics();
+  log.mockRestore();
+}
+
+function loggedMetrics(log: { mock: { calls: unknown[][] } }): MetricEntry[] {
+  return log.mock.calls
+    .map((call) => (typeof call[0] === "string" ? call[0] : ""))
+    .filter((message) => message.startsWith("cwm-"))
+    .flatMap((message) => JSON.parse(message.slice("cwm-".length)));
+}
+
+function metricValue(
+  metrics: MetricEntry[],
+  name: string,
+  tags: Record<string, string>,
+): number | undefined {
+  return metrics.find(
+    (metric) =>
+      metric.n === name &&
+      Object.entries(tags).every(([key, value]) => metric.tags[key] === value),
+  )?.v;
 }

--- a/workers/mcp-services/src/mcp.ts
+++ b/workers/mcp-services/src/mcp.ts
@@ -1,3 +1,4 @@
+import { workerMetrics } from "../../../src/lib/worker-metrics.js";
 import { getCatalog } from "./cache.js";
 import {
   countPaymentOffers,
@@ -67,6 +68,30 @@ const TASK_STOP_WORDS = new Set([
   "using",
   "want",
   "with",
+]);
+const TOOL_NAMES = [
+  "list_services",
+  "search_services",
+  "search_offers",
+  "recommend_services",
+  "get_usage_recipe",
+  "get_facets",
+  "get_services_by_recipient",
+  "get_catalog_status",
+  "get_service",
+  "get_offers",
+  "get_openapi",
+] as const;
+const METRIC_TOOL_NAMES = new Set<string>(TOOL_NAMES);
+const METRIC_MCP_METHODS = new Set<string>([
+  "initialize",
+  "notifications/initialized",
+  "ping",
+  "tools/list",
+  "tools/call",
+  "resources/list",
+  "resources/templates/list",
+  "prompts/list",
 ]);
 
 const INITIALIZE_INSTRUCTIONS = [
@@ -139,6 +164,7 @@ export async function handleMcp(
   try {
     payload = await request.json();
   } catch {
+    recordJsonRpcError(undefined, "-32700");
     return jsonResponse(jsonRpcError(null, -32700, "Parse error"));
   }
 
@@ -208,6 +234,7 @@ async function handleMessage(
   ctx: ExecutionContext,
 ): Promise<JsonRpcResponsePayload | undefined> {
   if (request?.jsonrpc !== "2.0" || typeof request.method !== "string") {
+    recordJsonRpcError(request?.method, "-32600");
     return jsonRpcError(request?.id ?? null, -32600, "Invalid Request");
   }
 
@@ -235,6 +262,7 @@ async function handleMessage(
     case "prompts/list":
       return jsonRpcResult(request.id ?? null, { prompts: [] });
     default:
+      recordJsonRpcError(request.method, "-32601");
       return jsonRpcError(
         request.id ?? null,
         -32601,
@@ -250,6 +278,9 @@ async function handleToolCall(
 ) {
   const name = typeof params.name === "string" ? params.name : "";
   const args = objectArgs(params.arguments);
+  const metricToolName = metricToolNameFor(name);
+  const startedAt = Date.now();
+  let outcome = "success";
 
   try {
     const catalog = await getCatalog(env, ctx);
@@ -469,9 +500,15 @@ async function handleToolCall(
       );
     }
 
+    outcome = "error";
+    recordJsonRpcError("tools/call", "tool_error", name);
     return toolError(`Unknown tool: ${name || "(missing)"}`);
   } catch (error) {
+    outcome = "error";
+    recordJsonRpcError("tools/call", "tool_error", name);
     return toolError(errorMessage(error));
+  } finally {
+    recordToolCallMetrics(metricToolName, outcome, Date.now() - startedAt);
   }
 }
 
@@ -2212,6 +2249,42 @@ function asRequest(value: unknown): JsonRpcRequest | undefined {
     return undefined;
   }
   return value as JsonRpcRequest;
+}
+
+function recordJsonRpcError(
+  method: unknown,
+  errorCode: string,
+  toolName?: unknown,
+): void {
+  workerMetrics.count("mpp_discovery_mcp_jsonrpc_error_count", 1, {
+    error_code: errorCode,
+    mcp_method: metricMcpMethod(method),
+    tool_name: metricToolNameFor(toolName),
+  });
+}
+
+function recordToolCallMetrics(
+  toolName: string,
+  outcome: string,
+  durationMs: number,
+): void {
+  const tags = { outcome, tool_name: toolName };
+  workerMetrics.count("mpp_discovery_mcp_tool_call_count", 1, tags);
+  workerMetrics.histogram(
+    "mpp_discovery_mcp_tool_duration_ms",
+    durationMs,
+    tags,
+  );
+}
+
+function metricMcpMethod(method: unknown): string {
+  if (typeof method !== "string" || method.trim() === "") return "none";
+  return METRIC_MCP_METHODS.has(method) ? method : "other";
+}
+
+function metricToolNameFor(name: unknown): string {
+  if (typeof name !== "string" || name.trim() === "") return "none";
+  return METRIC_TOOL_NAMES.has(name) ? name : "unknown";
 }
 
 function jsonRpcResult(id: JsonRpcId, result: unknown): JsonRpcResponsePayload {


### PR DESCRIPTION
## Summary

- remove low-value MCP health metrics that were redundant or misleading
- add bounded JSON-RPC error, tool call, tool duration, and total health duration metrics
- update Worker tests and README metric docs

## Suggested Datadog monitors

- No health data for `mpp_discovery_mcp_health_ok{service:mpp-discovery-service-mcp}` for 5 minutes
- Public health failing: `avg(last_5m):avg:mpp_discovery_mcp_health_ok{service:mpp-discovery-service-mcp} < 1`
- Catalog stale: `avg(last_10m):max:mpp_discovery_mcp_catalog_cache_age_seconds{service:mpp-discovery-service-mcp,endpoint:public} > 10800`
- Catalog regression: service count below 100 or offer count below 1000
- Sustained MCP application errors: JSON-RPC/tool error rate over tool calls above a small threshold, gated on minimum traffic

## Testing

- `pnpm mcp-services:check`
- `pnpm check:ci`
- `git diff --check`
- `CLOUDFLARE_ACCOUNT_ID=ba6ee3674b03f08481e57ff9992c601e pnpm --filter mpp-services-mcp run deploy:dry-run`