### PR TITLE
Update OpenClaw partner integration guide

### DIFF
--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -45,6 +45,7 @@ type Page =
   | { path: '/overview'; render: 'static' }
   | { path: '/partner-integrations/cloudflare-agents'; render: 'static' }
   | { path: '/partner-integrations/mcp-sdk'; render: 'static' }
+  | { path: '/partner-integrations/openclaw'; render: 'static' }
   | { path: '/partner-integrations/vercel-ai-sdk'; render: 'static' }
   | { path: '/payment-methods/card/charge'; render: 'static' }
   | { path: '/payment-methods/card'; render: 'static' }

--- a/src/pages/partner-integrations/openclaw.mdx
+++ b/src/pages/partner-integrations/openclaw.mdx
@@ -13,16 +13,20 @@ $ openclaw plugins enable mpp
 
 ## Set up payments
 
-Configure the payment account and the origins OpenClaw is allowed to pay.
+Set `TEMPO_PRIVATE_KEY` in the OpenClaw gateway environment, then restart the gateway.
+
+```bash [terminal]
+$ TEMPO_PRIVATE_KEY=0x... openclaw gateway run
+```
+
+By default, the plugin can pay any origin. Add `allowedOrigins` when an OpenClaw runtime should only pay specific origins.
 
 ```json5 [openclaw.json]
 {
   plugins: {
     entries: {
       mpp: {
-        enabled: true,
         config: {
-          privateKey: "0x...",
           allowedOrigins: ["https://mpp.dev"],
         },
       },
@@ -32,12 +36,6 @@ Configure the payment account and the origins OpenClaw is allowed to pay.
 ```
 
 ## Pay for HTTP requests
-
-Restart the gateway after changing plugin config.
-
-```bash [terminal]
-$ openclaw gateway restart
-```
 
 After the plugin loads, OpenClaw code in the gateway process that uses `fetch` can call free and paid HTTP endpoints through the same path. The plugin also exposes an `mpp_fetch` tool for requests that should explicitly use the payment-aware fetch.
 

--- a/src/pages/partner-integrations/openclaw.mdx
+++ b/src/pages/partner-integrations/openclaw.mdx
@@ -4,97 +4,45 @@ description: "Use MPP with OpenClaw."
 
 # OpenClaw
 
-Use [`Mppx.create`](/sdk/typescript/client/Mppx.create) from an [OpenClaw plugin](https://docs.openclaw.ai/plugins/building-plugins) to make plugin-owned HTTP requests and MCP tool calls payment-aware. Free calls pass through untouched; when a paid tool or a 402-protected request returns an MPP Challenge, `mppx` creates a Credential, retries the call, and returns the result.
+Use the official MPP plugin to make OpenClaw HTTP requests payment-aware. Free calls pass through untouched; when a 402-protected request returns an MPP or [x402](/guides/use-mpp-with-x402) Challenge, `mppx` creates a Credential, retries the call, and returns the result.
 
 ```bash [terminal]
-$ pnpm add mppx viem openclaw typebox @modelcontextprotocol/sdk
+$ openclaw plugins install clawhub:@tempoxyz/openclaw-mpp
+$ openclaw plugins enable mpp
 ```
 
-```ts [payments.ts]
-import { Mppx, tempo } from 'mppx/client'
-import { privateKeyToAccount } from 'viem/accounts'
+## Set up payments
 
-const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`)
+Configure the payment account and the origins OpenClaw is allowed to pay.
 
-export const mppx = Mppx.create({
-  methods: [tempo({ account })],
-})
+```json5 [openclaw.json]
+{
+  plugins: {
+    entries: {
+      mpp: {
+        enabled: true,
+        config: {
+          privateKey: "0x...",
+          allowedOrigins: ["https://mpp.dev"],
+        },
+      },
+    },
+  },
+}
 ```
 
 ## Pay for HTTP requests
 
-Register the plugin on startup, then use the payment-aware fetch for HTTP calls your plugin owns.
+Restart the gateway after changing plugin config.
 
-```ts [index.ts]
-import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry'
-import { Type } from 'typebox'
-import { mppx } from './payments'
-
-export default definePluginEntry({
-  id: 'mpp-payments',
-  name: 'MPP Payments',
-  description: 'Adds payment-aware OpenClaw tools.',
-  register(api) {
-    api.registerTool({
-      name: 'paid_ping',
-      description: 'Call a paid MPP HTTP endpoint.',
-      parameters: Type.Object({}),
-      async execute() {
-        const response = await mppx.fetch('https://mpp.dev/api/ping/paid')
-        return {
-          content: [{ type: 'text', text: JSON.stringify(await response.json()) }],
-        }
-      },
-    })
-  },
-})
+```bash [terminal]
+$ openclaw gateway restart
 ```
 
-## Pay for MCP tools
-
-For paid MCP tools, create the MCP client inside the plugin and pass the same payment-aware fetch to the Streamable HTTP transport.
-
-```ts [mcp.ts]
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import { mppx } from './payments'
-
-const client = new Client({
-  name: 'openclaw-mpp',
-  version: '1.0.0',
-})
-
-await client.connect(
-  new StreamableHTTPClientTransport(new URL('<mcp-url>'), {
-    fetch: mppx.fetch,
-  }),
-)
-
-const result = await client.callTool({
-  name: 'premium_search',
-  arguments: { query: 'tempo' },
-})
-
-console.log(result)
-```
-
-OpenClaw-managed MCP servers configured through `openclaw mcp` currently use OpenClaw's own guarded HTTP fetch. Until OpenClaw exposes a fetch override for that registry, use the plugin-owned MCP client pattern above for paid MCP tools.
+After the plugin loads, OpenClaw code in the gateway process that uses `fetch` can call free and paid HTTP endpoints through the same path. The plugin also exposes an `mpp_fetch` tool for requests that should explicitly use the payment-aware fetch.
 
 ## Manage agent spend
 
-The examples above use a standard viem account. For long-running apps or agents, use scoped access keys when the runtime should pay in the background with spending limits, call scopes, recipient restrictions, and independent revocation.
-
-Create the access key first, then pass the Tempo account into the same setup.
-
-```ts [payments.ts]
-export const mppx = Mppx.create({
-  methods: [
-    tempo({
-      account: provider.getAccount(),
-      ...provider.getMppxParameters({ accessKey }),
-    }),
-  ],
-})
-```
+The example above uses a raw payment key. For long-running apps or agents, use scoped access keys when the runtime should pay in the background with spending limits, call scopes, recipient restrictions, and independent revocation.
 
 See [Managing agent spend](/guides/managing-agent-spend) for limits, scopes, recipients, and revocation.

--- a/src/pages/partner-integrations/openclaw.mdx
+++ b/src/pages/partner-integrations/openclaw.mdx
@@ -1,0 +1,100 @@
+---
+description: "Use MPP with OpenClaw."
+---
+
+# OpenClaw
+
+Use [`Mppx.create`](/sdk/typescript/client/Mppx.create) from an [OpenClaw plugin](https://docs.openclaw.ai/plugins/building-plugins) to make plugin-owned HTTP requests and MCP tool calls payment-aware. Free calls pass through untouched; when a paid tool or a 402-protected request returns an MPP Challenge, `mppx` creates a Credential, retries the call, and returns the result.
+
+```bash [terminal]
+$ pnpm add mppx viem openclaw typebox @modelcontextprotocol/sdk
+```
+
+```ts [payments.ts]
+import { Mppx, tempo } from 'mppx/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`)
+
+export const mppx = Mppx.create({
+  methods: [tempo({ account })],
+})
+```
+
+## Pay for HTTP requests
+
+Register the plugin on startup, then use the payment-aware fetch for HTTP calls your plugin owns.
+
+```ts [index.ts]
+import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry'
+import { Type } from 'typebox'
+import { mppx } from './payments'
+
+export default definePluginEntry({
+  id: 'mpp-payments',
+  name: 'MPP Payments',
+  description: 'Adds payment-aware OpenClaw tools.',
+  register(api) {
+    api.registerTool({
+      name: 'paid_ping',
+      description: 'Call a paid MPP HTTP endpoint.',
+      parameters: Type.Object({}),
+      async execute() {
+        const response = await mppx.fetch('https://mpp.dev/api/ping/paid')
+        return {
+          content: [{ type: 'text', text: JSON.stringify(await response.json()) }],
+        }
+      },
+    })
+  },
+})
+```
+
+## Pay for MCP tools
+
+For paid MCP tools, create the MCP client inside the plugin and pass the same payment-aware fetch to the Streamable HTTP transport.
+
+```ts [mcp.ts]
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { mppx } from './payments'
+
+const client = new Client({
+  name: 'openclaw-mpp',
+  version: '1.0.0',
+})
+
+await client.connect(
+  new StreamableHTTPClientTransport(new URL('<mcp-url>'), {
+    fetch: mppx.fetch,
+  }),
+)
+
+const result = await client.callTool({
+  name: 'premium_search',
+  arguments: { query: 'tempo' },
+})
+
+console.log(result)
+```
+
+OpenClaw-managed MCP servers configured through `openclaw mcp` currently use OpenClaw's own guarded HTTP fetch. Until OpenClaw exposes a fetch override for that registry, use the plugin-owned MCP client pattern above for paid MCP tools.
+
+## Manage agent spend
+
+The examples above use a standard viem account. For long-running apps or agents, use scoped access keys when the runtime should pay in the background with spending limits, call scopes, recipient restrictions, and independent revocation.
+
+Create the access key first, then pass the Tempo account into the same setup.
+
+```ts [payments.ts]
+export const mppx = Mppx.create({
+  methods: [
+    tempo({
+      account: provider.getAccount(),
+      ...provider.getMppxParameters({ accessKey }),
+    }),
+  ],
+})
+```
+
+See [Managing agent spend](/guides/managing-agent-spend) for limits, scopes, recipients, and revocation.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -300,6 +300,10 @@ export default defineConfig({
             link: "/partner-integrations/mcp-sdk",
           },
           {
+            text: "OpenClaw",
+            link: "/partner-integrations/openclaw",
+          },
+          {
             text: "Vercel AI SDK",
             link: "/partner-integrations/vercel-ai-sdk",
           },


### PR DESCRIPTION
## Summary

- updates the OpenClaw guide to use the official MPP plugin install path
- documents payment account and allowed-origin configuration
- keeps the guide focused on HTTP fetch payments and links spend management separately

## Validation

- `pnpm check:generated`
- `pnpm check:ci`
- `git diff --check`