### PR TITLE
Expand quickstart prompts in generated docs

### DIFF
--- a/src/components/QuickstartPrompt.tsx
+++ b/src/components/QuickstartPrompt.tsx
@@ -2,17 +2,9 @@
 
 import { Tabs } from "@base-ui/react/tabs";
 import { PromptBlock } from "./PromptBlock";
+import { CLIENT_PROMPT, SERVER_PROMPT } from "./quickstart-prompts.js";
 
-export const CLIENT_PROMPT = `Reference https://mpp.dev/quickstart/client.md
-
-Add mppx to my app as a client.
-Polyfill the global fetch to automatically handle 402 Payment Required responses using the Tempo payment method.
-Make a request to https://mpp.dev/api/ping/paid to test.`;
-
-export const SERVER_PROMPT = `Reference https://mpp.dev/quickstart/server.md
-
-Add mppx to my server with a /api/test route that charges $0.01 per request using the Tempo payment method with USDC.e.
-Use the mppx CLI to test your endpoint.`;
+export { CLIENT_PROMPT, SERVER_PROMPT } from "./quickstart-prompts.js";
 
 export function ClientPrompt() {
   return <PromptBlock>{CLIENT_PROMPT}</PromptBlock>;

--- a/src/components/quickstart-prompts.ts
+++ b/src/components/quickstart-prompts.ts
@@ -1,0 +1,10 @@
+export const CLIENT_PROMPT = `Reference https://mpp.dev/quickstart/client.md
+
+Add mppx to my app as a client.
+Polyfill the global fetch to automatically handle 402 Payment Required responses using the Tempo payment method.
+Make a request to https://mpp.dev/api/ping/paid to test.`;
+
+export const SERVER_PROMPT = `Reference https://mpp.dev/quickstart/server.md
+
+Add mppx to my server with a /api/test route that charges $0.01 per request using the Tempo payment method with USDC.e.
+Use the mppx CLI to test your endpoint.`;

--- a/src/quickstart-prompt-markdown.test.ts
+++ b/src/quickstart-prompt-markdown.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLIENT_PROMPT,
+  SERVER_PROMPT,
+} from "./components/quickstart-prompts.js";
+import { expandQuickstartPromptComponents } from "./quickstart-prompt-markdown.js";
+
+describe("expandQuickstartPromptComponents", () => {
+  it("expands the server prompt component", () => {
+    const output = expandQuickstartPromptComponents("<ServerPrompt />");
+
+    expect(output).not.toContain("<ServerPrompt");
+    expect(output).toContain(SERVER_PROMPT);
+  });
+
+  it("expands the client prompt component", () => {
+    const output = expandQuickstartPromptComponents("<ClientPrompt />");
+
+    expect(output).not.toContain("<ClientPrompt");
+    expect(output).toContain(CLIENT_PROMPT);
+  });
+
+  it("expands the combined quickstart prompts component", () => {
+    const output = expandQuickstartPromptComponents("<QuickstartPrompts />");
+
+    expect(output).not.toContain("<QuickstartPrompts");
+    expect(output).toContain(CLIENT_PROMPT);
+    expect(output).toContain(SERVER_PROMPT);
+  });
+
+  it("leaves markdown without prompt components unchanged", () => {
+    const markdown = "# Quickstart\n\nNo prompt components here.";
+
+    expect(expandQuickstartPromptComponents(markdown)).toBe(markdown);
+  });
+});

--- a/src/quickstart-prompt-markdown.ts
+++ b/src/quickstart-prompt-markdown.ts
@@ -1,0 +1,23 @@
+import {
+  CLIENT_PROMPT,
+  SERVER_PROMPT,
+} from "./components/quickstart-prompts.js";
+
+const CLIENT_PROMPT_COMPONENT = /<ClientPrompt\s*\/>/g;
+const QUICKSTART_PROMPTS_COMPONENT = /<QuickstartPrompts\s*\/>/g;
+const SERVER_PROMPT_COMPONENT = /<ServerPrompt\s*\/>/g;
+
+export function expandQuickstartPromptComponents(markdown: string): string {
+  return markdown
+    .replace(QUICKSTART_PROMPTS_COMPONENT, quickstartPromptsMarkdown())
+    .replace(CLIENT_PROMPT_COMPONENT, promptCodeBlock(CLIENT_PROMPT))
+    .replace(SERVER_PROMPT_COMPONENT, promptCodeBlock(SERVER_PROMPT));
+}
+
+function promptCodeBlock(prompt: string): string {
+  return `\`\`\`text\n${prompt.trimEnd()}\n\`\`\``;
+}
+
+function quickstartPromptsMarkdown(): string {
+  return `### Client\n\n${promptCodeBlock(CLIENT_PROMPT)}\n\n### Server\n\n${promptCodeBlock(SERVER_PROMPT)}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import { defineConfig, loadEnv } from "vite";
 import mkcert from "vite-plugin-mkcert";
 import { configDefaults } from "vitest/config";
 import { vocs } from "vocs/vite";
+import { expandQuickstartPromptComponents } from "./src/quickstart-prompt-markdown.js";
 
 const commitSha = child_process
   .execSync("git rev-parse --short HEAD")
@@ -236,6 +237,62 @@ function sectionLlmsTxt(): Plugin {
   };
 }
 
+// Vocs serializes unknown MDX components as JSX in generated Markdown and LLM
+// artifacts. Expand quickstart prompt components into the prompt text agents
+// consume, without changing how the interactive docs pages render.
+function expandPromptComponents(): Plugin {
+  let outDir: string | undefined;
+  return {
+    name: "expand-prompt-components",
+    enforce: "post",
+    configResolved(config) {
+      outDir = path.resolve(config.root, config.build.outDir, "public");
+    },
+    async closeBundle() {
+      if (!outDir) return;
+
+      for (const file of await agentFacingGeneratedFiles(outDir)) {
+        const current = await fs.readFile(file, "utf8").catch((error) => {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+          throw error;
+        });
+        if (!current) continue;
+
+        const next = expandQuickstartPromptComponents(current);
+        if (next !== current) await fs.writeFile(file, next, "utf8");
+      }
+    },
+  };
+}
+
+async function agentFacingGeneratedFiles(outDir: string): Promise<string[]> {
+  return [
+    path.join(outDir, "llms-full.txt"),
+    path.join(outDir, "llms.txt"),
+    ...(await generatedMarkdownFiles(path.join(outDir, "assets", "md"))),
+  ];
+}
+
+async function generatedMarkdownFiles(directory: string): Promise<string[]> {
+  const entries = await fs
+    .readdir(directory, { withFileTypes: true })
+    .catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    });
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await generatedMarkdownFiles(entryPath)));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
 // Keep each llms.txt row useful while preventing verbose frontmatter
 // descriptions from pushing the whole index over the scanner's token limit.
 function trimLlmsEntry(entry: string): string {
@@ -304,6 +361,7 @@ export default defineConfig(({ mode }) => {
       contentSignalsRobotsTxt(),
       pruneSitemap(),
       sectionLlmsTxt(),
+      expandPromptComponents(),
       ...(mode !== "production" && mode !== "test"
         ? [mkcert({ force: true, hosts: ["localhost"] })]
         : []),


### PR DESCRIPTION
## Summary
Generated agent-facing docs currently include raw React component tags like`<QuickstartPrompts />` instead of the prompt text agents need to read: https://mpp.dev/quickstart.md

<img width="1354" height="330" alt="image" src="https://github.com/user-attachments/assets/8a185296-0107-43cd-b352-c7456416c631" />

This PR expands the quickstart prompt components into literal prompt text in generatedMarkdown and LLM artifacts, while keeping the prompt copy sourced from one shared module.

## Verification
- pnpm test src/quickstart-prompt-markdown.test.ts
- pnpm check:types
- MPP_SECRET_KEY=<blah> pnpm build
- Confirmed generated Markdown and `llms-full.txt` no longer contain `<ServerPrompt />`,`<ClientPrompt />`, or `<QuickstartPrompts />`