### PR TITLE
Encode access key limit as hex

### DIFF
--- a/src/pages/guides/managing-agent-spend.mdx
+++ b/src/pages/guides/managing-agent-spend.mdx
@@ -51,7 +51,7 @@ Replace the basic `accessKey` object with limits and scopes when a runtime shoul
 
 ```ts [wallet.ts]
 import { Expiry } from 'accounts'
-import { parseUnits } from 'viem'
+import { numberToHex, parseUnits } from 'viem'
 import { Scopes } from 'viem/tempo'
 
 const usdc = '0x20C000000000000000000000b9537d11c60E8b50'
@@ -62,7 +62,7 @@ const accessKey = {
   limits: [
     {
       token: usdc,
-      limit: parseUnits('10', 6),
+      limit: numberToHex(parseUnits('10', 6)),
       period: 86_400,
     },
   ],


### PR DESCRIPTION
## Summary

- Import `numberToHex` in the manage agent spend guide
- Wrap the existing `parseUnits('10', 6)` access-key limit before passing it through the `wallet_connect` capability example

## Validation

- `pnpm check:types`
- `pnpm check:ci`