### PR TITLE
Add DisputeTracker to the service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -122,6 +122,68 @@ export interface ServiceDef {
 
 // prettier-ignore
 export const services: ServiceDef[] = [
+  // ── DisputeTracker ────────────────────────────────────────────────────
+  {
+    id: "disputetracker",
+    name: "DisputeTracker",
+    url: "https://disputetracker.xyz",
+    serviceUrl: "https://mpp.disputetracker.xyz",
+    description:
+      "Machine-readable Polymarket and UMA dispute intelligence with stage assessment, market metrics, evidence readiness, and resolution-risk analysis.",
+    icon: "https://disputetracker.xyz/icon.png",
+    categories: ["blockchain", "data"],
+    integration: "first-party",
+    tags: [
+      "dispute-intelligence",
+      "oracle",
+      "polymarket",
+      "prediction-markets",
+      "uma",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://disputetracker.xyz/docs",
+      llmsTxt: "https://disputetracker.xyz/llms.txt",
+      apiReference: "https://mpp.disputetracker.xyz/openapi.json",
+    },
+    provider: { name: "DisputeTracker", url: "https://disputetracker.xyz" },
+    realm: "mpp.disputetracker.xyz",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /api/agent/dispute-brief/mpp",
+        desc: "Build a compact dispute brief for a live Polymarket market",
+        amount: "1000",
+        unitType: "request",
+      },
+      {
+        route: "POST /api/agent/evidence-readiness/mpp",
+        desc: "Assess whether dispute evidence is ready for review",
+        amount: "5000",
+        unitType: "request",
+      },
+      {
+        route: "POST /api/agent/market-metrics/mpp",
+        desc: "Return liquidity, pricing, and dispute activity metrics",
+        amount: "3000",
+        unitType: "request",
+      },
+      {
+        route: "POST /api/agent/resolution-risk/mpp",
+        desc: "Analyze resolution risk from market and oracle signals",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "POST /api/agent/stage-assessment/mpp",
+        desc: "Classify the current Polymarket and UMA dispute stage",
+        amount: "2000",
+        unitType: "request",
+      },
+    ],
+  },
+
   // ── Apex DB ───────────────────────────────────────────────────────────
   {
     id: "apex-db",


### PR DESCRIPTION
## Summary

Add DisputeTracker to the curated MPP service directory.

DisputeTracker provides machine-readable Polymarket and UMA dispute intelligence through five live MPP endpoints:

- dispute brief
- stage assessment
- market metrics
- evidence readiness
- resolution risk

The service accepts Tempo mainnet USDC.e payments with the `charge` intent.

## Production readiness

- Service: https://mpp.disputetracker.xyz
- OpenAPI: https://mpp.disputetracker.xyz/openapi.json
- Documentation: https://disputetracker.xyz/docs
- Agent instructions: https://disputetracker.xyz/llms.txt
- MPPScan: https://mppscan.com/server/1c8a197cd02bcceb9df19dc88e3411f6dda6381341665ee2e146f9ede2733d05
- MPPScan discovery registered all 10 resources (5 MPP and 5 x402).
- `mppx validate https://mpp.disputetracker.xyz` reports 63 passed challenge and error-handling checks across all five MPP endpoints.
- Ten successful Tempo mainnet MPP settlements were completed across the five listed endpoints (two per endpoint). Representative settlement reference: `0xa3eff1e846f3af681ff58427966b413e2380a98ed420c5f8aacb7e52314d23fd`.

## Validation

- `pnpm generate:discovery`
- `pnpm check:types`
- `pnpm check`
- `pnpm build` on Linux with Node 24

This PR changes only `schemas/services.ts`.
