### PR TITLE
chore: audit Markdown components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: node scripts/generate-discovery.ts
       - run: pnpm test
+      - run: pnpm check:markdown
 
   mcp-services:
     name: MPP Discovery Service MCP Worker

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "node scripts/generate-discovery.ts && node scripts/build-diagrams.ts && node scripts/copy-vocs-theme.ts && node scripts/generate-cli-help.ts && node scripts/generate-og-descriptions.ts && vite build",
     "check": "biome check --write",
     "check:ci": "biome check",
+    "check:markdown": "node scripts/check-markdown-components.mjs",
     "check:generated": "pnpm generate:pages && git diff --exit-code -- src/pages.gen.ts",
     "check:sdk-drift": "npx tsx .github/actions/sdk-drift-check/check-sdk-drift.ts",
     "check:types": "tsc --noEmit",
@@ -38,7 +39,7 @@
     "stripe": "^22.2.0",
     "tailwindcss": "^4.3.0",
     "viem": "^2.54.0",
-    "vocs": "https://pkg.pr.new/wevm/vocs/vocs@593",
+    "vocs": "https://pkg.pr.new/wevm/vocs/vocs@595",
     "wagmi": "^3.6.16",
     "waku": "1.0.0-beta.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^2.54.0
         version: 2.54.0(typescript@6.0.3)(zod@4.4.3)
       vocs:
-        specifier: https://pkg.pr.new/wevm/vocs/vocs@593
-        version: https://pkg.pr.new/wevm/vocs/vocs@593(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.40)(date-fns@4.1.0)(esbuild@0.28.1)(idb-keyval@6.2.5)(mermaid@11.15.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.5)(rollup@4.60.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(waku@1.0.0-beta.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.105.2(esbuild@0.28.1))
+        specifier: https://pkg.pr.new/wevm/vocs/vocs@595
+        version: https://pkg.pr.new/wevm/vocs/vocs@595(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.40)(date-fns@4.1.0)(esbuild@0.28.1)(idb-keyval@6.2.5)(mermaid@11.15.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.5)(rollup@4.60.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(waku@1.0.0-beta.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.105.2(esbuild@0.28.1))
       wagmi:
         specifier: ^3.6.16
         version: 3.6.16(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.7))(@types/react@19.2.16)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
@@ -5021,8 +5021,8 @@ packages:
       jsdom:
         optional: true
 
-  vocs@https://pkg.pr.new/wevm/vocs/vocs@593:
-    resolution: {tarball: https://pkg.pr.new/wevm/vocs/vocs@593}
+  vocs@https://pkg.pr.new/wevm/vocs/vocs@595:
+    resolution: {tarball: https://pkg.pr.new/wevm/vocs/vocs@595}
     version: 2.6.2
     hasBin: true
     peerDependencies:
@@ -10602,7 +10602,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@https://pkg.pr.new/wevm/vocs/vocs@593(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.40)(date-fns@4.1.0)(esbuild@0.28.1)(idb-keyval@6.2.5)(mermaid@11.15.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.5)(rollup@4.60.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(waku@1.0.0-beta.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.105.2(esbuild@0.28.1)):
+  vocs@https://pkg.pr.new/wevm/vocs/vocs@595(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.40)(date-fns@4.1.0)(esbuild@0.28.1)(idb-keyval@6.2.5)(mermaid@11.15.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.5)(rollup@4.60.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(waku@1.0.0-beta.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.105.2(esbuild@0.28.1)):
     dependencies:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/scripts/check-markdown-components.mjs
+++ b/scripts/check-markdown-components.mjs
@@ -1,0 +1,55 @@
+import { spawnSync } from "node:child_process";
+
+const allowedComponents = new Set([
+  "Badge",
+  "BlogPostList",
+  "Card",
+  "Cards",
+  "DownloadSvgButton",
+  "MermaidDiagram",
+  "MppxCreateReferenceCard",
+  "PromptBlock",
+  "SdkBadge.GitHub",
+  "SdkBadge.Maintainer",
+  "SpecCard",
+  "Tab",
+  "Tabs",
+]);
+
+const command = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const audit = spawnSync(command, ["exec", "vocs", "markdown-audit", "--json"], {
+  encoding: "utf8",
+});
+
+if (audit.error) throw audit.error;
+
+let report;
+try {
+  report = JSON.parse(audit.stdout);
+} catch {
+  console.error(audit.stderr || audit.stdout);
+  throw new Error("Vocs did not produce a JSON Markdown audit report.");
+}
+
+if (audit.status !== 0 && audit.status !== 1) {
+  console.error(audit.stderr);
+  process.exit(audit.status ?? 1);
+}
+
+const unexpected = report.components.filter(
+  ({ name }) => !allowedComponents.has(name),
+);
+if (report.errors.length > 0 || unexpected.length > 0) {
+  console.error("Markdown component audit failed.");
+  for (const { path, error } of report.errors)
+    console.error(`- ${path}: ${error}`);
+  for (const { name, count } of unexpected)
+    console.error(
+      `- ${name}: ${count} unallowlisted occurrence${count === 1 ? "" : "s"}`,
+    );
+  process.exit(1);
+}
+
+console.log(
+  `Markdown component audit passed (${report.components.length} allowlisted component types).`,
+);


### PR DESCRIPTION
## Motivation

Vocs PR #595 adds a Markdown component audit. Keep AI-facing Markdown from gaining new unresolved components.

## Summary

- Upgrade Vocs from the existing preview build to PR #595.
- Add an allowlist-backed Markdown audit command.
- Run the audit in CI.

## Key design considerations

- Existing unresolved components remain explicitly allowlisted; new names fail CI.