### PR TITLE
docs: add Go SDK to SDK table

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Contributions to documentation, the service directory, and site improvements are
 | [wevm/mppx](https://github.com/wevm/mppx) | TypeScript |
 | [tempoxyz/pympp](https://github.com/tempoxyz/pympp) | Python |
 | [tempoxyz/mpp-rs](https://github.com/tempoxyz/mpp-rs) | Rust |
-| [inference-sh/mpp](https://github.com/inference-sh/mpp) | Go |
 | [tempoxyz/mpp-specs](https://github.com/tempoxyz/mpp-specs) | IETF specifications |
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Contributions to documentation, the service directory, and site improvements are
 | [wevm/mppx](https://github.com/wevm/mppx) | TypeScript |
 | [tempoxyz/pympp](https://github.com/tempoxyz/pympp) | Python |
 | [tempoxyz/mpp-rs](https://github.com/tempoxyz/mpp-rs) | Rust |
+| [inference-sh/mpp](https://github.com/inference-sh/mpp) | Go |
 | [tempoxyz/mpp-specs](https://github.com/tempoxyz/mpp-specs) | IETF specifications |
 
 ## Security

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -42,7 +42,7 @@ Community-maintained SDKs extend MPP to more language ecosystems.
 |---|---|---|---|---|
 | Elixir | `mpp` | ZenHive | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/ZenHive/mpp) · [hex.pm](https://hex.pm/packages/mpp) · [Docs](https://hexdocs.pm/mpp/) |
 | Go | `mppx` | cp0x | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/cp0x-org/mppx) · [Docs](https://pkg.go.dev/github.com/cp0x-org/mppx) |
-| Go | `mpp` | inference.sh | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/inference-sh/mpp) · [Docs](https://pkg.go.dev/github.com/inference-sh/mpp) |
+| Go | `mpp` (net/http middleware) | inference.sh | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/inference-sh/mpp) · [Docs](https://pkg.go.dev/github.com/inference-sh/mpp) |
 | Swift | `mpp-swift` | Amit Acharya | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/amitach/mpp-swift) · [DeepWiki](https://deepwiki.com/amitach/mpp-swift) |
 
 Want to add another SDK? Open a PR and we can list it here.

--- a/src/pages/sdk/index.mdx
+++ b/src/pages/sdk/index.mdx
@@ -42,6 +42,7 @@ Community-maintained SDKs extend MPP to more language ecosystems.
 |---|---|---|---|---|
 | Elixir | `mpp` | ZenHive | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/ZenHive/mpp) · [hex.pm](https://hex.pm/packages/mpp) · [Docs](https://hexdocs.pm/mpp/) |
 | Go | `mppx` | cp0x | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/cp0x-org/mppx) · [Docs](https://pkg.go.dev/github.com/cp0x-org/mppx) |
+| Go | `mpp` | inference.sh | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/inference-sh/mpp) · [Docs](https://pkg.go.dev/github.com/inference-sh/mpp) |
 | Swift | `mpp-swift` | Amit Acharya | <Badge variant="note">Community</Badge> | [GitHub](https://github.com/amitach/mpp-swift) · [DeepWiki](https://deepwiki.com/amitach/mpp-swift) |
 
 Want to add another SDK? Open a PR and we can list it here.


### PR DESCRIPTION
adds [inference-sh/mpp](https://github.com/inference-sh/mpp) to the SDK table.

go middleware for MPP — `net/http` native, works with chi/gorilla/stdlib. stripe SPT (fiat) built-in, `Method` interface for custom payment rails.

key features not in other Go implementations:
- `AllowFallthrough` — mount on same route as existing API key auth
- `OnPayment` callback — hook into billing after payment verification  
- `PriceFn` — dynamic per-request pricing
- string amounts for both fiat and crypto precision

44 tests, MIT licensed.