### PR TITLE
Add GitHub Releases Intelligence service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -3189,6 +3189,65 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── GitHub Releases Intelligence ──────────────────────────────────────
+  {
+    id: "github-releases-intelligence",
+    name: "GitHub Releases Intelligence",
+    url: "https://mpp.agent-signals.com",
+    serviceUrl: "https://mpp.agent-signals.com",
+    description:
+      "Structured, metadata-only GitHub Releases intelligence for agents. Check one or more repositories for recent release activity without returning release notes, changelogs, or raw GitHub API payloads.",
+
+    categories: ["data"],
+    integration: "third-party",
+    tags: [
+      "github",
+      "releases",
+      "developer-tools",
+      "monitoring",
+      "metadata",
+      "agents",
+      "software",
+      "changelog",
+    ],
+    status: "beta",
+    docs: {
+      homepage: "https://mpp.agent-signals.com/",
+      llmsTxt: "https://mpp.agent-signals.com/llms.txt",
+      apiReference: "https://mpp.agent-signals.com/openapi.json",
+    },
+    provider: {
+      name: "Agent Signals",
+      url: "https://mpp.agent-signals.com",
+    },
+    realm: "mpp.agent-signals.com",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /github/releases/latest",
+        desc: "Return sanitized GitHub Releases metadata for one repository",
+        amount: "15000",
+        unitType: "repo_check",
+      },
+      {
+        route: "POST /github/releases/batch",
+        desc: "Check sanitized GitHub Releases metadata for multiple repositories",
+        dynamic: true,
+        amountHint: "0.015 USDC.e per repository",
+        unitType: "repo_check",
+      },
+      {
+        route: "POST /github/releases/latest/quote",
+        desc: "Free quote for one GitHub Releases latest check",
+      },
+      {
+        route: "POST /github/releases/quote",
+        desc: "Free quote for batch GitHub Releases checks",
+      },
+    ],
+  },
+
   // ── FlightAPI ──────────────────────────────────────────────────────────
   {
     id: "flightapi",


### PR DESCRIPTION
## Summary

Adds GitHub Releases Intelligence to the MPP service directory.

GitHub Releases Intelligence is a live MPP-enabled service that returns structured, metadata-only GitHub Releases data for agents. It is designed for release monitoring and watchlist workflows without returning release notes, raw GitHub API payloads, or asset manifests.

## Service

- Service URL: https://mpp.agent-signals.com
- Support: f5547ssdf@gmail.com
- Manifest: https://mpp.agent-signals.com/.well-known/mpp
- llms.txt: https://mpp.agent-signals.com/llms.txt
- OpenAPI: https://mpp.agent-signals.com/openapi.json
- Health: https://mpp.agent-signals.com/health

## Payment

- Method: Tempo MPP
- Intent: charge
- Currency: USDC.e
- Billing unit: repo_check
- Price: 0.015 USDC.e per repo_check
- Fee sponsorship: enabled via feePayer URL
- Expected payer wallet delta: provider charge only
- Free quote endpoints are available before paid execution.

## Endpoints

- POST /github/releases/latest - one repository, 0.015 USDC.e
- POST /github/releases/batch - multiple repositories, 0.015 USDC.e per repository
- POST /github/releases/latest/quote - free quote
- POST /github/releases/quote - free quote

## Safety / Data Boundary

- Metadata-only.
- Does not return release notes.
- Does not return release bodies.
- Does not return markdown changelogs.
- Does not return raw GitHub API payloads.
- Does not return tokens, cookies, authorization headers, or asset manifests.
- Payment-Receipt stays in the HTTP header and is not returned in JSON.

## Validation

- Live health endpoint checked.
- Free quote endpoint checked.
- Unpaid 402 challenge checked: feePayer=true.
- Paid smoke test checked after user-approved spend.
- Payment-Receipt header present.
- Payer wallet delta matched provider charge: 0.015000 USDC.e.
- No full Payment-Receipt, private key, authorization header, payment credential, GitHub token, or raw upstream body saved in evidence.
- Phase B.0 official catalog dry run:
  - Official repo HEAD: a890897.
  - Applied catalog entry as a clean 59-line `schemas/services.ts` diff.
  - `node scripts/generate-discovery.ts` passed.
  - `pnpm check:types` passed.
  - Full `pnpm build` was not completed on the 1GB VPS because Vite docs build exceeded the available memory; run it in GitHub Actions or a 4GB+ RAM environment before final merge.