### PR TITLE
Add Tempo Data API service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -10985,11 +10985,20 @@ export const services: ServiceDef[] = [
     url: "https://venture-mpp.vercel.app",
     serviceUrl: "https://venture-mpp.vercel.app",
     description:
-      "Pay-per-call on-chain data for Tempo mainnet: TIP-20 token metadata (name, symbol, decimals, total supply) and holder balances, read straight from the chain. No signup, no API key.",
+      "Pay-per-call on-chain data for Tempo mainnet — TIP-20 token metadata (name, symbol, decimals, total supply) and holder balances read straight from the chain — plus AI image generation (~1024px PNG). No signup, no API key.",
 
-    categories: ["blockchain", "data"],
+    categories: ["ai", "blockchain", "data"],
     integration: "third-party",
-    tags: ["tempo", "onchain", "tip-20", "erc-20", "token", "balance", "rpc"],
+    tags: [
+      "tempo",
+      "onchain",
+      "tip-20",
+      "erc-20",
+      "token",
+      "balance",
+      "rpc",
+      "image-generation",
+    ],
     status: "active",
     docs: {
       homepage: "https://venture-mpp.vercel.app",
@@ -11010,6 +11019,12 @@ export const services: ServiceDef[] = [
         route: "GET /tempo/balance",
         desc: "TIP-20 token balance of a holder (raw + formatted)",
         amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "POST /image",
+        desc: "AI image generation (~1024px): send {prompt, aspect?, format?}, get raw PNG bytes or base64 JSON",
+        amount: "100000",
         unitType: "request",
       },
     ],

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -10978,4 +10978,40 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+  // ── Tempo Data API ─────────────────────────────────────────────────────
+  {
+    id: "tempo-data-api",
+    name: "Tempo Data API",
+    url: "https://venture-mpp.vercel.app",
+    serviceUrl: "https://venture-mpp.vercel.app",
+    description:
+      "Pay-per-call on-chain data for Tempo mainnet: TIP-20 token metadata (name, symbol, decimals, total supply) and holder balances, read straight from the chain. No signup, no API key.",
+
+    categories: ["blockchain", "data"],
+    integration: "third-party",
+    tags: ["tempo", "onchain", "tip-20", "erc-20", "token", "balance", "rpc"],
+    status: "active",
+    docs: {
+      homepage: "https://venture-mpp.vercel.app",
+      apiReference: "https://venture-mpp.vercel.app/openapi.json",
+    },
+    provider: { name: "venture", url: "https://venture-mpp.vercel.app" },
+    realm: "venture-mpp.vercel.app",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /tempo/token",
+        desc: "TIP-20 token metadata: name, symbol, decimals, totalSupply for any token address",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "GET /tempo/balance",
+        desc: "TIP-20 token balance of a holder (raw + formatted)",
+        amount: "10000",
+        unitType: "request",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
Adds a live, third-party MPP service to the registry.

**Tempo Data API** — https://venture-mpp.vercel.app — pay-per-call on-chain data **plus AI image generation** for Tempo mainnet, settled in USDC.e via HTTP 402 (built with the official mppx SDK).

Endpoints:

- `GET /tempo/token?address=0x…` — TIP-20 token metadata (name, symbol, decimals, totalSupply) — 0.01 USDC.e
- `GET /tempo/balance?token=0x…&holder=0x…` — holder balance (raw + formatted) — 0.01 USDC.e
- `POST /image` — AI image generation, ~1024px PNG (raw bytes or base64 JSON) — 0.10 USDC.e

Machine-discoverable OpenAPI 3.1 doc with `x-payment-info` offers at https://venture-mpp.vercel.app/openapi.json

- `schemas/services.ts` type-checks clean (`tsc --noEmit`)
- `scripts/generate-discovery.ts` runs clean with the entry included
- Registered on MPPScan: https://www.mppscan.com/server/71e416f1c37386019f0e481b852a33793149e67a2d06104becb844d2d97d5e78

Live check: `curl 'https://venture-mpp.vercel.app/tempo/token?address=0x20c000000000000000000000b9537d11c60e8b50'` returns a 402 MPP challenge (recipient + USDC.e + chainId 4217).
