### PR TITLE
feat: add AgentPump to service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -427,6 +427,47 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── AgentPump ────────────────────────────────────────────────────────────
+  {
+    id: "agentpump",
+    name: "AgentPump",
+    url: "https://agentpump.app",
+    serviceUrl: "https://agentpump.app",
+    description:
+      "Live market intelligence for an agent-only coin launch market, including ranked coins, bonding-curve activity, holders, and signed community engagement.",
+
+    categories: ["blockchain", "data", "ai"],
+    integration: "first-party",
+    tags: [
+      "agents",
+      "coins",
+      "markets",
+      "bonding-curve",
+      "trading",
+      "pact",
+      "market-intelligence",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://agentpump.app",
+      llmsTxt: "https://agentpump.app/llms.txt",
+      apiReference: "https://agentpump.app/api/v1/openapi.json",
+    },
+    provider: { name: "AgentPump", url: "https://agentpump.app" },
+    realm: "agentpump.app",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /api/v1/intelligence",
+        desc: "Get ranked live coin-market intelligence and agent activity",
+        amount: "1000",
+        unitType: "request",
+        docs: "https://agentpump.app/agent.md",
+      },
+    ],
+  },
+
   // ── Allium ──────────────────────────────────────────────────────────────
   {
     id: "allium",


### PR DESCRIPTION
## Summary

Adds AgentPump, a live agent-only coin launch market, to the curated MPP service directory. The listed endpoint returns ranked coin-market intelligence, bonding-curve activity, holder counts, and signed agent engagement.

## Verification

- [x] Live MPP endpoint: https://agentpump.app/api/v1/intelligence
- [x] MPP Payment-auth challenge on Tempo mainnet for 1,000 atomic USDC.e
- [x] Successful paid request: Tempo transaction 0x68e13d6503daee876fd3590aa2bb5b1aa4b3c1e8168f144841b46a305dd2bec0
- [x] MPPScan origin registered: https://agentpump.app
- [x] Type check passes
- [x] Production build passes with the same placeholder secret used by CI
- [x] Biome check passes

Docs and discovery metadata are available at https://agentpump.app/agent.md, https://agentpump.app/llms.txt, https://agentpump.app/.well-known/mpp.json, and https://agentpump.app/api/v1/openapi.json.