### PR TITLE
docs: update sidebar integrations placement

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -247,6 +247,22 @@ a[class*="rounded-md"][class*="border"]:hover {
   text-decoration: none !important;
 }
 
+[data-v-sidebar] a[data-v-sidebar-item][href="/payment-methods/custom"]::after {
+  content: "new";
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.4rem;
+  border-radius: 999px;
+  background: light-dark(#dbeafe, #1e3a8a);
+  color: light-dark(#1d4ed8, #bfdbfe);
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.125rem 0.35rem;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
 /* Active sidebar item — avoid font-weight change to prevent text reflow/shake */
 a[data-v-sidebar-item][data-active="true"],
 a[data-v-sidebar-item][data-active="true"]:link,

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -289,23 +289,6 @@ export default defineConfig({
         ],
       },
       {
-        text: "Partner Integrations",
-        items: [
-          {
-            text: "Cloudflare Agents",
-            link: "/partner-integrations/cloudflare-agents",
-          },
-          {
-            text: "Official MCP SDK",
-            link: "/partner-integrations/mcp-sdk",
-          },
-          {
-            text: "Vercel AI SDK",
-            link: "/partner-integrations/vercel-ai-sdk",
-          },
-        ],
-      },
-      {
         text: "Guides",
         items: [
           {
@@ -379,6 +362,23 @@ export default defineConfig({
               { text: "MCP and JSON-RPC", link: "/protocol/transports/mcp" },
               { text: "WebSocket", link: "/protocol/transports/websocket" },
             ],
+          },
+        ],
+      },
+      {
+        text: "Partner Integrations",
+        items: [
+          {
+            text: "Cloudflare Agents",
+            link: "/partner-integrations/cloudflare-agents",
+          },
+          {
+            text: "Official MCP SDK",
+            link: "/partner-integrations/mcp-sdk",
+          },
+          {
+            text: "Vercel AI SDK",
+            link: "/partner-integrations/vercel-ai-sdk",
           },
         ],
       },


### PR DESCRIPTION
## Motivation

Keep the docs sidebar order aligned with the overview page flow and make the custom payment method option easier to spot.

## Summary

- Move Partner Integrations below Protocol in the sidebar
- Add a blue `new` badge to the Custom payment methods sidebar item

## Key design considerations

- Scope the badge to the `/payment-methods/custom` sidebar link
- Leave generated pages and unrelated sidebar entries unchanged