### PR TITLE
Document mppx validate CLI command in the docs

### DIFF
--- a/src/components/QuickstartPrompt.tsx
+++ b/src/components/QuickstartPrompt.tsx
@@ -12,7 +12,7 @@ Make a request to https://mpp.dev/api/ping/paid to test.`;
 export const SERVER_PROMPT = `Reference https://mpp.dev/quickstart/server.md
 
 Add mppx to my server with a /api/test route that charges $0.01 per request using the Tempo payment method with USDC.e.
-Use the mppx CLI to test your endpoint.`;
+Run \`npx mppx validate <your-server>\` to validate the implementation as you develop.`;
 
 export function ClientPrompt() {
   return <PromptBlock>{CLIENT_PROMPT}</PromptBlock>;

--- a/src/pages/guides/multiple-payment-methods.mdx
+++ b/src/pages/guides/multiple-payment-methods.mdx
@@ -142,6 +142,9 @@ Bun.serve({
 The `mppx` CLI uses Tempo by default. Each payment method has its own client SDK—see the individual method docs for client setup.
 
 ```bash [terminal]
+# Validate the paid route
+$ npx mppx validate http://localhost:3000
+
 # Create account funded with testnet tokens
 $ npx mppx account create
 

--- a/src/pages/guides/proxy-existing-service.mdx
+++ b/src/pages/guides/proxy-existing-service.mdx
@@ -160,6 +160,9 @@ export default { fetch: proxy.fetch }
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
+# Validate the paid route
+$ npx mppx validate http://localhost:3000
+
 # Create account funded with testnet tokens
 $ npx mppx account create
 

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -336,6 +336,14 @@ Register your service on [MPPScan](https://mppscan.com) or the [MPP Services dir
 After your server is running, test it with the `mppx` CLI:
 
 ```bash [terminal]
+$ npx mppx validate <your-server>
+```
+
+The command tests discovery, challenge formats, error handling, and the full payment flow. We recommend addressing all noted issues to make it easy for agents to pay your server.
+
+You can also test each step individually:
+
+```bash [terminal]
 # Create an account funded with testnet tokens
 $ npx mppx account create
 

--- a/src/pages/sdk/typescript/cli.mdx
+++ b/src/pages/sdk/typescript/cli.mdx
@@ -53,6 +53,25 @@ $ mppx --help
 ```
 :::
 
+## Validate command
+
+Use `mppx validate` to automatically verify an MPP server implementation end-to-end. The command tests discovery, challenge formats, error handling, and the full payment flow.
+
+```bash [terminal]
+$ mppx validate https://api.example.com
+```
+
+To test a specific route that needs request data, pass a body or query parameters:
+
+```bash [terminal]
+$ mppx validate https://api.example.com --endpoint POST:/reports --body '{"format":"csv"}'
+$ mppx validate https://api.example.com --endpoint GET:/quotes --query symbol=ETH
+```
+
+:::note[End-to-end payments]
+Run `mppx validate` against both test and production versions of your server. On testnets and Stripe test mode, the CLI automatically completes roundtrip test payments. On mainnets, the CLI can complete real payments from the local `mppx` wallet.
+:::
+
 ## Environment variables
 
 | Variable | Description |


### PR DESCRIPTION
Add mppx validate to relevant sections of the docs. 

In evals (3 runs per mpp server task) this seems to have improved agent efficiency a little bit.

<img width="1041" height="815" alt="image" src="https://github.com/user-attachments/assets/76b0da04-2029-4976-8974-b005dfc1b948" />

[index.html](https://github.com/user-attachments/files/30349948/index.html)
