### PR TITLE
Add MON Unlock service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -3944,6 +3944,63 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── MON Unlock ─────────────────────────────────────────────────────────
+  {
+    id: "mon-unlock",
+    name: "MON Unlock",
+    url: "https://mon-unlock-widget-production.up.railway.app",
+    serviceUrl: "https://mon-unlock-widget-production.up.railway.app",
+    description:
+      "Create embeddable paywalls for long-form articles. Agents validate for free, then pay via MPP to publish paste-ready <mon-unlock> HTML.",
+
+    categories: ["media", "web"],
+    integration: "first-party",
+    tags: [
+      "paywall",
+      "publishing",
+      "embed",
+      "micropayments",
+      "content-monetization",
+      "monad",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://mon-unlock-widget-production.up.railway.app",
+      llmsTxt: "https://mon-unlock-widget-production.up.railway.app/llms.txt",
+      apiReference: "https://mon-unlock-widget-production.up.railway.app/agents.md",
+    },
+    provider: {
+      name: "Open Paywall / MON Unlock",
+      url: "https://mon-unlock-widget-production.up.railway.app",
+    },
+    realm: "mon-unlock-widget-production.up.railway.app",
+    intent: "charge",
+    payments: [
+      {
+        method: "tempo",
+        currency: "0x20c0000000000000000000000000000000000000",
+        decimals: 6,
+      },
+      STRIPE_PAYMENT,
+    ],
+    endpoints: [
+      {
+        route: "GET /api/agents/health",
+        desc: "Agent API + MPP configuration status",
+      },
+      {
+        route: "POST /api/agents/publish/validate",
+        desc: "Validate publish payload and return quote (free)",
+      },
+      {
+        route: "POST /api/agents/publish",
+        desc: "Pay to publish paste-ready <mon-unlock> embed HTML",
+        amount: "50000",
+        unitType: "request",
+      },
+    ],
+  },
+
   // ── Prospect Butcher Co ─────────────────────────────────────────────────
   {
     id: "prospect-butcher",


### PR DESCRIPTION
## Summary
- Adds **MON Unlock** to the curated `mpp.dev/services` directory (`schemas/services.ts`).
- Live production MPP API: agents validate for free, then pay via HTTP 402 to publish paste-ready `<mon-unlock>` embed HTML.

## Service
- **URL:** https://mon-unlock-widget-production.up.railway.app
- **Paid endpoint:** `POST /api/agents/publish` — $0.05 (pathUSD `50000` @ 6 decimals; Stripe also offered)
- **Free:** `GET /api/agents/health`, `POST /api/agents/publish/validate`
- **Realm:** `mon-unlock-widget-production.up.railway.app`
- **Docs:** [/llms.txt](https://mon-unlock-widget-production.up.railway.app/llms.txt), [/agents.md](https://mon-unlock-widget-production.up.railway.app/agents.md), [/openapi.json](https://mon-unlock-widget-production.up.railway.app/openapi.json)

## Checklist
- [x] Service is live and accepting MPP payments
- [x] Entry added to `schemas/services.ts`
- [x] Registered on [MPPScan](https://www.mppscan.com/register)
- [ ] `pnpm check:types` / `pnpm build` (schema entry only; please run in CI)

## Test plan
- [ ] Visit health: https://mon-unlock-widget-production.up.railway.app/api/agents/health
- [ ] Unpaid `POST /api/agents/publish` returns 402 with realm matching host
- [ ] Discovery artifacts regenerate cleanly with the new entry

Made with [Cursor](https://cursor.com)