### PR TITLE
docs: alphabetize proxy parameters

### DIFF
--- a/src/pages/sdk/typescript/proxy.mdx
+++ b/src/pages/sdk/typescript/proxy.mdx
@@ -264,7 +264,7 @@ The proxy returns markdown instead of JSON when the request comes from a known A
 
 ## Parameters
 
-### `Proxy.create` config
+`Proxy.create` accepts these config fields:
 
 ### basePath (optional)
 


### PR DESCRIPTION
## Motivation

Keep the TypeScript proxy SDK reference aligned with the docs style guide for alphabetized parameter headings.

## Summary

- Replace the non-parameter `### Proxy.create config` heading with a lead-in sentence
- Leave the actual parameter headings in alphabetical order


## Key design considerations

- Keeps the change scoped to the proxy reference page
- Avoids changing generated files or package manager approval config
