### PR TITLE
fix: render MDX components in Markdown output

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "stripe": "^22.2.0",
     "tailwindcss": "^4.3.0",
     "viem": "^2.54.0",
-    "vocs": "https://pkg.pr.new/wevm/vocs/vocs@595",
+    "vocs": "https://pkg.pr.new/wevm/vocs/vocs@594",
     "wagmi": "^3.6.16",
     "waku": "1.0.0-beta.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^2.54.0
         version: 2.54.0(typescript@6.0.3)(zod@4.4.3)
       vocs:
-        specifier: https://pkg.pr.new/wevm/vocs/vocs@595
-        version: https://pkg.pr.new/wevm/vocs/vocs@595(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.40)(date-fns@4.1.0)(esbuild@0.28.1)(idb-keyval@6.2.5)(mermaid@11.15.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.5)(rollup@4.60.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(waku@1.0.0-beta.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.105.2(esbuild@0.28.1))
+        specifier: https://pkg.pr.new/wevm/vocs/vocs@594
+        version: https://pkg.pr.new/wevm/vocs/vocs@594(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.40)(date-fns@4.1.0)(esbuild@0.28.1)(idb-keyval@6.2.5)(mermaid@11.15.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.5)(rollup@4.60.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(waku@1.0.0-beta.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.105.2(esbuild@0.28.1))
       wagmi:
         specifier: ^3.6.16
         version: 3.6.16(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.7))(@types/react@19.2.16)(accounts@0.14.11)(react@19.2.7)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
@@ -5021,8 +5021,8 @@ packages:
       jsdom:
         optional: true
 
-  vocs@https://pkg.pr.new/wevm/vocs/vocs@595:
-    resolution: {tarball: https://pkg.pr.new/wevm/vocs/vocs@595}
+  vocs@https://pkg.pr.new/wevm/vocs/vocs@594:
+    resolution: {tarball: https://pkg.pr.new/wevm/vocs/vocs@594}
     version: 2.6.2
     hasBin: true
     peerDependencies:
@@ -5749,15 +5749,15 @@ snapshots:
   '@floating-ui/vue@1.1.9(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.8.0
-      '@floating-ui/utils': 0.2.10
+      '@floating-ui/utils': 0.2.12
       vue-demi: 0.14.10(vue@3.5.40(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@headlessui/tailwindcss@0.2.2(tailwindcss@4.3.0)':
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@4.3.3)':
     dependencies:
-      tailwindcss: 4.3.0
+      tailwindcss: 4.3.3
 
   '@headlessui/vue@1.7.23(vue@3.5.40(typescript@6.0.3))':
     dependencies:
@@ -6336,17 +6336,17 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
-  '@scalar/api-client@3.13.7(idb-keyval@6.2.5)(tailwindcss@4.3.0)(typescript@6.0.3)':
+  '@scalar/api-client@3.13.7(idb-keyval@6.2.5)(tailwindcss@4.3.3)(typescript@6.0.3)':
     dependencies:
-      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.0)
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.3)
       '@headlessui/vue': 1.7.23(vue@3.5.40(typescript@6.0.3))
-      '@scalar/blocks': 0.1.8(tailwindcss@4.3.0)(typescript@6.0.3)
-      '@scalar/components': 0.27.9(tailwindcss@4.3.0)(typescript@6.0.3)
+      '@scalar/blocks': 0.1.8(tailwindcss@4.3.3)(typescript@6.0.3)
+      '@scalar/components': 0.27.9(tailwindcss@4.3.3)(typescript@6.0.3)
       '@scalar/helpers': 0.9.2
       '@scalar/icons': 0.7.5(typescript@6.0.3)
       '@scalar/oas-utils': 0.19.8(typescript@6.0.3)
       '@scalar/openapi-types': 0.9.3
-      '@scalar/sidebar': 0.9.33(tailwindcss@4.3.0)(typescript@6.0.3)
+      '@scalar/sidebar': 0.9.33(tailwindcss@4.3.3)(typescript@6.0.3)
       '@scalar/snippetz': 0.9.23
       '@scalar/themes': 0.17.1
       '@scalar/typebox': 0.1.3
@@ -6388,9 +6388,9 @@ snapshots:
     dependencies:
       '@scalar/helpers': 0.9.2
 
-  '@scalar/blocks@0.1.8(tailwindcss@4.3.0)(typescript@6.0.3)':
+  '@scalar/blocks@0.1.8(tailwindcss@4.3.3)(typescript@6.0.3)':
     dependencies:
-      '@scalar/components': 0.27.9(tailwindcss@4.3.0)(typescript@6.0.3)
+      '@scalar/components': 0.27.9(tailwindcss@4.3.3)(typescript@6.0.3)
       '@scalar/helpers': 0.9.2
       '@scalar/icons': 0.7.5(typescript@6.0.3)
       '@scalar/snippetz': 0.9.23
@@ -6426,11 +6426,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@scalar/components@0.27.9(tailwindcss@4.3.0)(typescript@6.0.3)':
+  '@scalar/components@0.27.9(tailwindcss@4.3.3)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/utils': 0.2.10
       '@floating-ui/vue': 1.1.9(vue@3.5.40(typescript@6.0.3))
-      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.0)
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.3)
       '@headlessui/vue': 1.7.23(vue@3.5.40(typescript@6.0.3))
       '@scalar/code-highlight': 0.4.3
       '@scalar/helpers': 0.9.2
@@ -6522,9 +6522,9 @@ snapshots:
       '@scalar/helpers': 0.9.2
       '@scalar/validation': 0.6.2
 
-  '@scalar/sidebar@0.9.33(tailwindcss@4.3.0)(typescript@6.0.3)':
+  '@scalar/sidebar@0.9.33(tailwindcss@4.3.3)(typescript@6.0.3)':
     dependencies:
-      '@scalar/components': 0.27.9(tailwindcss@4.3.0)(typescript@6.0.3)
+      '@scalar/components': 0.27.9(tailwindcss@4.3.3)(typescript@6.0.3)
       '@scalar/helpers': 0.9.2
       '@scalar/icons': 0.7.5(typescript@6.0.3)
       '@scalar/themes': 0.17.1
@@ -10214,9 +10214,9 @@ snapshots:
 
   tailwind-merge@3.5.0: {}
 
-  tailwindcss-logical@4.2.0(tailwindcss@4.3.0):
+  tailwindcss-logical@4.2.0(tailwindcss@4.3.3):
     dependencies:
-      tailwindcss: 4.3.0
+      tailwindcss: 4.3.3
 
   tailwindcss@4.3.0: {}
 
@@ -10602,7 +10602,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@https://pkg.pr.new/wevm/vocs/vocs@595(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.40)(date-fns@4.1.0)(esbuild@0.28.1)(idb-keyval@6.2.5)(mermaid@11.15.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.5)(rollup@4.60.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(waku@1.0.0-beta.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.105.2(esbuild@0.28.1)):
+  vocs@https://pkg.pr.new/wevm/vocs/vocs@594(@cfworker/json-schema@4.1.1)(@date-fns/tz@1.4.1)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.40)(date-fns@4.1.0)(esbuild@0.28.1)(idb-keyval@6.2.5)(mermaid@11.15.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.1.5)(rollup@4.60.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(waku@1.0.0-beta.1(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.105.2(esbuild@0.28.1)))(react@19.2.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.105.2(esbuild@0.28.1)):
     dependencies:
       '@base-ui/react': 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -10618,7 +10618,7 @@ snapshots:
       '@mdx-js/rollup': 3.1.1(rollup@4.60.1)
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@remix-run/node-fetch-server': 0.13.3
-      '@scalar/api-client': 3.13.7(idb-keyval@6.2.5)(tailwindcss@4.3.0)(typescript@6.0.3)
+      '@scalar/api-client': 3.13.7(idb-keyval@6.2.5)(tailwindcss@4.3.3)(typescript@6.0.3)
       '@scalar/openapi-parser': 0.28.10
       '@scalar/snippetz': 0.9.23
       '@scalar/workspace-store': 0.54.5(typescript@6.0.3)
@@ -10671,8 +10671,8 @@ snapshots:
       remark-stringify: 11.0.0
       shiki: 3.23.0
       sucrase: 3.35.1
-      tailwindcss: 4.3.0
-      tailwindcss-logical: 4.2.0(tailwindcss@4.3.0)
+      tailwindcss: 4.3.3
+      tailwindcss-logical: 4.2.0(tailwindcss@4.3.3)
       tsx: 4.23.1
       twoslash: 0.3.9(typescript@6.0.3)
       unhead: 3.2.3(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.60.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(webpack@5.105.2(esbuild@0.28.1))

--- a/scripts/check-markdown-components.mjs
+++ b/scripts/check-markdown-components.mjs
@@ -1,20 +1,7 @@
 import { spawnSync } from "node:child_process";
 
-const allowedComponents = new Set([
-  "Badge",
-  "BlogPostList",
-  "Card",
-  "Cards",
-  "DownloadSvgButton",
-  "MermaidDiagram",
-  "MppxCreateReferenceCard",
-  "PromptBlock",
-  "SdkBadge.GitHub",
-  "SdkBadge.Maintainer",
-  "SpecCard",
-  "Tab",
-  "Tabs",
-]);
+// Add component names here only when generated Markdown cannot represent them.
+const allowedComponents = new Set([]);
 
 const command = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const audit = spawnSync(command, ["exec", "vocs", "markdown-audit", "--json"], {

--- a/scripts/remark-mpp-markdown.d.mts
+++ b/scripts/remark-mpp-markdown.d.mts
@@ -1,0 +1,3 @@
+declare const remarkMppMarkdown: () => (tree: { children: unknown[] }) => void;
+
+export default remarkMppMarkdown;

--- a/scripts/remark-mpp-markdown.mjs
+++ b/scripts/remark-mpp-markdown.mjs
@@ -1,0 +1,322 @@
+/**
+ * Replaces interactive documentation components with semantic Markdown nodes.
+ *
+ * Vocs runs this plugin only for generated Markdown output. The React site
+ * continues to render the original MDX components.
+ */
+export default function remarkMppMarkdown() {
+  return (tree) => {
+    tree.children = transformNodes(tree.children, 2);
+  };
+}
+
+function transformNodes(nodes, defaultHeadingDepth) {
+  let headingDepth = defaultHeadingDepth - 1;
+  const transformed = [];
+
+  for (const node of nodes) {
+    const replacements = transformNode(node, headingDepth);
+    for (const replacement of replacements) {
+      transformed.push(replacement);
+      if (replacement.type === "heading") headingDepth = replacement.depth;
+    }
+  }
+
+  return transformed;
+}
+
+function transformNode(node, headingDepth) {
+  if (node.type !== "mdxJsxFlowElement" && node.type !== "mdxJsxTextElement")
+    return [transformChildren(node, headingDepth)];
+
+  switch (node.name) {
+    case "Badge":
+    case "Cards":
+    case "Tab":
+      return transformNodes(node.children, headingDepth + 1);
+    case "Tabs":
+      return transformTabs(node, headingDepth);
+    case "BlogPostList":
+      return [blogPostList(node)];
+    case "Card":
+      return [card(node)];
+    case "DownloadSvgButton":
+      return [downloadLinks(node)];
+    case "MermaidDiagram":
+      return [mermaidDiagram(node)];
+    case "MppxCreateReferenceCard":
+      return [mppxCreateReferenceCard(node)];
+    case "PromptBlock":
+      return [promptBlock(node)];
+    case "SdkBadge.GitHub":
+      return badgeGithub(node);
+    case "SdkBadge.Maintainer":
+      return badgeMaintainer(node);
+    case "SpecCard":
+      return [specCard(node)];
+    default:
+      return [transformChildren(node, headingDepth)];
+  }
+}
+
+function transformChildren(node, headingDepth) {
+  if (!node.children) return node;
+  return { ...node, children: transformNodes(node.children, headingDepth + 1) };
+}
+
+function transformTabs(node, headingDepth) {
+  const depth = Math.min(headingDepth + 1, 6);
+  const nodes = [];
+
+  for (const child of node.children) {
+    if (!isComponent(child, "Tab")) {
+      nodes.push(...transformNode(child, depth));
+      continue;
+    }
+
+    nodes.push(heading(depth, requiredString(child, "title")));
+    nodes.push(...transformNodes(child.children, depth + 1));
+  }
+
+  return nodes;
+}
+
+function blogPostList(node) {
+  const posts = requiredArray(node, "posts");
+  return {
+    type: "list",
+    ordered: false,
+    spread: true,
+    children: posts.map((post) => {
+      const title = requiredStaticString(post, "title", "BlogPostList post");
+      const to = requiredStaticString(post, "to", "BlogPostList post");
+      const date = requiredStaticString(post, "date", "BlogPostList post");
+      const description = requiredValue(
+        post,
+        "description",
+        "BlogPostList post",
+      );
+      return {
+        type: "listItem",
+        spread: true,
+        children: [
+          paragraph([link(to, [text(title)])]),
+          paragraph([text(`${date} — `), ...inlineNodes(description)]),
+        ],
+      };
+    }),
+  };
+}
+
+function card(node) {
+  return linkCard({
+    description: requiredString(node, "description"),
+    title: requiredString(node, "title"),
+    to: requiredString(node, "to"),
+  });
+}
+
+function downloadLinks(node) {
+  const files = requiredArray(node, "files");
+  return {
+    type: "list",
+    ordered: false,
+    spread: false,
+    children: files.map((file) => {
+      if (typeof file !== "string")
+        throw new TypeError("DownloadSvgButton files must be static strings.");
+      return {
+        type: "listItem",
+        spread: false,
+        children: [
+          paragraph([link(file, [text(file.split("/").at(-1) ?? file)])]),
+        ],
+      };
+    }),
+  };
+}
+
+function mermaidDiagram(node) {
+  return {
+    type: "code",
+    lang: "mermaid",
+    value: requiredString(node, "chart"),
+  };
+}
+
+function mppxCreateReferenceCard(node) {
+  return linkCard({
+    description: "Full API documentation",
+    title: "Mppx.create reference",
+    to: requiredString(node, "to"),
+  });
+}
+
+function promptBlock(node) {
+  return {
+    type: "code",
+    lang: "text",
+    value: node.children.map(expressionText).join(""),
+  };
+}
+
+function badgeGithub(node) {
+  const repo = requiredString(node, "repo");
+  return componentNodes(node, [
+    link(`https://github.com/${repo}`, [text(`GitHub: ${repo}`)]),
+  ]);
+}
+
+function badgeMaintainer(node) {
+  return componentNodes(node, [
+    text("Maintained by "),
+    link(requiredString(node, "href"), [text(requiredString(node, "name"))]),
+  ]);
+}
+
+function specCard(node) {
+  return linkCard({
+    description:
+      stringAttribute(node, "description") ?? "Read the full specification",
+    title: stringAttribute(node, "title") ?? "IETF Specification",
+    to: requiredString(node, "to"),
+  });
+}
+
+function componentNodes(node, children) {
+  return node.type === "mdxJsxTextElement" ? children : [paragraph(children)];
+}
+
+function linkCard({ description, title, to }) {
+  return paragraph([link(to, [text(title)]), text(` — ${description}`)]);
+}
+
+function requiredString(node, name) {
+  const value = stringAttribute(node, name);
+  if (value === undefined)
+    throw new TypeError(
+      `${node.name} requires a static ${name} attribute for Markdown output.`,
+    );
+  return value;
+}
+
+function requiredArray(node, name) {
+  const value = attributeValue(node, name);
+  if (!Array.isArray(value))
+    throw new TypeError(
+      `${node.name} requires a static ${name} array for Markdown output.`,
+    );
+  return value;
+}
+
+function requiredValue(object, name, context) {
+  const value = object?.[name];
+  if (value === undefined)
+    throw new TypeError(
+      `${context} requires a static ${name} value for Markdown output.`,
+    );
+  return value;
+}
+
+function requiredStaticString(object, name, context) {
+  const value = expressionValue(requiredValue(object, name, context));
+  if (typeof value !== "string")
+    throw new TypeError(
+      `${context} requires a static ${name} string for Markdown output.`,
+    );
+  return value;
+}
+
+function stringAttribute(node, name) {
+  const value = attributeValue(node, name);
+  return typeof value === "string" ? value : undefined;
+}
+
+function attributeValue(node, name) {
+  const attribute = node.attributes.find(
+    (candidate) =>
+      candidate.type === "mdxJsxAttribute" && candidate.name === name,
+  );
+  if (!attribute) return undefined;
+  if (typeof attribute.value === "string") return attribute.value;
+  return expressionValue(attribute.value?.data?.estree?.body?.[0]?.expression);
+}
+
+function expressionText(node) {
+  if (node.type === "mdxFlowExpression" || node.type === "mdxTextExpression")
+    return (
+      expressionValue(node.data?.estree?.body?.[0]?.expression) ??
+      node.value ??
+      ""
+    );
+  return inlineNodes(node)
+    .map((child) => child.value ?? "")
+    .join("");
+}
+
+function expressionValue(expression) {
+  if (!expression) return undefined;
+  if (expression.type === "Literal") return expression.value;
+  if (expression.type === "TemplateLiteral") {
+    if (expression.expressions.length > 0) return undefined;
+    return expression.quasis
+      .map((quasi) => quasi.value.cooked ?? quasi.value.raw)
+      .join("");
+  }
+  if (expression.type === "ArrayExpression")
+    return expression.elements.map(expressionValue);
+  if (expression.type === "ObjectExpression") {
+    return Object.fromEntries(
+      expression.properties.map((property) => [
+        property.key.name ?? property.key.value,
+        property.value,
+      ]),
+    );
+  }
+  return expression;
+}
+
+function inlineNodes(node) {
+  if (typeof node === "string") return [text(node)];
+  if (node?.type === "Literal") return [text(String(node.value))];
+  if (node?.type === "JSXText") return [text(node.value)];
+  if (node?.type === "JSXFragment") return node.children.flatMap(inlineNodes);
+  if (node?.type === "JSXElement") {
+    const children = node.children.flatMap(inlineNodes);
+    const name = node.openingElement.name.name;
+    if (name === "code")
+      return [
+        {
+          type: "inlineCode",
+          value: children.map((child) => child.value).join(""),
+        },
+      ];
+    return children;
+  }
+  if (node?.type === "JSXExpressionContainer")
+    return inlineNodes(node.expression);
+  return [text(String(node ?? ""))];
+}
+
+function isComponent(node, name) {
+  return (
+    (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") &&
+    node.name === name
+  );
+}
+
+function heading(depth, value) {
+  return { type: "heading", depth, children: [text(value)] };
+}
+
+function link(url, children) {
+  return { type: "link", url, children };
+}
+
+function paragraph(children) {
+  return { type: "paragraph", children };
+}
+
+function text(value) {
+  return { type: "text", value };
+}

--- a/scripts/remark-mpp-markdown.test.mjs
+++ b/scripts/remark-mpp-markdown.test.mjs
@@ -1,0 +1,483 @@
+import { describe, expect, it } from "vitest";
+import remarkMppMarkdown from "./remark-mpp-markdown.mjs";
+
+function attribute(name, value) {
+  return { name, type: "mdxJsxAttribute", value };
+}
+
+function expression(expression) {
+  return {
+    data: { estree: { body: [{ expression }] } },
+    type: "mdxJsxAttributeValueExpression",
+    value: "",
+  };
+}
+
+function literal(value) {
+  return { type: "Literal", value };
+}
+
+function flow(name, attributes = [], children = []) {
+  return { attributes, children, name, type: "mdxJsxFlowElement" };
+}
+
+function textComponent(name, attributes = [], children = []) {
+  return { attributes, children, name, type: "mdxJsxTextElement" };
+}
+
+function names(nodes) {
+  return nodes.flatMap((node) => [
+    ...(node.name ? [node.name] : []),
+    ...(node.children ? names(node.children) : []),
+  ]);
+}
+
+function transform(children) {
+  const tree = { children, type: "root" };
+  remarkMppMarkdown()(tree);
+  return tree;
+}
+
+function object(properties) {
+  return {
+    properties: Object.entries(properties).map(([name, value]) => ({
+      key: { name },
+      value,
+    })),
+    type: "ObjectExpression",
+  };
+}
+
+function paragraph(children) {
+  return { children, type: "paragraph" };
+}
+
+describe("remarkMppMarkdown", () => {
+  it("replaces every audited component with semantic Markdown", () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [
+            textComponent("Badge", [], [{ type: "text", value: "New" }]),
+          ],
+        },
+        flow("BlogPostList", [
+          attribute(
+            "posts",
+            expression({
+              elements: [
+                {
+                  properties: [
+                    { key: { name: "date" }, value: literal("June 17, 2026") },
+                    {
+                      key: { name: "description" },
+                      value: {
+                        children: [
+                          { type: "JSXText", value: "Session updates" },
+                        ],
+                        type: "JSXFragment",
+                      },
+                    },
+                    { key: { name: "title" }, value: literal("Sessions") },
+                    { key: { name: "to" }, value: literal("/blog/sessions") },
+                  ],
+                  type: "ObjectExpression",
+                },
+              ],
+              type: "ArrayExpression",
+            }),
+          ),
+        ]),
+        flow(
+          "Cards",
+          [],
+          [
+            flow("Card", [
+              attribute("description", "Use the API"),
+              attribute("title", "Quickstart"),
+              attribute("to", "/quickstart"),
+            ]),
+            flow("MppxCreateReferenceCard", [
+              attribute("to", "/sdk/Mppx.create"),
+            ]),
+            flow("SpecCard", [attribute("to", "https://paymentauth.org")]),
+          ],
+        ),
+        flow("DownloadSvgButton", [
+          attribute(
+            "files",
+            expression({
+              elements: [literal("/logo-dark.svg"), literal("/logo-light.svg")],
+              type: "ArrayExpression",
+            }),
+          ),
+        ]),
+        flow("MermaidDiagram", [
+          attribute(
+            "chart",
+            expression({
+              expressions: [],
+              quasis: [{ value: { cooked: "sequenceDiagram\\nA->>B: Pay" } }],
+              type: "TemplateLiteral",
+            }),
+          ),
+        ]),
+        flow(
+          "PromptBlock",
+          [],
+          [
+            {
+              data: {
+                estree: { body: [{ expression: literal("Build a paid API") }] },
+              },
+              type: "mdxFlowExpression",
+              value: '"Build a paid API"',
+            },
+          ],
+        ),
+        {
+          type: "paragraph",
+          children: [
+            textComponent("SdkBadge.GitHub", [
+              attribute("repo", "tempoxyz/mpp"),
+            ]),
+            textComponent("SdkBadge.Maintainer", [
+              attribute("href", "https://github.com/tempoxyz"),
+              attribute("name", "Tempo"),
+            ]),
+          ],
+        },
+        flow(
+          "Tabs",
+          [],
+          [
+            flow(
+              "Tab",
+              [attribute("title", "Accounts SDK")],
+              [
+                {
+                  type: "paragraph",
+                  children: [{ type: "text", value: "Accounts example" }],
+                },
+              ],
+            ),
+            flow(
+              "Tab",
+              [attribute("title", "viem")],
+              [
+                {
+                  type: "paragraph",
+                  children: [{ type: "text", value: "viem example" }],
+                },
+              ],
+            ),
+          ],
+        ),
+      ],
+    };
+
+    remarkMppMarkdown()(tree);
+
+    expect(names(tree.children)).not.toEqual(
+      expect.arrayContaining([
+        "Badge",
+        "BlogPostList",
+        "Card",
+        "Cards",
+        "DownloadSvgButton",
+        "MermaidDiagram",
+        "MppxCreateReferenceCard",
+        "PromptBlock",
+        "SdkBadge.GitHub",
+        "SdkBadge.Maintainer",
+        "SpecCard",
+        "Tab",
+        "Tabs",
+      ]),
+    );
+    expect(tree.children).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ lang: "mermaid", type: "code" }),
+        expect.objectContaining({
+          lang: "text",
+          type: "code",
+          value: "Build a paid API",
+        }),
+        expect.objectContaining({ depth: 2, type: "heading" }),
+      ]),
+    );
+  });
+
+  it("converts cards to titled Markdown links with their descriptions", () => {
+    const tree = transform([
+      flow("Card", [
+        attribute("description", "Start accepting payments"),
+        attribute("title", "Quickstart"),
+        attribute("to", "/quickstart"),
+      ]),
+      flow("MppxCreateReferenceCard", [attribute("to", "/sdk/Mppx.create")]),
+      flow("SpecCard", [
+        attribute("description", "Read the charge specification"),
+        attribute("title", "Charge specification"),
+        attribute("to", "https://paymentauth.org/charge"),
+      ]),
+    ]);
+
+    expect(tree.children).toEqual([
+      paragraph([
+        {
+          children: [{ type: "text", value: "Quickstart" }],
+          type: "link",
+          url: "/quickstart",
+        },
+        { type: "text", value: " — Start accepting payments" },
+      ]),
+      paragraph([
+        {
+          children: [{ type: "text", value: "Mppx.create reference" }],
+          type: "link",
+          url: "/sdk/Mppx.create",
+        },
+        { type: "text", value: " — Full API documentation" },
+      ]),
+      paragraph([
+        {
+          children: [{ type: "text", value: "Charge specification" }],
+          type: "link",
+          url: "https://paymentauth.org/charge",
+        },
+        { type: "text", value: " — Read the charge specification" },
+      ]),
+    ]);
+  });
+
+  it("preserves every tab as a sequential subsection at the active heading level", () => {
+    const tree = transform([
+      {
+        children: [{ type: "text", value: "Examples" }],
+        depth: 2,
+        type: "heading",
+      },
+      flow(
+        "Tabs",
+        [],
+        [
+          flow(
+            "Tab",
+            [attribute("title", "Accounts SDK")],
+            [
+              paragraph([
+                textComponent(
+                  "Badge",
+                  [],
+                  [{ type: "text", value: "Recommended" }],
+                ),
+              ]),
+            ],
+          ),
+          flow(
+            "Tab",
+            [attribute("title", "viem")],
+            [paragraph([{ type: "text", value: "Use viem." }])],
+          ),
+        ],
+      ),
+    ]);
+
+    expect(tree.children).toEqual([
+      {
+        children: [{ type: "text", value: "Examples" }],
+        depth: 2,
+        type: "heading",
+      },
+      {
+        children: [{ type: "text", value: "Accounts SDK" }],
+        depth: 3,
+        type: "heading",
+      },
+      paragraph([{ type: "text", value: "Recommended" }]),
+      {
+        children: [{ type: "text", value: "viem" }],
+        depth: 3,
+        type: "heading",
+      },
+      paragraph([{ type: "text", value: "Use viem." }]),
+    ]);
+  });
+
+  it("serializes blog metadata, inline code, downloads, diagrams, and prompts", () => {
+    const tree = transform([
+      flow("BlogPostList", [
+        attribute(
+          "posts",
+          expression({
+            elements: [
+              object({
+                date: literal("June 17, 2026"),
+                description: {
+                  children: [
+                    { type: "JSXText", value: "Install " },
+                    {
+                      children: [{ type: "JSXText", value: "mppx" }],
+                      openingElement: { name: { name: "code" } },
+                      type: "JSXElement",
+                    },
+                  ],
+                  type: "JSXFragment",
+                },
+                title: literal("Sessions"),
+                to: literal("/blog/sessions"),
+              }),
+            ],
+            type: "ArrayExpression",
+          }),
+        ),
+      ]),
+      flow("DownloadSvgButton", [
+        attribute(
+          "files",
+          expression({
+            elements: [literal("/logo-dark.svg"), literal("/logo-light.svg")],
+            type: "ArrayExpression",
+          }),
+        ),
+      ]),
+      flow("MermaidDiagram", [
+        attribute(
+          "chart",
+          expression({
+            expressions: [],
+            quasis: [{ value: { cooked: "sequenceDiagram\nA->>B: Pay" } }],
+            type: "TemplateLiteral",
+          }),
+        ),
+      ]),
+      flow(
+        "PromptBlock",
+        [],
+        [
+          {
+            data: {
+              estree: { body: [{ expression: literal("Build a paid API") }] },
+            },
+            type: "mdxFlowExpression",
+            value: '"Build a paid API"',
+          },
+        ],
+      ),
+    ]);
+
+    expect(tree.children[0].children[0].children[0].children).toEqual([
+      {
+        children: [{ type: "text", value: "Sessions" }],
+        type: "link",
+        url: "/blog/sessions",
+      },
+    ]);
+    expect(tree.children[0].children[0].children[1].children).toEqual([
+      { type: "text", value: "June 17, 2026 — " },
+      { type: "text", value: "Install " },
+      { type: "inlineCode", value: "mppx" },
+    ]);
+    expect(tree.children[1].children).toHaveLength(2);
+    expect(tree.children[2]).toMatchObject({
+      lang: "mermaid",
+      type: "code",
+      value: "sequenceDiagram\nA->>B: Pay",
+    });
+    expect(tree.children[3]).toMatchObject({
+      lang: "text",
+      type: "code",
+      value: "Build a paid API",
+    });
+  });
+
+  it("renders SDK badges in text and flow contexts", () => {
+    const tree = transform([
+      paragraph([
+        textComponent("SdkBadge.GitHub", [attribute("repo", "tempoxyz/mpp")]),
+        textComponent("SdkBadge.Maintainer", [
+          attribute("href", "https://github.com/tempoxyz"),
+          attribute("name", "Tempo"),
+        ]),
+      ]),
+      flow("SdkBadge.GitHub", [attribute("repo", "wevm/mppx")]),
+    ]);
+
+    expect(tree.children[0].children).toEqual([
+      {
+        children: [{ type: "text", value: "GitHub: tempoxyz/mpp" }],
+        type: "link",
+        url: "https://github.com/tempoxyz/mpp",
+      },
+      { type: "text", value: "Maintained by " },
+      {
+        children: [{ type: "text", value: "Tempo" }],
+        type: "link",
+        url: "https://github.com/tempoxyz",
+      },
+    ]);
+    expect(tree.children[1]).toEqual(
+      paragraph([
+        {
+          children: [{ type: "text", value: "GitHub: wevm/mppx" }],
+          type: "link",
+          url: "https://github.com/wevm/mppx",
+        },
+      ]),
+    );
+  });
+
+  it("leaves unknown components unchanged after transforming their children", () => {
+    const tree = transform([
+      flow(
+        "CustomWrapper",
+        [],
+        [flow("Tab", [], [paragraph([{ type: "text", value: "Child" }])])],
+      ),
+    ]);
+
+    expect(tree.children).toEqual([
+      flow(
+        "CustomWrapper",
+        [],
+        [paragraph([{ type: "text", value: "Child" }])],
+      ),
+    ]);
+  });
+
+  it.each([
+    [
+      flow("Card", [
+        attribute("title", "Quickstart"),
+        attribute("to", "/quickstart"),
+      ]),
+    ],
+    [
+      flow("DownloadSvgButton", [
+        attribute("files", expression({ type: "Identifier" })),
+      ]),
+    ],
+    [
+      flow("MermaidDiagram", [
+        attribute("chart", expression({ type: "Identifier" })),
+      ]),
+    ],
+    [flow("Tabs", [], [flow("Tab")])],
+    [
+      flow("BlogPostList", [
+        attribute(
+          "posts",
+          expression({
+            elements: [object({ title: literal("Missing fields") })],
+            type: "ArrayExpression",
+          }),
+        ),
+      ]),
+    ],
+  ])("rejects incomplete static component data", (children) => {
+    expect(() => transform(children)).toThrow(TypeError);
+  });
+});

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -1,5 +1,6 @@
 import ruby from "shiki/langs/ruby.mjs";
 import { defineConfig, McpSource } from "vocs/config";
+import remarkMppMarkdown from "./scripts/remark-mpp-markdown.mjs";
 import { shikiStyleToClass } from "./src/shiki-style-to-class.js";
 
 const baseUrl = (() => {
@@ -13,6 +14,9 @@ export default defineConfig({
   accentColor: "light-dark(#000000, #ffffff)",
   colorScheme: "light dark",
   baseUrl,
+  markdown: {
+    outputRemarkPlugins: [remarkMppMarkdown],
+  },
   redirects: [
     { source: "/index", destination: "/" },
 


### PR DESCRIPTION
## Motivation

Generated Markdown retained MDX component tags, preventing clean .md, llms.txt, and llms-full.txt output.

## Summary

- Replaced supported documentation component AST nodes with semantic Markdown output nodes
- Enabled the Vocs output Remark hook and retained an empty future allowlist
- Added transformer coverage for all components and invalid static props

## Key design considerations

- The transformation runs only during Markdown generation; React site components remain unchanged
- Unsupported or dynamic component data fails explicitly during output generation