### PR TITLE
Add agentschedule to the services registry

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -427,6 +427,50 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── agentschedule ──────────────────────────────────────────────────────
+  {
+    id: "agentschedule",
+    name: "agentschedule",
+    url: "https://mwork.dev",
+    serviceUrl: "https://mwork.dev",
+    description:
+      "Stateless scheduling coordination for AI agents: find the best common meeting slot across participants' busy/free time and timezones, then generate a standard ICS invite. No calendar accounts or OAuth.",
+
+    categories: ["data"],
+    integration: "first-party",
+    tags: [
+      "scheduling",
+      "calendar",
+      "meetings",
+      "timezone",
+      "ics",
+      "availability",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://mwork.dev",
+      llmsTxt: "https://mwork.dev/llms.txt",
+    },
+    provider: { name: "agentschedule", url: "https://mwork.dev" },
+    realm: "mwork.dev",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/find-slot",
+        desc: "Find the best common meeting slot given each participant's busy intervals, timezone, and working hours",
+        amount: "20000",
+        unitType: "request",
+      },
+      {
+        route: "POST /v1/generate-ics",
+        desc: "Generate an RFC 5545 ICS invite for a given meeting time, organizer, and attendees",
+        amount: "10000",
+        unitType: "request",
+      },
+    ],
+  },
+
   // ── Allium ──────────────────────────────────────────────────────────────
   {
     id: "allium",


### PR DESCRIPTION
## Summary

Adds **agentschedule** (https://mwork.dev) — stateless scheduling coordination for AI agents: find the best common meeting slot across participants' busy/free time and timezones, then generate a standard ICS invite. No calendar accounts or OAuth required.

- Live service: https://mwork.dev
- OpenAPI: https://mwork.dev/openapi.json
- llms.txt: https://mwork.dev/llms.txt
- Registered on [MPPScan](https://www.mppscan.com/register) — service `agentschedule`, both endpoints discoverable

## Endpoints

Two endpoints, flat pricing, MPP `charge` via Tempo (USDC.e):

- `POST /v1/find-slot` — $0.02 — best common meeting slot given each participant's busy intervals, timezone, and working hours
- `POST /v1/generate-ics` — $0.01 — RFC 5545 ICS invite for a given meeting time, organizer, and attendees

## Required checklist

- [x] Service is **live and accepting payments** via MPP (not a placeholder)
- [x] Entry added to `schemas/services.ts`
- [x] Types pass: `pnpm check:types`
- [x] Biome clean: `pnpm check`
- [x] Discovery regenerates: `node scripts/generate-discovery.ts` (agentschedule present in `discovery.json` + `llms.txt`, 138 services)
- [x] Build succeeds: `pnpm build`

## Recommended

- [x] Registered on [MPPScan](https://www.mppscan.com/register)