### PR TITLE
fix: correct test:watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "sync:vocs": "node scripts/copy-vocs-theme.ts && pnpm check",
     "test": "vitest run",
     "test:e2e": "VITE_SKIP_ANIMATION=true VITE_DEMO_LIVE=false vitest run --config vitest.config.e2e.ts",
-    "test:watch": "viest"
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",


### PR DESCRIPTION
## Description

Fix the `test:watch` script in `package.json` so it invokes `vitest` instead of the misspelled `viest` command.

## Validation

- `git diff --check`
- `./node_modules/.bin/biome check package.json`
- `./node_modules/.bin/vitest --help`

## Notes

The repo's normal `pnpm run ...` entrypoints are blocked in this runtime because the preinstall hook calls `pnpx only-allow pnpm` and `pnpx` is not available here, so validation used the checked-in local binaries directly.
