### PR TITLE
fix: make indexed content redirects permanent

### DIFF
--- a/scripts/redirects.test.ts
+++ b/scripts/redirects.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import vocsConfig from "../vocs.config.ts";
+
+const permanentContentMoves = [
+  {
+    source: "/docs",
+    destination: "/overview",
+    status: 308,
+  },
+  {
+    source: "/guides/upgrade-x402",
+    destination: "/guides/use-mpp-with-x402",
+    status: 308,
+  },
+  {
+    source: "/protocol/discovery",
+    destination: "/advanced/discovery",
+    status: 308,
+  },
+] as const;
+
+describe("permanent content redirects", () => {
+  it("uses 308 only for the confirmed permanent moves", () => {
+    const redirects = (vocsConfig.redirects ?? [])
+      .filter((redirect) => redirect.status === 308)
+      .map(({ source, destination, status }) => ({
+        source,
+        destination,
+        status,
+      }))
+      .sort((a, b) => a.source.localeCompare(b.source));
+
+    expect(redirects).toEqual(
+      [...permanentContentMoves].sort((a, b) =>
+        a.source.localeCompare(b.source),
+      ),
+    );
+  });
+});

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     { source: "/index", destination: "/" },
 
     // Aliases for overview
-    { source: "/docs", destination: "/overview" },
+    { source: "/docs", destination: "/overview", status: 308 },
     { source: "/documentation", destination: "/overview" },
     { source: "/about", destination: "/overview" },
 
@@ -59,6 +59,7 @@ export default defineConfig({
     {
       source: "/guides/upgrade-x402",
       destination: "/guides/use-mpp-with-x402",
+      status: 308,
     },
     { source: "/challenges", destination: "/protocol/challenges" },
     { source: "/challenge", destination: "/protocol/challenges" },
@@ -217,6 +218,7 @@ export default defineConfig({
     {
       source: "/protocol/discovery",
       destination: "/advanced/discovery",
+      status: 308,
     },
     { source: "/refunds", destination: "/advanced/refunds" },
 


### PR DESCRIPTION
## What changed

- Changed the three Search Console content-move examples from temporary redirects to HTTP 308:
  - `/docs` to `/overview`
  - `/guides/upgrade-x402` to `/guides/use-mpp-with-x402`
  - `/protocol/discovery` to `/advanced/discovery`
- Added a regression test that locks the exact permanent redirect set.

## Why

These are permanent content moves. Vocs defaults to HTTP 307, which keeps them in Search Console's redirect exclusions without the strongest permanent-move signal.

## Validation

- Full test suite: 9,522 tests passed
- Biome and TypeScript checks passed
- Production build and SSG passed using a non-sensitive local placeholder key
- Vercel preview confirmed all three routes return 308 and resolve to 200
- No generated-file drift
- All GitHub and Vercel checks passed