### PR TITLE
docs: sync mppx 0.8.14 references

### DIFF
--- a/.github/actions/sdk-drift-check/check-sdk-drift.test.ts
+++ b/.github/actions/sdk-drift-check/check-sdk-drift.test.ts
@@ -196,6 +196,20 @@ describe("parseLink", () => {
         member: "charge",
       });
     });
+
+    it("maps Mppx instance methods as docs-only", () => {
+      const result = parseLink(
+        "/sdk/typescript/server/Mppx.broadcastCredential",
+        prefix,
+      );
+      expect(result).toEqual<SidebarReference>({
+        link: "/sdk/typescript/server/Mppx.broadcastCredential",
+        area: "server",
+        namespace: "Mppx",
+        member: "broadcastCredential",
+        docsOnly: true,
+      });
+    });
   });
 
   describe("special entrypoints", () => {

--- a/.github/actions/sdk-drift-check/check-sdk-drift.ts
+++ b/.github/actions/sdk-drift-check/check-sdk-drift.ts
@@ -274,12 +274,19 @@ export function parseLink(
     };
   }
 
-  if (area === "server" && symbolPart === "Mppx.verifyCredential") {
+  if (
+    area === "server" &&
+    [
+      "Mppx.broadcastCredential",
+      "Mppx.validateCredential",
+      "Mppx.verifyCredential",
+    ].includes(symbolPart)
+  ) {
     return {
       link,
       area,
       namespace: "Mppx",
-      member: "verifyCredential",
+      member: symbolPart.slice("Mppx.".length),
       docsOnly: true,
     };
   }

--- a/.mppx-docs-sync
+++ b/.mppx-docs-sync
@@ -4,5 +4,5 @@
 # When updating docs from mppx changes, bump this SHA to HEAD of mppx main
 # after incorporating the new features/changes into the docs site.
 
-mppx_version=0.5.12
-mppx_sha=d670f4b81ef21edb7b0917f6a7a1802476015ced
+mppx_version=0.8.14
+mppx_sha=7a277bc68efdac57f43f56feaf1c1202bf574b5d

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,10 @@ When editing Python or Rust pages, keep the structure aligned with the existing 
 - Python: <https://github.com/tempoxyz/pympp>
 - Rust: <https://github.com/tempoxyz/mpp-rs>
 
+## MPPX documentation sync
+
+When updating MPPX interfaces, examples, reference pages, or the `mppx` dependency, review upstream `mppx/main` from the SHA in `.mppx-docs-sync`. After incorporating every relevant public change, update both `mppx_version` and `mppx_sha` in that bookmark to the reviewed upstream HEAD. Do not advance the bookmark before the docs are complete.
+
 ## Be Opinionated
 
 When multiple approaches exist, recommend one as the default. Don't present options equally—pick the best path for most users and lead with it.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cloudflare-worker-metrics": "^1.4.0",
     "hono": "^4.12.27",
     "mermaid": "^11.15.0",
-    "mppx": "^0.8.13",
+    "mppx": "^0.8.14",
     "react": "^19",
     "react-dom": "^19",
     "stripe": "^22.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       mppx:
-        specifier: ^0.8.13
-        version: 0.8.13(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
+        specifier: ^0.8.14
+        version: 0.8.14(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
       react:
         specifier: ^19
         version: 19.2.7
@@ -3930,8 +3930,8 @@ packages:
       hono:
         optional: true
 
-  mppx@0.8.13:
-    resolution: {integrity: sha512-8H01392Cn5tlwUG3wqxKe8qd/lxi2krAdw6MQzWWRMnhv/CDEJD3Ia1Qipy631NYQBWm3VE/pU6aQOYYjmcYbg==}
+  mppx@0.8.14:
+    resolution: {integrity: sha512-rXeq9HvU5oKtJ5K89WdO1s40uCsimGPxyaRnY44jxtctKL20Wd9WmQYRWIIab73ruMmM9KnvevN1BkDKGRI+7A==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
@@ -9408,7 +9408,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.8.13(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.8.14(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.9.0
       eventsource-parser: 3.1.0

--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -165,9 +165,11 @@ type Page =
   | { path: '/sdk/typescript/server/Method.tempo.renewSubscription'; render: 'static' }
   | { path: '/sdk/typescript/server/Method.tempo.session'; render: 'static' }
   | { path: '/sdk/typescript/server/Method.tempo.subscription'; render: 'static' }
+  | { path: '/sdk/typescript/server/Mppx.broadcastCredential'; render: 'static' }
   | { path: '/sdk/typescript/server/Mppx.compose'; render: 'static' }
   | { path: '/sdk/typescript/server/Mppx.create'; render: 'static' }
   | { path: '/sdk/typescript/server/Mppx.toNodeListener'; render: 'static' }
+  | { path: '/sdk/typescript/server/Mppx.validateCredential'; render: 'static' }
   | { path: '/sdk/typescript/server/Mppx.verifyCredential'; render: 'static' }
   | { path: '/sdk/typescript/server/Request.toNodeListener'; render: 'static' }
   | { path: '/sdk/typescript/server/Response.requirePayment'; render: 'static' }

--- a/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session-manager.mdx
@@ -641,6 +641,12 @@ The `reference` field contains the channel ID, not a transaction hash. To get th
 
 Account to sign channel transactions and vouchers with.
 
+### autoSwap (optional)
+
+- **Type:** `boolean | { slippage?: number; tokenIn?: Address[] }`
+
+Automatically acquire the session currency from fallback stablecoins before opening or topping up a channel. Use the object form to set a maximum slippage percentage and the fallback token order.
+
 ### bootstrap (optional)
 
 - **Type:** `boolean`
@@ -690,6 +696,12 @@ Function that returns a viem client for the given chain ID.
 - **Type:** `string`
 
 Maximum deposit in human-readable units. Converted to raw units via `decimals`.
+
+### topUpAmount (optional)
+
+- **Type:** `string`
+
+Preferred automatic top-up size in human-readable units. When omitted, `mppx` uses a bounded server `suggestedDeposit`, then the exact shortfall.
 
 ### webSocket (optional)
 

--- a/src/pages/sdk/typescript/client/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session.mdx
@@ -230,6 +230,12 @@ const method = tempo.session({
 </Tab>
 </Tabs>
 
+### autoSwap (optional)
+
+- **Type:** `boolean | { slippage?: number; tokenIn?: Address[] }`
+
+Automatically acquire the session currency from fallback stablecoins before opening or topping up a channel. Use the object form to set a maximum slippage percentage and the fallback token order.
+
 ### channelStore (optional)
 
 - **Type:** `ChannelStore`
@@ -260,6 +266,12 @@ Function that returns a viem client for the given chain ID.
 - **Type:** `string`
 
 Maximum deposit in human-readable units. Caps server-suggested channel opens and automatic top-ups.
+
+### topUpAmount (optional)
+
+- **Type:** `string`
+
+Preferred automatic top-up size in human-readable units. When omitted, `mppx` uses a bounded server `suggestedDeposit`, then the exact shortfall.
 
 ### onChannelUpdate (optional)
 

--- a/src/pages/sdk/typescript/core/Method.toServer.mdx
+++ b/src/pages/sdk/typescript/core/Method.toServer.mdx
@@ -1,6 +1,6 @@
-# `Method.toServer` [Extend a method with server verification]
+# `Method.toServer` [Extend a method with server payment handling]
 
-Extends a payment method with server-side verification logic.
+Extends a payment method with server-side validation and broadcast logic.
 
 ## Usage
 
@@ -14,13 +14,23 @@ import * as Methods from './methods' // [!code focus]
 // [!code focus:start]
 // Create server-configured method.
 const charge = Method.toServer(Methods.charge, {
-  async verify({ credential, request }) {
+  async broadcast({ credential, request }) {
     return Receipt.from({
       method: 'tempo',
       reference: '0x...',
       status: 'success',
       timestamp: new Date().toISOString(),
     })
+  },
+  async validate({ credential, request }) {
+    return {
+      challenge: credential.challenge,
+      credential,
+      details: {},
+      intent: 'charge',
+      method: 'tempo',
+      request,
+    }
   },
 })
 // [!code focus:end]
@@ -79,6 +89,12 @@ The base payment method definition (created with `Method.from`).
 
 ### options
 
+### broadcast
+
+- **Type:** `(parameters: { credential: Credential; request: request }) => Promise<Receipt>`
+
+Completes a validated payment and returns its Receipt.
+
 ### request (optional)
 
 - **Type:** `(options: { credential?: Credential; request: request }) => request`
@@ -89,7 +105,7 @@ Transform function called before Challenge creation. Use to modify or enrich req
 
 - **Type:** `(parameters: { credential: Credential; input: Request; receipt: Receipt; request: request }) => Response | undefined`
 
-Called after `verify` succeeds. Return a `Response` to short-circuit the handler (for example, for channel open/close management responses). Return `undefined` to let the server handler serve content via `withReceipt(response)`. HTTP-only—MCP transports do not invoke this hook.
+Called after payment succeeds. Return a `Response` to short-circuit the handler (for example, for channel open/close management responses). Return `undefined` to let the server handler serve content via `withReceipt(response)`. HTTP-only—MCP transports do not invoke this hook.
 
 ### transport (optional)
 
@@ -97,8 +113,14 @@ Called after `verify` succeeds. Return a `Response` to short-circuit the handler
 
 Override the transport for this method.
 
-### verify
+### validate (optional)
+
+- **Type:** `(parameters: { credential: Credential; request: request }) => Promise<Method.Validation>`
+
+Validates a Credential without settling, reserving, broadcasting, or otherwise consuming payment state.
+
+### verify (deprecated)
 
 - **Type:** `(parameters: { credential: Credential; request: request }) => Promise<Receipt>`
 
-Function that verifies a Credential and returns a Receipt.
+Legacy combined validation and settlement function. Use `validate` and `broadcast` for new methods.

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -94,6 +94,24 @@ const mppx = Mppx.create({
 })
 ```
 
+### With Tempo API relay
+
+Delegate Tempo charge validation and broadcast to Tempo API. The relay preserves this method's Challenge configuration and needs an API key with the `mpp:write` scope.
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.charge({
+      relay: {
+        apiKey: process.env.TEMPO_API_KEY!,
+      },
+    }),
+  ],
+})
+```
+
 ### With replay protection for zero-dollar auth
 
 Pass `store` when you want zero-dollar proof Credentials to be single-use.
@@ -161,13 +179,13 @@ This setting only applies to non-zero charges. Zero-amount proof flows do not cr
 
 ### feePayerPolicy (optional)
 
-- **Type:** `Partial<{ maxFeePerGas: bigint; maxGas: bigint; maxPriorityFeePerGas: bigint; maxTotalFee: bigint; maxValidityWindowSeconds: number }>`
+- **Type:** `Partial<{ maxFeePerGas: bigint; maxGas: bigint; maxInFlightReservations: number; maxInFlightTotalFee: bigint; maxPriorityFeePerGas: bigint; maxTotalFee: bigint; maxValidityWindowSeconds: number }>`
 
 Override the local fee-sponsor policy used when the server co-signs Tempo charge transactions. Remote fee payer services enforce their own policy.
 
-`mppx` resolves defaults per chain automatically. On mainnet (`4217`), the defaults are `maxFeePerGas: 100_000_000_000n`, `maxGas: 2_000_000n`, `maxPriorityFeePerGas: 10_000_000_000n`, `maxTotalFee: 50_000_000_000_000_000n`, and `maxValidityWindowSeconds: 900`. On Moderato (`42431`), `maxPriorityFeePerGas` increases to `50_000_000_000n` and the other limits stay the same.
+`mppx` resolves defaults per chain automatically. On mainnet (`4217`), the defaults are `maxFeePerGas: 100_000_000_000n`, `maxGas: 2_000_000n`, `maxPriorityFeePerGas: 10_000_000_000n`, `maxTotalFee: 50_000_000_000_000_000n`, and `maxValidityWindowSeconds: 900`. `maxInFlightReservations` defaults to `100`; `maxInFlightTotalFee` defaults to ten times `maxTotalFee`. On Moderato (`42431`), `maxPriorityFeePerGas` increases to `50_000_000_000n` and the other limits stay the same.
 
-If you raise `maxFeePerGas` or `maxGas`, you may also need to raise `maxTotalFee` so the combined fee budget stays within policy.
+If you raise `maxFeePerGas`, `maxGas`, or `maxTotalFee`, you may also need to raise `maxInFlightTotalFee` so concurrent sponsored transactions stay within policy.
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'
@@ -199,6 +217,12 @@ Function that returns a viem client for the given chain ID. Overrides the defaul
 - **Type:** `string`
 
 On-chain memo for the transaction.
+
+### relay (optional)
+
+- **Type:** `{ apiBaseUrl?: string; apiKey: string; fetch?: typeof globalThis.fetch }`
+
+Delegates Tempo charge Credential validation and broadcast to Tempo API or a compatible MPP relay. `apiKey` needs the `mpp:write` scope. Defaults to `https://api.tempo.xyz`; set `apiBaseUrl` for a compatible relay.
 
 ### store (optional)
 

--- a/src/pages/sdk/typescript/server/Mppx.broadcastCredential.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.broadcastCredential.mdx
@@ -1,0 +1,74 @@
+---
+description: "Accept an MPP Credential from a custom transport or background workflow."
+imageDescription: "Complete payments outside HTTP handlers"
+---
+
+# `mppx.broadcastCredential` [Complete a Credential payment]
+
+Validates a Credential again and completes its payment on an `Mppx.create` instance.
+
+## Usage
+
+Use `broadcastCredential` when a custom transport or background workflow accepts payment. It can settle payment or persist payment state.
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({ methods: [tempo.charge()] })
+
+const receipt = await mppx.broadcastCredential('Payment credential="..."', {
+  request: {
+    amount: '0.10',
+    currency: '0x20c0000000000000000000000000000000000000',
+    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  },
+  scope: 'GET /v1/report',
+})
+
+console.log(receipt.status)
+// @log: success
+```
+
+## Return type
+
+```ts
+type ReturnType = Promise<Receipt>
+```
+
+## Parameters
+
+### capturedRequest (optional)
+
+- **Type:** `Method.CapturedRequest`
+
+Authoritative request snapshot used by method hooks.
+
+### credential
+
+- **Type:** `string | Credential`
+
+Serialized `Authorization` header value or parsed Credential object.
+
+### meta (optional)
+
+- **Type:** `Record<string, string>`
+
+Expected Challenge metadata.
+
+### realm (optional)
+
+- **Type:** `string`
+
+Expected Challenge realm.
+
+### request (optional)
+
+- **Type:** `Record<string, unknown>`
+
+Expected method request parameters.
+
+### scope (optional)
+
+- **Type:** `string`
+
+Expected route or resource scope bound to the Challenge.

--- a/src/pages/sdk/typescript/server/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.create.mdx
@@ -58,7 +58,24 @@ import type { Mppx, Transport } from 'mppx/server'
 type ReturnType = Mppx<[Method.Server], Transport.Http>
 ```
 
-The returned object includes the method's intent functions (for example, `charge`), `challenge`, `compose`, payment hooks, and `verifyCredential`.
+The returned object includes the method's intent functions (for example, `charge`), `broadcastCredential`, `challenge`, `compose`, payment hooks, `validateCredential`, and `verifyCredential`.
+
+### Validate and broadcast Credentials
+
+Use `validateCredential` to pre-check a Credential without consuming payment state. Use `broadcastCredential` to validate again and complete the payment. `verifyCredential` remains as a deprecated alias for the mutating broadcast operation.
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({ methods: [tempo.charge()] })
+
+const validation = await mppx.validateCredential('Payment credential="..."')
+console.log(validation.source)
+
+const receipt = await mppx.broadcastCredential('Payment credential="..."')
+console.log(receipt.status)
+// @log: success
+```
 
 ## Parameters
 

--- a/src/pages/sdk/typescript/server/Mppx.validateCredential.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.validateCredential.mdx
@@ -1,0 +1,75 @@
+---
+description: "Pre-check an MPP Credential without consuming payment state."
+imageDescription: "Validate payments before you accept them"
+---
+
+# `mppx.validateCredential` [Pre-check a Credential]
+
+Validates a Credential without settling, reserving, or broadcasting payment.
+
+## Usage
+
+Use `validateCredential` before a later `broadcastCredential` call when your application needs a non-mutating payment check.
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({ methods: [tempo.charge()] })
+
+const validation = await mppx.validateCredential('Payment credential="..."', {
+  request: {
+    amount: '0.10',
+    currency: '0x20c0000000000000000000000000000000000000',
+    recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  },
+  scope: 'GET /v1/report',
+})
+
+console.log(validation.source)
+```
+
+`validateCredential` is an advisory pre-check. Call `broadcastCredential` to accept payment.
+
+## Return type
+
+```ts
+type ReturnType = Promise<Method.Validation>
+```
+
+## Parameters
+
+### capturedRequest (optional)
+
+- **Type:** `Method.CapturedRequest`
+
+Authoritative request snapshot used by method hooks.
+
+### credential
+
+- **Type:** `string | Credential`
+
+Serialized `Authorization` header value or parsed Credential object.
+
+### meta (optional)
+
+- **Type:** `Record<string, string>`
+
+Expected Challenge metadata.
+
+### realm (optional)
+
+- **Type:** `string`
+
+Expected Challenge realm.
+
+### request (optional)
+
+- **Type:** `Record<string, unknown>`
+
+Expected method request parameters.
+
+### scope (optional)
+
+- **Type:** `string`
+
+Expected route or resource scope bound to the Challenge.

--- a/src/pages/sdk/typescript/server/Mppx.verifyCredential.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.verifyCredential.mdx
@@ -3,13 +3,13 @@ description: "Verify MPP Credentials directly in custom transports and backgroun
 imageDescription: "Verify Credentials outside HTTP handlers"
 ---
 
-# `mppx.verifyCredential` [Verify a Credential directly]
+# `mppx.verifyCredential` [Legacy Credential verification]
 
-Verifies a serialized or parsed Credential on an `Mppx.create` instance.
+Verifies and completes a serialized or parsed Credential on an `Mppx.create` instance.
 
 ## Usage
 
-Use `verifyCredential` when you receive a Credential through a custom transport or job boundary and need the same method verification as an `mppx` route.
+Use [`broadcastCredential`](/sdk/typescript/server/Mppx.broadcastCredential) for new integrations. `verifyCredential` remains as a deprecated alias that validates and completes payment in one call.
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'

--- a/src/pages/sdk/typescript/server/Response.requirePayment.mdx
+++ b/src/pages/sdk/typescript/server/Response.requirePayment.mdx
@@ -45,3 +45,5 @@ The Challenge to serialize into the `WWW-Authenticate` header.
 - **Type:** `PaymentError`
 
 An error to include as RFC 9457 Problem Details in the response body.
+
+Problem details can include a method-specific `details` object and an actionable `hint`. Treat `details` as safe-to-expose diagnostic data only.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -666,6 +666,10 @@ export default defineConfig({
                     collapsed: true,
                     items: [
                       {
+                        text: ".broadcastCredential",
+                        link: "/sdk/typescript/server/Mppx.broadcastCredential",
+                      },
+                      {
                         text: ".compose",
                         link: "/sdk/typescript/server/Mppx.compose",
                       },
@@ -676,6 +680,10 @@ export default defineConfig({
                       {
                         text: ".toNodeListener",
                         link: "/sdk/typescript/server/Mppx.toNodeListener",
+                      },
+                      {
+                        text: ".validateCredential",
+                        link: "/sdk/typescript/server/Mppx.validateCredential",
                       },
                       {
                         text: ".verifyCredential",


### PR DESCRIPTION
## Motivation

Keep the MPP TypeScript documentation aligned with the current MPPX public API and make future syncs traceable.

## Summary

- Upgrade MPPX to `0.8.14` and advance the documentation sync bookmark
- Document Credential validation and broadcast APIs, Tempo relay configuration, and session funding controls
- Add a sync-bookmark requirement and drift-check coverage for Mppx instance methods

## Key design considerations

- Treat instance methods as documentation-only references because they are created by `Mppx.create`, not exported by the module
- Keep `verifyCredential` documented as the deprecated mutating alias
