### PR TITLE
Fix session management requests on mpp.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cloudflare-worker-metrics": "^1.4.0",
     "hono": "^4.12.27",
     "mermaid": "^11.15.0",
-    "mppx": "^0.8.12",
+    "mppx": "https://pkg.pr.new/mppx@679",
     "react": "^19",
     "react-dom": "^19",
     "stripe": "^22.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cloudflare-worker-metrics": "^1.4.0",
     "hono": "^4.12.27",
     "mermaid": "^11.15.0",
-    "mppx": "^0.8.8",
+    "mppx": "^0.8.12",
     "react": "^19",
     "react-dom": "^19",
     "stripe": "^22.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cloudflare-worker-metrics": "^1.4.0",
     "hono": "^4.12.27",
     "mermaid": "^11.15.0",
-    "mppx": "^0.8.12",
+    "mppx": "^0.8.13",
     "react": "^19",
     "react-dom": "^19",
     "stripe": "^22.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cloudflare-worker-metrics": "^1.4.0",
     "hono": "^4.12.27",
     "mermaid": "^11.15.0",
-    "mppx": "https://pkg.pr.new/mppx@679",
+    "mppx": "^0.8.12",
     "react": "^19",
     "react-dom": "^19",
     "stripe": "^22.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       mppx:
-        specifier: ^0.8.8
-        version: 0.8.8(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
+        specifier: ^0.8.12
+        version: 0.8.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
       react:
         specifier: ^19
         version: 19.2.7
@@ -3425,8 +3425,8 @@ packages:
       hono:
         optional: true
 
-  mppx@0.8.8:
-    resolution: {integrity: sha512-beUt0x0tsQQIXTZTxZcmNWGMrktcb3e3KcUyyLWdYmCleB6sJUrL60SA93/tNlqyD1Nssz5BpWWzWuxu0gvBUg==}
+  mppx@0.8.12:
+    resolution: {integrity: sha512-aLtXfnOZ92E2aYsBNAo6StO7osQvBoSyzLc82pyrVKRn2VGhgVcMiqDIhSq0NWWhjrl8UQAjqU1Q8Qpt9WFSrw==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
@@ -8003,7 +8003,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.8.8(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.8.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.9.0
       eventsource-parser: 3.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       mppx:
-        specifier: https://pkg.pr.new/mppx@679
-        version: https://pkg.pr.new/mppx@679(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
+        specifier: ^0.8.12
+        version: 0.8.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
       react:
         specifier: ^19
         version: 19.2.7
@@ -3425,9 +3425,8 @@ packages:
       hono:
         optional: true
 
-  mppx@https://pkg.pr.new/mppx@679:
-    resolution: {tarball: https://pkg.pr.new/mppx@679}
-    version: 0.8.12
+  mppx@0.8.12:
+    resolution: {integrity: sha512-aLtXfnOZ92E2aYsBNAo6StO7osQvBoSyzLc82pyrVKRn2VGhgVcMiqDIhSq0NWWhjrl8UQAjqU1Q8Qpt9WFSrw==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
@@ -8004,7 +8003,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@https://pkg.pr.new/mppx@679(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.8.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.9.0
       eventsource-parser: 3.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       mppx:
-        specifier: ^0.8.12
-        version: 0.8.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
+        specifier: https://pkg.pr.new/mppx@679
+        version: https://pkg.pr.new/mppx@679(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
       react:
         specifier: ^19
         version: 19.2.7
@@ -3425,8 +3425,9 @@ packages:
       hono:
         optional: true
 
-  mppx@0.8.12:
-    resolution: {integrity: sha512-aLtXfnOZ92E2aYsBNAo6StO7osQvBoSyzLc82pyrVKRn2VGhgVcMiqDIhSq0NWWhjrl8UQAjqU1Q8Qpt9WFSrw==}
+  mppx@https://pkg.pr.new/mppx@679:
+    resolution: {tarball: https://pkg.pr.new/mppx@679}
+    version: 0.8.12
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
@@ -8003,7 +8004,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.8.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@https://pkg.pr.new/mppx@679(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.9.0
       eventsource-parser: 3.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       mppx:
-        specifier: ^0.8.12
-        version: 0.8.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
+        specifier: ^0.8.13
+        version: 0.8.13(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
       react:
         specifier: ^19
         version: 19.2.7
@@ -3425,8 +3425,8 @@ packages:
       hono:
         optional: true
 
-  mppx@0.8.12:
-    resolution: {integrity: sha512-aLtXfnOZ92E2aYsBNAo6StO7osQvBoSyzLc82pyrVKRn2VGhgVcMiqDIhSq0NWWhjrl8UQAjqU1Q8Qpt9WFSrw==}
+  mppx@0.8.13:
+    resolution: {integrity: sha512-8H01392Cn5tlwUG3wqxKe8qd/lxi2krAdw6MQzWWRMnhv/CDEJD3Ia1Qipy631NYQBWm3VE/pU6aQOYYjmcYbg==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
@@ -8003,7 +8003,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.8.12(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.8.13(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.9.0
       eventsource-parser: 3.1.0

--- a/src/mppx.server.ts
+++ b/src/mppx.server.ts
@@ -31,3 +31,11 @@ export const mppx = Mppx.create({
   realm,
   secretKey,
 });
+
+mppx.onPaymentFailed(({ error, method }) => {
+  console.warn("MPP payment failed", {
+    error: error.message,
+    intent: method.intent,
+    method: method.name,
+  });
+});

--- a/src/mppx.server.ts
+++ b/src/mppx.server.ts
@@ -31,11 +31,3 @@ export const mppx = Mppx.create({
   realm,
   secretKey,
 });
-
-mppx.onPaymentFailed(({ error, method }) => {
-  console.warn("MPP payment failed", {
-    error: error.message,
-    intent: method.intent,
-    method: method.name,
-  });
-});

--- a/src/pages/_api/api/sessions/photo.ts
+++ b/src/pages/_api/api/sessions/photo.ts
@@ -8,6 +8,8 @@ export async function GET(request: Request) {
 
   if (result.status === 402) return result.challenge;
 
+  if (request.method === "POST") return result.withReceipt();
+
   let url: string;
   try {
     const res = await fetch("https://picsum.photos/200/200");
@@ -23,3 +25,5 @@ export async function GET(request: Request) {
 
   return result.withReceipt(Response.json({ url }));
 }
+
+export const POST = GET;

--- a/src/pages/sdk/typescript/server/Mppx.compose.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.compose.mdx
@@ -15,6 +15,7 @@ const recipient = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
 
 const charge = tempo.charge({ recipient })
 const card = stripe.charge({
+  decimals: 2,
   networkId: 'acct_1234',
   paymentMethodTypes: ['card'],
   secretKey: 'sk_live_...',


### PR DESCRIPTION
## Summary

- expose `POST /api/sessions/photo` so session management Credentials reach mppx
- return management Receipts without invoking the photo upstream
- update the locked SDK to released `mppx@0.8.13`

## Root causes

1. The Waku route exported only `GET`, so session management requests failed before mppx handled them.
2. Earlier mppx versions made the server account sponsor its own management transaction. `mppx@0.8.13` includes the fix from wevm/mppx#679.

## Validation

- `pnpm check:types`
- `pnpm test` (9,632 tests)
- `MPP_SECRET_KEY=local-build-only-secret-key-32-bytes pnpm build`

Before production deployment, rerun the live request, top-up, and close smoke test against the preview.
