### PR TITLE
docs: list Celo on the evm method pages

### DIFF
--- a/src/pages/payment-methods/evm/charge.mdx
+++ b/src/pages/payment-methods/evm/charge.mdx
@@ -76,6 +76,15 @@ console.log(response.status)
 
 ## Known assets
 
+`mppx` ships known assets for the following networks:
+
+| Network      | Chain ID   | Known assets                                   |
+| ------------ | ---------- | ---------------------------------------------- |
+| Base         | `8453`     | `evm.assets.base.USDC`                         |
+| Base Sepolia | `84532`    | `evm.assets.baseSepolia.USDC`                  |
+| Celo         | `42220`    | `evm.assets.celo.USDC`, `evm.assets.celo.USDT` |
+| Celo Sepolia | `11142220` | `evm.assets.celoSepolia.USDC`                  |
+
 Use known assets when possible so `mppx` can infer the chain ID, token decimals, and authorization metadata:
 
 ```ts twoslash

--- a/src/pages/sdk/typescript/client/Method.evm.mdx
+++ b/src/pages/sdk/typescript/client/Method.evm.mdx
@@ -35,7 +35,7 @@ Mppx.create({
 
 - **Type:** `typeof import('mppx/client').evm.assets`
 
-Known EVM asset metadata. Use `evm.assets.base.USDC` for Base mainnet and `evm.assets.baseSepolia.USDC` for Base Sepolia.
+Known EVM asset metadata. Use `evm.assets.base.USDC` for Base mainnet, `evm.assets.baseSepolia.USDC` for Base Sepolia, `evm.assets.celo.USDC` or `evm.assets.celo.USDT` for Celo, and `evm.assets.celoSepolia.USDC` for Celo Sepolia.
 
 Use `evm.assets.define` for custom EVM assets:
 
@@ -58,7 +58,7 @@ const USDC = evm.assets.define({
 
 - **Type:** `typeof import('mppx/client').evm.chains`
 
-Known EVM chain IDs. Use `evm.chains.base` for Base mainnet and `evm.chains.baseSepolia` for Base Sepolia.
+Known EVM chain IDs. Use `evm.chains.base` for Base mainnet, `evm.chains.baseSepolia` for Base Sepolia, `evm.chains.celo` for Celo, and `evm.chains.celoSepolia` for Celo Sepolia.
 
 ### charge
 

--- a/src/pages/sdk/typescript/server/Method.evm.mdx
+++ b/src/pages/sdk/typescript/server/Method.evm.mdx
@@ -33,7 +33,7 @@ Mppx.create({
 
 - **Type:** `typeof import('mppx/server').evm.assets`
 
-Known EVM asset metadata. Use `evm.assets.base.USDC` for Base mainnet and `evm.assets.baseSepolia.USDC` for Base Sepolia.
+Known EVM asset metadata. Use `evm.assets.base.USDC` for Base mainnet, `evm.assets.baseSepolia.USDC` for Base Sepolia, `evm.assets.celo.USDC` or `evm.assets.celo.USDT` for Celo, and `evm.assets.celoSepolia.USDC` for Celo Sepolia.
 
 Use `evm.assets.define` for custom EVM assets:
 
@@ -56,7 +56,7 @@ const USDC = evm.assets.define({
 
 - **Type:** `typeof import('mppx/server').evm.chains`
 
-Known EVM chain IDs. Use `evm.chains.base` for Base mainnet and `evm.chains.baseSepolia` for Base Sepolia.
+Known EVM chain IDs. Use `evm.chains.base` for Base mainnet, `evm.chains.baseSepolia` for Base Sepolia, `evm.chains.celo` for Celo, and `evm.chains.celoSepolia` for Celo Sepolia.
 
 ### charge
 


### PR DESCRIPTION
## Motivation

Celo is being added to `mppx`'s known EVM chains and assets in [wevm/mppx#626](https://github.com/wevm/mppx/pull/626), following the unified `evm` method path per [draft-evm-charge-00](https://paymentauth.org/draft-evm-charge-00). This PR lists Celo alongside Base on the `evm` method docs.

## Summary

- Added a known networks/assets table to the EVM charge page (`payment-methods/evm/charge.mdx`): Base, Base Sepolia, Celo (USDC + USDT), and Celo Sepolia (USDC)
- Extended the `assets`/`chains` export descriptions on the `evm` SDK reference pages (client and server) to mention `celo`/`celoSepolia`

All referenced exports land with wevm/mppx#626 — this PR should merge after that releases. Code samples are unchanged (no twoslash references to the new exports), so the build stays green against the currently published `mppx`.

Asset metadata behind the new entries was verified on-chain (addresses from Circle's/Tether's official deployments; EIP-712 domains recomputed against on-chain `DOMAIN_SEPARATOR()`, EIP-3009 probed functionally on both tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
