### PR TITLE
Add Lightning Rod Labs MPP services

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1270,23 +1270,21 @@ export const services: ServiceDef[] = [
     endpoints: [
       {
         route: "POST /v1/mpp/topup",
-        desc: "Add credits via MPP — returns an API key on payment (default $5.00)",
+        desc: "Pay via MPP to add credits and receive an API key (default $5.00), then call the OpenAI-compatible forecasting API with that key",
         dynamic: true,
         amountHint: "$1-$10,000",
       },
       {
         route: "POST /v1/openai/chat/completions",
-        desc: "OpenAI-compatible chat completions for Foresight forecasting models — price varies by model, tokens, and research usage",
-        dynamic: true,
+        desc: "OpenAI-compatible chat completions for Foresight forecasting models with structured answers and research mode — requires an active balance from /v1/mpp/topup (billed against your API key)",
       },
       {
         route: "POST /v1/openai/completions",
-        desc: "OpenAI-compatible text completions — prefer chat/completions for multi-turn",
-        dynamic: true,
+        desc: "OpenAI-compatible text completions for Foresight forecasting models — requires an active balance from /v1/mpp/topup (billed against your API key)",
       },
       {
         route: "GET /v1/openai/models",
-        desc: "List available forecasting models (free)",
+        desc: "List available forecasting models.",
       },
     ],
   },

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1239,6 +1239,58 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── LightningRod ───────────────────────────────────────────────────────
+  {
+    id: "lightningrod",
+    name: "LightningRod",
+    url: "https://lightningrod.ai",
+    serviceUrl: "https://api.lightningrod.ai",
+    description:
+      "Predict anything with AI. OpenAI-compatible forecasting API with built-in research and structured answers.",
+
+    categories: ["ai", "data"],
+    integration: "first-party",
+    tags: [
+      "llm",
+      "forecasting",
+      "prediction",
+      "foresight",
+      "reasoning",
+      "chat",
+    ],
+    docs: {
+      homepage: "https://lightningrod.ai",
+      llmsTxt: "https://www.lightningrod.ai/llms.txt",
+      apiReference: "https://api.lightningrod.ai/openapi.json",
+    },
+    provider: { name: "Lightning Rod Labs", url: "https://lightningrod.ai" },
+    realm: "api.lightningrod.ai",
+    intent: "charge",
+    payments: [STRIPE_PAYMENT, TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/mpp/topup",
+        desc: "Add credits via MPP — returns an API key on payment (default $5.00)",
+        dynamic: true,
+        amountHint: "$1-$10,000",
+      },
+      {
+        route: "POST /v1/openai/chat/completions",
+        desc: "OpenAI-compatible chat completions for Foresight forecasting models — price varies by model, tokens, and research usage",
+        dynamic: true,
+      },
+      {
+        route: "POST /v1/openai/completions",
+        desc: "OpenAI-compatible text completions — prefer chat/completions for multi-turn",
+        dynamic: true,
+      },
+      {
+        route: "GET /v1/openai/models",
+        desc: "List available forecasting models (free)",
+      },
+    ],
+  },
+
   // ── Modal ──────────────────────────────────────────────────────────────
   {
     id: "modal",


### PR DESCRIPTION
## Summary

Adds **LightningRod** (Lightning Rod Labs) to the service directory — an AI forecasting API that predicts anything via OpenAI-compatible endpoints, with structured answers (binary, multiple-choice, continuous, free-response), optional web research, and low/medium/high reasoning effort.

Unlike a per-request proxy, LightningRod uses a **credit + API-key model**: agents pay once over MPP at `POST /v1/mpp/topup` to fund a balance and receive an API key, then call the forecasting endpoints with that key. Accepts **Stripe** and **Tempo USDC.e**.

- Live service: https://api.lightningrod.ai
- OpenAPI: https://api.lightningrod.ai/openapi.json
- llms.txt: https://www.lightningrod.ai/llms.txt
- Homepage: https://lightningrod.ai

## Endpoints

Only `POST /v1/mpp/topup` carries an MPP payment (`charge`, dynamic, $1–$10,000, default $5). The forecasting endpoints (`/v1/openai/chat/completions`, `/v1/openai/completions`, `/v1/openai/models`) authenticate with the API key returned by top-up and draw down the prepaid balance — no per-request MPP payment — so they are listed **without an amount** (rendered as "—", no intent badge) purely to surface the product's API surface. Each description states the balance requirement. A code comment in the entry documents this so the routes aren't mistaken for missing prices.

## Required checklist

- [x] Service is **live and accepting payments** via MPP (not a placeholder)
- [x] Entry added to `schemas/services.ts`
- [x] Types pass: `pnpm check:types`
- [x] Biome clean: `pnpm check`
- [x] Discovery regenerates: `node scripts/generate-discovery.ts` (LightningRod present in `discovery.json` + `llms.txt`)
- [x] Build succeeds: `pnpm build` (verified locally; static generation emits LightningRod into the services bundle. Requires an `MPP_SECRET_KEY` ≥ 32 bytes — CI supplies the real secret)

## Recommended

- [x] Register on [MPPScan](https://www.mppscan.com/register) — to be completed by Lightning Rod Labs
