### PR TITLE
Add Smarty Swap Safety service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11167,4 +11167,45 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── Smarty Swap Safety ──────────────────────────────────────────────────
+  {
+    id: "smarty-swap-safety",
+    name: "Smarty Swap Safety",
+    url: "https://smarty-money.vercel.app",
+    serviceUrl: "https://smarty-money.vercel.app",
+    description:
+      "Inspect proposed Solana swaps using fresh mint-authority checks, Jupiter route evidence, and executable round-trip loss.",
+    icon: "https://smarty-money.vercel.app/favicon.ico",
+    categories: ["blockchain", "data"],
+    integration: "first-party",
+    tags: ["solana", "swap", "risk", "jupiter", "pre-trade"],
+    status: "active",
+    docs: {
+      homepage: "https://smarty-money.vercel.app",
+      llmsTxt: "https://smarty-money.vercel.app/llms.txt",
+      apiReference: "https://smarty-money.vercel.app/openapi.json",
+    },
+    provider: {
+      name: "Smarty Swap Safety",
+      url: "https://smarty-money.vercel.app",
+    },
+    realm: "smarty-money.vercel.app",
+    intent: "charge",
+    payments: [
+      {
+        method: "solana",
+        currency: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        decimals: 6,
+      },
+    ],
+    endpoints: [
+      {
+        route: "POST /mpp/swap-safety",
+        desc: "Inspect a proposed Solana swap",
+        amount: "10000",
+        unitType: "request",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary

- add the live Smarty Swap Safety service to the curated directory
- list its Solana MPP charge endpoint at $0.01 USDC per request
- link its OpenAPI document, `llms.txt`, and production homepage

## Verification

- [x] Production endpoint returns a valid Solana MPP `402` Challenge
- [x] `npx mppx discover validate https://smarty-money.vercel.app/openapi.json`
- [x] `pnpm generate:discovery && pnpm check:types`
- [x] `MPP_SECRET_KEY=<test-secret> pnpm build`
- [x] Registered on [MPPScan](https://mppscan.com/server/543671b7b6053eee64a836bd7e9bbb95350b8303777f68b75cd7815ca2ea36b4)

No self-purchase was made to manufacture registry activity; the production payment path, discovery metadata, persistent replay store, and recipient configuration are live.
