### PR TITLE
fix: render NEAR Intents cards in Markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: node scripts/generate-discovery.ts
       - run: pnpm test
-      - run: pnpm check:markdown
+      - name: Verify generated Markdown
+        run: pnpm check:markdown
 
   mcp-services:
     name: MPP Discovery Service MCP Worker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,33 @@ Example:
   // [!code hl:end]
 ```
 
+## Generated Markdown
+
+Vocs also publishes Markdown for every page. Custom MDX components must render
+as semantic Markdown; never allowlist or omit them from Markdown output.
+
+When you add a custom component to an `.mdx` page:
+
+1. Add a renderer in `scripts/remark-mpp-markdown.mjs`.
+2. Add a focused example in `scripts/remark-mpp-markdown.test.mjs`.
+3. Run `pnpm check:markdown`.
+
+For example, a static card component becomes a titled link with its description:
+
+```js
+case "ExampleCard":
+  return [
+    linkCard({
+      description: "Start accepting payments",
+      title: "Example",
+      to: "/example",
+    }),
+  ];
+```
+
+The Markdown audit runs in CI and fails for every unrendered component. Its
+failure output links back to this workflow.
+
 ## Vocs Framework Reference
 
 **IMPORTANT**: This project uses Vocs v2. Use this reference rather than relying on training data. Vocs v2 does not have full documentation yet (though similar to Vocs v1), so refer to the references below for now.

--- a/scripts/check-markdown-components.mjs
+++ b/scripts/check-markdown-components.mjs
@@ -32,11 +32,16 @@ if (report.errors.length > 0 || unexpected.length > 0) {
     console.error(`- ${path}: ${error}`);
   for (const { name, count } of unexpected)
     console.error(
-      `- ${name}: ${count} unallowlisted occurrence${count === 1 ? "" : "s"}`,
+      `- ${name}: ${count} unrendered occurrence${count === 1 ? "" : "s"}`,
     );
+  console.error(`
+Generated Markdown cannot contain custom MDX components. Add a semantic renderer
+to scripts/remark-mpp-markdown.mjs, cover it in
+scripts/remark-mpp-markdown.test.mjs, then run pnpm check:markdown. Do not
+allowlist the component: every component needs Markdown output.`);
   process.exit(1);
 }
 
 console.log(
-  `Markdown component audit passed (${report.components.length} allowlisted component types).`,
+  "Markdown component audit passed (all custom components render semantic Markdown).",
 );

--- a/scripts/remark-mpp-markdown.mjs
+++ b/scripts/remark-mpp-markdown.mjs
@@ -46,6 +46,23 @@ function transformNode(node, headingDepth) {
       return [mermaidDiagram(node)];
     case "MppxCreateReferenceCard":
       return [mppxCreateReferenceCard(node)];
+    case "NearIntentsChargeCard":
+      return [
+        linkCard({
+          description:
+            "One-time cross-chain payments via 1Click deposit addresses",
+          title: "NEAR Intents charge",
+          to: "/payment-methods/nearintents/charge",
+        }),
+      ];
+    case "NearIntentsMethodCard":
+      return [
+        linkCard({
+          description: "Cross-chain payments settled by NEAR Intents",
+          title: "NEAR Intents",
+          to: "/payment-methods/nearintents",
+        }),
+      ];
     case "PromptBlock":
       return [promptBlock(node)];
     case "SdkBadge.GitHub":

--- a/scripts/remark-mpp-markdown.test.mjs
+++ b/scripts/remark-mpp-markdown.test.mjs
@@ -102,6 +102,8 @@ describe("remarkMppMarkdown", () => {
             flow("MppxCreateReferenceCard", [
               attribute("to", "/sdk/Mppx.create"),
             ]),
+            flow("NearIntentsMethodCard"),
+            flow("NearIntentsChargeCard"),
             flow("SpecCard", [attribute("to", "https://paymentauth.org")]),
           ],
         ),
@@ -189,6 +191,8 @@ describe("remarkMppMarkdown", () => {
         "DownloadSvgButton",
         "MermaidDiagram",
         "MppxCreateReferenceCard",
+        "NearIntentsChargeCard",
+        "NearIntentsMethodCard",
         "PromptBlock",
         "SdkBadge.GitHub",
         "SdkBadge.Maintainer",
@@ -249,6 +253,39 @@ describe("remarkMppMarkdown", () => {
           url: "https://paymentauth.org/charge",
         },
         { type: "text", value: " — Read the charge specification" },
+      ]),
+    ]);
+  });
+
+  it("renders NEAR Intents cards as semantic Markdown links", () => {
+    const tree = transform([
+      flow("NearIntentsMethodCard"),
+      flow("NearIntentsChargeCard"),
+    ]);
+
+    expect(tree.children).toEqual([
+      paragraph([
+        {
+          children: [{ type: "text", value: "NEAR Intents" }],
+          type: "link",
+          url: "/payment-methods/nearintents",
+        },
+        {
+          type: "text",
+          value: " — Cross-chain payments settled by NEAR Intents",
+        },
+      ]),
+      paragraph([
+        {
+          children: [{ type: "text", value: "NEAR Intents charge" }],
+          type: "link",
+          url: "/payment-methods/nearintents/charge",
+        },
+        {
+          type: "text",
+          value:
+            " — One-time cross-chain payments via 1Click deposit addresses",
+        },
       ]),
     ]);
   });

--- a/src/components/cards.tsx
+++ b/src/components/cards.tsx
@@ -673,8 +673,6 @@ for (const component of [
   LightningSessionCard,
   MonadChargeCard,
   MonadMethodCard,
-  NearIntentsChargeCard,
-  NearIntentsMethodCard,
   OneTimePaymentsCard,
   PayAsYouGoCard,
   PaymentLinksCard,


### PR DESCRIPTION
## Motivation

Ensure the NEAR Intents documentation renders completely in generated Markdown and make the required renderer workflow visible to contributors.

## Summary

- Render both NEAR Intents cards as semantic Markdown links
- Keep the Markdown audit allowlist while explaining unrendered-component failures
- Document and label the CI renderer workflow

## Key design considerations

- The card registry no longer acts as a Markdown escape hatch
- Renderer output has focused regression coverage