### PR TITLE
feat: add MPPX integration carousel

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -74,7 +74,11 @@ const PAYMENT_METHOD_SNIPPETS = [
   {
     code: `const mppx = Mppx.create({ methods: [tempo.charge()] })
 
-app.get('/premium', mppx.charge({ amount: '1' }), (c) => c.text('Paid'))`,
+app.get(
+  '/premium',
+  mppx.charge({ amount: '1' }),
+  (c) => c.text('Paid'),
+)`,
     imports: `import { Mppx, tempo } from 'mppx/hono'`,
     method: "Tempo",
   },
@@ -87,7 +91,11 @@ app.get('/premium', mppx.charge({ amount: '1' }), (c) => c.text('Paid'))`,
   })],
 })
 
-app.get('/premium', mppx.charge({ amount: '1' }), (c) => c.text('Paid'))`,
+app.get(
+  '/premium',
+  mppx.charge({ amount: '1' }),
+  (c) => c.text('Paid'),
+)`,
     imports: `import { Mppx, stripe } from 'mppx/hono'`,
     method: "Stripe",
   },
@@ -96,26 +104,14 @@ app.get('/premium', mppx.charge({ amount: '1' }), (c) => c.text('Paid'))`,
   methods: [spark.charge({ mnemonic: process.env.MNEMONIC! })],
 })
 
-app.get('/premium', mppx.charge({ amount: '1' }), (c) => c.text('Paid'))`,
+app.get(
+  '/premium',
+  mppx.charge({ amount: '1' }),
+  (c) => c.text('Paid'),
+)`,
     imports: `import { Mppx } from 'mppx/hono'
 import { spark } from '@buildonspark/lightning-mpp-sdk/server'`,
     method: "Bitcoin",
-  },
-  {
-    code: `const mppx = Mppx.create({
-  methods: [
-    tempo.charge(),
-    stripe.charge({
-      networkId: 'internal',
-      paymentMethodTypes: ['card'],
-      secretKey: process.env.STRIPE_SECRET_KEY!,
-    }),
-  ],
-})
-
-app.get('/premium', mppx.charge({ amount: '1' }), (c) => c.text('Paid'))`,
-    imports: `import { Mppx, stripe, tempo } from 'mppx/hono'`,
-    method: "Multi-method",
   },
 ];
 

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -489,7 +489,6 @@ ${activeSnippet.code}${activeSnippet.route ? `\n\n${activeSnippet.route}` : ""}`
       <div className="marketing-single-line-intro">
         <SectionLabel>Integrate</SectionLabel>
         <h2>Sell to agents with just a single line of code</h2>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
       </div>
       <div className="marketing-code-carousel">
         <div className="marketing-code-carousel-header">
@@ -723,7 +722,6 @@ function LandingStyles() {
       .marketing-single-line { border-top: 1px solid var(--marketing-border); display: grid; gap: 2.5rem; margin-inline: auto; max-width: 1728px; padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 4vw, 3rem); }
       .marketing-single-line h2 { margin: 0 !important; }
       .marketing-single-line-intro { padding: clamp(1rem, 3vw, 2rem); }
-      .marketing-single-line-intro > p { color: var(--marketing-muted); font-size: 1.125rem; line-height: 1.3; margin: 1.5rem 0 0; max-width: 25rem; }
       .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); display: flex; flex-direction: column; height: 28rem; min-width: 0; }
       .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-copy); display: flex; flex: none; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: flex-start; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }
       .marketing-code-carousel-content { background: #101010; display: flex; flex: 1; min-height: 0; overflow: auto; padding: clamp(1rem, 3vw, 2rem); }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -72,59 +72,84 @@ const INTEGRATIONS = [
 
 const PAYMENT_METHOD_SNIPPETS = [
   {
-    code: `const payment = Mppx.create({
-  methods: [
-    tempo.charge(),
-  ],
-})`,
+    code: `const app = new Hono()
+const mppx = Mppx.create({ methods: [tempo.charge()] })
+
+app.get(
+  '/premium',
+  mppx.charge({ amount: '1' }),
+  (c) => c.json({ data: 'paid content' }),
+)`,
     comment: "Accept USDC.e payments on Tempo.",
-    imports: 'import { Mppx, tempo } from "mppx/server"',
+    imports: `import { Hono } from 'hono'
+import { Mppx, tempo } from 'mppx/hono'`,
     method: "Tempo",
   },
   {
-    code: `const payment = Mppx.create({
+    code: `const app = new Hono()
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
+const mppx = Mppx.create({
   methods: [
     stripe.charge({
       client: stripeClient,
-      networkId: "internal",
-      paymentMethodTypes: ["card"],
+      networkId: 'internal',
+      paymentMethodTypes: ['card'],
     }),
   ],
 })`,
+    route: `app.get(
+  '/premium',
+  mppx.charge({ amount: '1' }),
+  (c) => c.json({ data: 'paid content' }),
+)`,
     comment: "Accept card payments with Stripe.",
-    imports: `import Stripe from "stripe"
-import { Mppx, stripe } from "mppx/server"
-const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)`,
+    imports: `import { Hono } from 'hono'
+import Stripe from 'stripe'
+import { Mppx, stripe } from 'mppx/hono'`,
     method: "Stripe",
   },
   {
-    code: `const payment = Mppx.create({
+    code: `const app = new Hono()
+const mppx = Mppx.create({
   methods: [
     spark.charge({ mnemonic: process.env.MNEMONIC! }),
   ],
 })`,
+    route: `app.get(
+  '/premium',
+  mppx.charge({ amount: '1' }),
+  (c) => c.json({ data: 'paid content' }),
+)`,
     comment: "Accept Bitcoin payments over Lightning.",
-    imports:
-      'import { Mppx, spark } from "@buildonspark/lightning-mpp-sdk/server"',
+    imports: `import { Hono } from 'hono'
+import { Mppx } from 'mppx/hono'
+import { spark } from '@buildonspark/lightning-mpp-sdk/server'`,
     method: "Bitcoin",
   },
   {
-    code: `const payment = Mppx.create({
+    code: `const app = new Hono()
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
+const mppx = Mppx.create({
   methods: [
     tempo.charge(),
     stripe.charge({
       client: stripeClient,
-      networkId: "internal",
-      paymentMethodTypes: ["card"],
+      networkId: 'internal',
+      paymentMethodTypes: ['card'],
     }),
     spark.charge({ mnemonic: process.env.MNEMONIC! }),
   ],
 })`,
+    route: `app.get(
+  '/premium',
+  mppx.charge({ amount: '1' }),
+  (c) => c.json({ data: 'paid content' }),
+)`,
     comment: "Offer Tempo, Stripe, and Bitcoin in one integration.",
-    imports: `import Stripe from "stripe"
-import { Mppx, tempo, stripe } from "mppx/server"
-import { spark } from "@buildonspark/lightning-mpp-sdk/server"
-const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)`,
+    imports: `import { Hono } from 'hono'
+import Stripe from 'stripe'
+import { Mppx, tempo, stripe } from 'mppx/hono'
+import { spark } from '@buildonspark/lightning-mpp-sdk/server'`,
     method: "Multi-method",
   },
 ];
@@ -440,7 +465,8 @@ function IntegrationCodeCarousel() {
   const activeSnippet = PAYMENT_METHOD_SNIPPETS[activeIndex];
   const source = `// ${activeSnippet.comment}
 ${activeSnippet.imports}
-${activeSnippet.code}`;
+
+${activeSnippet.code}${activeSnippet.route ? `\n\n${activeSnippet.route}` : ""}`;
 
   useEffect(() => {
     let cancelled = false;

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -483,6 +483,10 @@ ${activeSnippet.code}`;
       <div className="marketing-single-line-intro">
         <SectionLabel>Integrate</SectionLabel>
         <h2>Sell to agents with just a single line of code</h2>
+        <p className="marketing-single-line-copy">
+          Accept payments in both fiat and stablecoins, even in amounts less
+          than $0.01
+        </p>
       </div>
       <div className="marketing-code-carousel">
         <div className="marketing-code-carousel-header">
@@ -723,6 +727,7 @@ function LandingStyles() {
       .marketing-single-line { border-top: 1px solid var(--marketing-border); display: grid; gap: 2.5rem; margin-inline: auto; max-width: 1728px; padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 4vw, 3rem); }
       .marketing-single-line h2 { margin: 0 !important; }
       .marketing-single-line-intro { padding: clamp(1rem, 3vw, 2rem); }
+      .marketing-single-line-copy { color: var(--marketing-muted); font-size: 1.125rem; line-height: 1.4; margin: 1.5rem 0 0; max-width: 28rem; }
       .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); display: flex; flex-direction: column; height: 28rem; min-width: 0; }
       .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-copy); display: flex; flex: none; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: flex-start; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }
       .marketing-code-carousel-content { background: #101010; display: flex; flex: 1; min-height: 0; overflow: auto; padding: clamp(1rem, 3vw, 2rem); }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -137,7 +137,6 @@ const mppx = Mppx.create({
       networkId: 'internal',
       paymentMethodTypes: ['card'],
     }),
-    spark.charge({ mnemonic: process.env.MNEMONIC! }),
   ],
 })`,
     route: `app.get(
@@ -145,11 +144,10 @@ const mppx = Mppx.create({
   mppx.charge({ amount: '1' }),
   (c) => c.json({ data: 'paid content' }),
 )`,
-    comment: "Offer Tempo, Stripe, and Bitcoin in one integration.",
+    comment: "Offer Tempo and Stripe in one integration.",
     imports: `import { Hono } from 'hono'
 import Stripe from 'stripe'
-import { Mppx, tempo, stripe } from 'mppx/hono'
-import { spark } from '@buildonspark/lightning-mpp-sdk/server'`,
+import { Mppx, tempo, stripe } from 'mppx/hono'`,
     method: "Multi-method",
   },
 ];
@@ -814,7 +812,7 @@ function LandingStyles() {
         .marketing-terminal-shell { height: 17.25rem; min-height: 0; }
         .marketing-integration-grid { grid-template-columns: repeat(7, minmax(0, 1fr)); }
         .marketing-single-line { align-items: start; gap: clamp(4rem, 10vw, 12rem); grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr); }
-        .marketing-code-carousel { max-width: 35rem; }
+        .marketing-code-carousel { max-width: 40rem; }
       }
       @media (min-width: 1280px) {
         .marketing-blog { gap: 0; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -112,6 +112,19 @@ const PAYMENT_METHOD_SNIPPETS = [
   },
 ];
 
+const TYPESCRIPT_HIGHLIGHTER = Promise.all([
+  import("shiki/core"),
+  import("shiki/engine/javascript"),
+  import("shiki/dist/langs/typescript.mjs"),
+  import("shiki/dist/themes/github-dark-default.mjs"),
+]).then(async ([core, engine, language, theme]) =>
+  core.createHighlighterCore({
+    engine: engine.createJavaScriptRegexEngine(),
+    langs: [language.default],
+    themes: [theme.default],
+  }),
+);
+
 const TERMINAL_STEPS = [
   Terminal.commands(["./mpp.sh"]),
   Terminal.wizard([
@@ -393,6 +406,7 @@ function SectionLabel({ children }: { children: ReactNode }) {
 
 function IntegrationCodeCarousel() {
   const [activeIndex, setActiveIndex] = useState(0);
+  const [highlightedCode, setHighlightedCode] = useState("");
   const prefersReducedMotion = useMediaQuery(
     "(prefers-reduced-motion: reduce)",
   );
@@ -407,39 +421,52 @@ function IntegrationCodeCarousel() {
   }, [prefersReducedMotion]);
 
   const activeSnippet = PAYMENT_METHOD_SNIPPETS[activeIndex];
+  const source = `// ${activeSnippet.comment}
+import { Mppx, ${activeSnippet.imports} } from "mppx/server"
+
+${activeSnippet.code}`;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    TYPESCRIPT_HIGHLIGHTER.then((highlighter) =>
+      highlighter.codeToHtml(source, {
+        lang: "ts",
+        theme: "github-dark-default",
+      }),
+    ).then((html) => {
+      if (!cancelled) setHighlightedCode(html);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source]);
 
   return (
     <section className="marketing-single-line">
       <div className="marketing-single-line-intro">
-        <SectionLabel>MPPX</SectionLabel>
-        <h2>Integrate in a single line.</h2>
-        <p>
-          Add the payment methods your API accepts with a single MPPX setup.
-        </p>
+        <SectionLabel>Integrate</SectionLabel>
+        <h2>Sell to agents with just a single line of code</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
       </div>
       <div className="marketing-code-carousel">
         <div className="marketing-code-carousel-header">
-          <span>TypeScript</span>
           <span>{activeSnippet.method}</span>
         </div>
         <div className="marketing-code-carousel-content">
           <div className="marketing-code-snippet" key={activeSnippet.method}>
-            <code>
-              <span className="marketing-code-comment">
-                {`// ${activeSnippet.comment}`}
-              </span>
-              {"\n"}
-              <span className="marketing-code-keyword">import</span>
-              {" { Mppx, "}
-              <span className="marketing-code-method">
-                {activeSnippet.imports}
-              </span>
-              {" } "}
-              <span className="marketing-code-keyword">from</span>
-              {' "mppx/server"'}
-              {"\n\n"}
-              {activeSnippet.code}
-            </code>
+            {highlightedCode ? (
+              <div
+                className="marketing-code-shiki"
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: renders static MPPX snippets highlighted by Shiki
+                dangerouslySetInnerHTML={{ __html: highlightedCode }}
+              />
+            ) : (
+              <pre className="marketing-code-fallback">
+                <code>{source}</code>
+              </pre>
+            )}
           </div>
         </div>
         <div aria-hidden="true" className="marketing-code-carousel-dots">
@@ -656,14 +683,13 @@ function LandingStyles() {
       .marketing-single-line h2 { margin: 0 !important; }
       .marketing-single-line-intro > p { color: var(--marketing-muted); font-size: 1.125rem; line-height: 1.3; margin: 1.5rem 0 0; max-width: 25rem; }
       .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); min-width: 0; }
-      .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-muted); display: flex; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: space-between; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }
-      .marketing-code-carousel-header span:last-child { color: var(--marketing-copy); }
+      .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-copy); display: flex; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: flex-start; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }
       .marketing-code-carousel-content { min-height: 18rem; overflow: hidden; padding: clamp(1rem, 3vw, 2rem); }
       .marketing-code-snippet { animation: marketing-code-fade 520ms ease both; min-height: 14rem; }
-      .marketing-code-snippet code { color: #dedede; display: block; font-family: var(--font-mono, monospace); font-size: clamp(0.75rem, 1.4vw, 0.9375rem); line-height: 1.5; overflow-x: auto; padding-bottom: 0.25rem; white-space: pre; }
-      .marketing-code-comment { color: var(--marketing-muted); }
-      .marketing-code-keyword { color: #d9a6ff; }
-      .marketing-code-method { color: #98f3aa; }
+      .marketing-code-fallback,
+      .marketing-code-shiki .shiki { background: transparent !important; color: #dedede !important; font-family: var(--font-mono, monospace) !important; font-size: clamp(0.75rem, 1.4vw, 0.9375rem) !important; line-height: 1.5 !important; margin: 0 !important; overflow-x: auto; padding: 0 0 0.25rem !important; white-space: pre; }
+      .marketing-code-fallback code,
+      .marketing-code-shiki .shiki code { font-family: inherit !important; }
       .marketing-code-carousel-dots { border-top: 1px solid var(--marketing-border); display: flex; gap: 0.375rem; padding: 0.875rem 1rem; }
       .marketing-code-carousel-dots span { background: var(--marketing-border); display: block; height: 2px; transition: background-color 300ms ease, width 300ms ease; width: 1.25rem; }
       .marketing-code-carousel-dots .is-active { background: var(--marketing-copy); width: 3rem; }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -428,6 +428,7 @@ ${activeSnippet.code}`;
 
   useEffect(() => {
     let cancelled = false;
+    setHighlightedCode("");
 
     TYPESCRIPT_HIGHLIGHTER.then((highlighter) =>
       highlighter.codeToHtml(source, {

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -484,8 +484,8 @@ ${activeSnippet.code}`;
         <SectionLabel>Integrate</SectionLabel>
         <h2>Sell to agents with just a single line of code</h2>
         <p className="marketing-single-line-copy">
-          Accept payments in both fiat and stablecoins, even in amounts less
-          than $0.01
+          Accept fiat and stablecoin payments, including transactions under
+          $0.01.
         </p>
       </div>
       <div className="marketing-code-carousel">

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -113,18 +113,29 @@ import { spark } from '@buildonspark/lightning-mpp-sdk/server'`,
   },
 ];
 
-const TYPESCRIPT_HIGHLIGHTER = Promise.all([
-  import("shiki/core"),
-  import("shiki/engine/javascript"),
-  import("shiki/dist/langs/typescript.mjs"),
-  import("shiki/dist/themes/github-dark-default.mjs"),
-]).then(async ([core, engine, language, theme]) =>
-  core.createHighlighterCore({
-    engine: engine.createJavaScriptRegexEngine(),
-    langs: [language.default],
-    themes: [theme.default],
-  }),
-);
+function createTypescriptHighlighter() {
+  return Promise.all([
+    import("shiki/core"),
+    import("shiki/engine/javascript"),
+    import("shiki/dist/langs/typescript.mjs"),
+    import("shiki/dist/themes/github-dark-default.mjs"),
+  ]).then(async ([core, engine, language, theme]) =>
+    core.createHighlighterCore({
+      engine: engine.createJavaScriptRegexEngine(),
+      langs: [language.default],
+      themes: [theme.default],
+    }),
+  );
+}
+
+let typescriptHighlighter:
+  | ReturnType<typeof createTypescriptHighlighter>
+  | undefined;
+
+function loadTypescriptHighlighter() {
+  typescriptHighlighter ??= createTypescriptHighlighter();
+  return typescriptHighlighter;
+}
 
 const TERMINAL_STEPS = [
   Terminal.commands(["./mpp.sh"]),
@@ -408,9 +419,28 @@ function SectionLabel({ children }: { children: ReactNode }) {
 function IntegrationCodeCarousel() {
   const [activeIndex, setActiveIndex] = useState(0);
   const [highlightedCode, setHighlightedCode] = useState("");
+  const [shouldHighlight, setShouldHighlight] = useState(false);
+  const sectionRef = useRef<HTMLElement>(null);
   const prefersReducedMotion = useMediaQuery(
     "(prefers-reduced-motion: reduce)",
   );
+
+  useEffect(() => {
+    if (shouldHighlight) return;
+    const section = sectionRef.current;
+    if (!section) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        setShouldHighlight(true);
+        observer.disconnect();
+      },
+      { rootMargin: "300px" },
+    );
+    observer.observe(section);
+    return () => observer.disconnect();
+  }, [shouldHighlight]);
 
   useEffect(() => {
     if (prefersReducedMotion) return;
@@ -427,25 +457,29 @@ function IntegrationCodeCarousel() {
 ${activeSnippet.code}`;
 
   useEffect(() => {
+    if (!shouldHighlight) return;
+
     let cancelled = false;
     setHighlightedCode("");
 
-    TYPESCRIPT_HIGHLIGHTER.then((highlighter) =>
-      highlighter.codeToHtml(source, {
-        lang: "ts",
-        theme: "github-dark-default",
-      }),
-    ).then((html) => {
-      if (!cancelled) setHighlightedCode(html);
-    });
+    loadTypescriptHighlighter()
+      .then((highlighter) =>
+        highlighter.codeToHtml(source, {
+          lang: "ts",
+          theme: "github-dark-default",
+        }),
+      )
+      .then((html) => {
+        if (!cancelled) setHighlightedCode(html);
+      });
 
     return () => {
       cancelled = true;
     };
-  }, [source]);
+  }, [shouldHighlight, source]);
 
   return (
-    <section className="marketing-single-line">
+    <section className="marketing-single-line" ref={sectionRef}>
       <div className="marketing-single-line-intro">
         <SectionLabel>Integrate</SectionLabel>
         <h2>Sell to agents with just a single line of code</h2>
@@ -469,14 +503,21 @@ ${activeSnippet.code}`;
             )}
           </div>
         </div>
-        <div aria-hidden="true" className="marketing-code-carousel-dots">
+        <fieldset
+          aria-label="Choose a payment method example"
+          className="marketing-code-carousel-dots"
+        >
           {PAYMENT_METHOD_SNIPPETS.map((snippet, index) => (
-            <span
+            <button
+              aria-label={`Show ${snippet.method} example`}
+              aria-pressed={index === activeIndex}
               className={index === activeIndex ? "is-active" : undefined}
               key={snippet.method}
+              onClick={() => setActiveIndex(index)}
+              type="button"
             />
           ))}
-        </div>
+        </fieldset>
       </div>
     </section>
   );
@@ -691,9 +732,12 @@ function LandingStyles() {
       .marketing-code-shiki .shiki { background: #101010 !important; color: #dedede !important; font-family: var(--font-mono, monospace) !important; font-size: clamp(0.75rem, 1.4vw, 0.9375rem) !important; height: 100%; line-height: 1.5 !important; margin: 0 !important; overflow-x: auto; padding: 0 0 0.25rem !important; white-space: pre; }
       .marketing-code-fallback code,
       .marketing-code-shiki .shiki code { font-family: inherit !important; }
-      .marketing-code-carousel-dots { border-top: 1px solid var(--marketing-border); display: flex; gap: 0.375rem; padding: 0.875rem 1rem; }
-      .marketing-code-carousel-dots span { background: var(--marketing-border); display: block; height: 2px; transition: background-color 300ms ease, width 300ms ease; width: 1.25rem; }
-      .marketing-code-carousel-dots .is-active { background: var(--marketing-copy); width: 3rem; }
+      .marketing-code-carousel-dots { align-items: center; border: 0; border-top: 1px solid var(--marketing-border); display: flex; gap: 0.375rem; margin: 0; min-width: 0; padding: 0.625rem 1rem; }
+      .marketing-code-carousel-dots button { appearance: none; background: transparent; border: 0; cursor: pointer; height: 1.5rem; padding: 0; position: relative; transition: width 300ms ease; width: 1.25rem; }
+      .marketing-code-carousel-dots button::after { background: var(--marketing-border); content: ""; height: 2px; inset: calc(50% - 1px) 0 auto; position: absolute; transition: background-color 300ms ease; }
+      .marketing-code-carousel-dots button.is-active { width: 3rem; }
+      .marketing-code-carousel-dots button.is-active::after { background: var(--marketing-copy); }
+      .marketing-code-carousel-dots button:focus-visible { outline: 1px solid var(--marketing-copy); outline-offset: 2px; }
       @keyframes marketing-code-fade { from { opacity: 0; transform: translateY(0.5rem); } to { opacity: 1; transform: translateY(0); } }
       .marketing-services,
       .marketing-blog { border-top: 1px solid var(--marketing-border); padding-bottom: clamp(5rem, 10vw, 9rem); padding-top: clamp(1.5rem, 3vw, 2rem); }
@@ -830,7 +874,8 @@ function LandingStyles() {
       }
       @media (prefers-reduced-motion: reduce) {
         .marketing-code-snippet { animation: none; }
-        .marketing-code-carousel-dots span { transition: none; }
+        .marketing-code-carousel-dots button,
+        .marketing-code-carousel-dots button::after { transition: none; }
       }
     `}</style>
   );

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -694,7 +694,7 @@ function LandingStyles() {
       .marketing-single-line h2 { margin: 0 !important; }
       .marketing-single-line-intro { padding: clamp(1rem, 3vw, 2rem); }
       .marketing-single-line-intro > p { color: var(--marketing-muted); font-size: 1.125rem; line-height: 1.3; margin: 1.5rem 0 0; max-width: 25rem; }
-      .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); display: flex; flex-direction: column; height: 31rem; min-width: 0; }
+      .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); display: flex; flex-direction: column; height: 28rem; min-width: 0; }
       .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-copy); display: flex; flex: none; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: flex-start; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }
       .marketing-code-carousel-content { background: #101010; flex: 1; min-height: 0; overflow: auto; padding: clamp(1rem, 3vw, 2rem); }
       .marketing-code-snippet { animation: marketing-code-fade 520ms ease both; background: #101010; min-height: 0; }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -484,8 +484,8 @@ ${activeSnippet.code}`;
         <SectionLabel>Integrate</SectionLabel>
         <h2>Sell to agents with just a single line of code</h2>
         <p className="marketing-single-line-copy">
-          Accept fiat and stablecoin payments, including transactions under
-          $0.01.
+          Accept fiat and stablecoin payments in any currency, including
+          transactions under $0.01.
         </p>
       </div>
       <div className="marketing-code-carousel">

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -726,10 +726,11 @@ function LandingStyles() {
       .marketing-single-line-intro > p { color: var(--marketing-muted); font-size: 1.125rem; line-height: 1.3; margin: 1.5rem 0 0; max-width: 25rem; }
       .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); display: flex; flex-direction: column; height: 28rem; min-width: 0; }
       .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-copy); display: flex; flex: none; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: flex-start; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }
-      .marketing-code-carousel-content { background: #101010; flex: 1; min-height: 0; overflow: auto; padding: clamp(1rem, 3vw, 2rem); }
-      .marketing-code-snippet { animation: marketing-code-fade 520ms ease both; background: #101010; min-height: 0; }
+      .marketing-code-carousel-content { background: #101010; display: flex; flex: 1; min-height: 0; overflow: auto; padding: clamp(1rem, 3vw, 2rem); }
+      .marketing-code-snippet { animation: marketing-code-fade 520ms ease both; background: #101010; flex: 1; min-height: 0; min-width: 0; }
+      .marketing-code-shiki { background: #101010; height: 100%; }
       .marketing-code-fallback,
-      .marketing-code-shiki .shiki { background: #101010 !important; color: #dedede !important; font-family: var(--font-mono, monospace) !important; font-size: clamp(0.75rem, 1.4vw, 0.9375rem) !important; line-height: 1.5 !important; margin: 0 !important; overflow-x: auto; padding: 0 0 0.25rem !important; white-space: pre; }
+      .marketing-code-shiki .shiki { background: #101010 !important; color: #dedede !important; font-family: var(--font-mono, monospace) !important; font-size: clamp(0.75rem, 1.4vw, 0.9375rem) !important; height: 100%; line-height: 1.5 !important; margin: 0 !important; overflow-x: auto; padding: 0 0 0.25rem !important; white-space: pre; }
       .marketing-code-fallback code,
       .marketing-code-shiki .shiki code { font-family: inherit !important; }
       .marketing-code-carousel-dots { border-top: 1px solid var(--marketing-border); display: flex; gap: 0.375rem; padding: 0.875rem 1rem; }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -72,22 +72,19 @@ const INTEGRATIONS = [
 
 const PAYMENT_METHOD_SNIPPETS = [
   {
-    code: `const app = new Hono()
-const mppx = Mppx.create({ methods: [tempo.charge()] })
+    code: `const mppx = Mppx.create({ methods: [tempo.charge()] })
 
 app.get(
   '/premium',
   mppx.charge({ amount: '1' }),
   (c) => c.json({ data: 'paid content' }),
-)`,
+    )`,
     comment: "Accept USDC.e payments on Tempo.",
-    imports: `import { Hono } from 'hono'
-import { Mppx, tempo } from 'mppx/hono'`,
+    imports: `import { Mppx, tempo } from 'mppx/hono'`,
     method: "Tempo",
   },
   {
-    code: `const app = new Hono()
-const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
+    code: `const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 const mppx = Mppx.create({
   methods: [
     stripe.charge({
@@ -101,16 +98,14 @@ const mppx = Mppx.create({
   '/premium',
   mppx.charge({ amount: '1' }),
   (c) => c.json({ data: 'paid content' }),
-)`,
+    )`,
     comment: "Accept card payments with Stripe.",
-    imports: `import { Hono } from 'hono'
-import Stripe from 'stripe'
+    imports: `import Stripe from 'stripe'
 import { Mppx, stripe } from 'mppx/hono'`,
     method: "Stripe",
   },
   {
-    code: `const app = new Hono()
-const mppx = Mppx.create({
+    code: `const mppx = Mppx.create({
   methods: [
     spark.charge({ mnemonic: process.env.MNEMONIC! }),
   ],
@@ -119,16 +114,14 @@ const mppx = Mppx.create({
   '/premium',
   mppx.charge({ amount: '1' }),
   (c) => c.json({ data: 'paid content' }),
-)`,
+    )`,
     comment: "Accept Bitcoin payments over Lightning.",
-    imports: `import { Hono } from 'hono'
-import { Mppx } from 'mppx/hono'
+    imports: `import { Mppx } from 'mppx/hono'
 import { spark } from '@buildonspark/lightning-mpp-sdk/server'`,
     method: "Bitcoin",
   },
   {
-    code: `const app = new Hono()
-const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
+    code: `const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
 const mppx = Mppx.create({
   methods: [
     tempo.charge(),
@@ -143,10 +136,9 @@ const mppx = Mppx.create({
   '/premium',
   mppx.charge({ amount: '1' }),
   (c) => c.json({ data: 'paid content' }),
-)`,
+    )`,
     comment: "Offer Tempo and Stripe in one integration.",
-    imports: `import { Hono } from 'hono'
-import Stripe from 'stripe'
+    imports: `import Stripe from 'stripe'
 import { Mppx, tempo, stripe } from 'mppx/hono'`,
     method: "Multi-method",
   },

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -693,12 +693,12 @@ function LandingStyles() {
       .marketing-single-line { border-top: 1px solid var(--marketing-border); display: grid; gap: 2.5rem; margin-inline: auto; max-width: 1728px; padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 4vw, 3rem); }
       .marketing-single-line h2 { margin: 0 !important; }
       .marketing-single-line-intro > p { color: var(--marketing-muted); font-size: 1.125rem; line-height: 1.3; margin: 1.5rem 0 0; max-width: 25rem; }
-      .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); min-width: 0; }
-      .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-copy); display: flex; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: flex-start; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }
-      .marketing-code-carousel-content { min-height: 18rem; overflow: hidden; padding: clamp(1rem, 3vw, 2rem); }
-      .marketing-code-snippet { animation: marketing-code-fade 520ms ease both; min-height: 14rem; }
+      .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); display: flex; flex-direction: column; height: 31rem; min-width: 0; }
+      .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-copy); display: flex; flex: none; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: flex-start; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }
+      .marketing-code-carousel-content { background: #101010; flex: 1; min-height: 0; overflow: auto; padding: clamp(1rem, 3vw, 2rem); }
+      .marketing-code-snippet { animation: marketing-code-fade 520ms ease both; background: #101010; min-height: 0; }
       .marketing-code-fallback,
-      .marketing-code-shiki .shiki { background: transparent !important; color: #dedede !important; font-family: var(--font-mono, monospace) !important; font-size: clamp(0.75rem, 1.4vw, 0.9375rem) !important; line-height: 1.5 !important; margin: 0 !important; overflow-x: auto; padding: 0 0 0.25rem !important; white-space: pre; }
+      .marketing-code-shiki .shiki { background: #101010 !important; color: #dedede !important; font-family: var(--font-mono, monospace) !important; font-size: clamp(0.75rem, 1.4vw, 0.9375rem) !important; line-height: 1.5 !important; margin: 0 !important; overflow-x: auto; padding: 0 0 0.25rem !important; white-space: pre; }
       .marketing-code-fallback code,
       .marketing-code-shiki .shiki code { font-family: inherit !important; }
       .marketing-code-carousel-dots { border-top: 1px solid var(--marketing-border); display: flex; gap: 0.375rem; padding: 0.875rem 1rem; }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -782,6 +782,7 @@ function LandingStyles() {
         .marketing-terminal-shell { height: 17.25rem; min-height: 0; }
         .marketing-integration-grid { grid-template-columns: repeat(7, minmax(0, 1fr)); }
         .marketing-single-line { align-items: start; gap: clamp(4rem, 10vw, 12rem); grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr); }
+        .marketing-code-carousel { max-width: 35rem; }
       }
       @media (min-width: 1280px) {
         .marketing-blog { gap: 0; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -70,6 +70,27 @@ const INTEGRATIONS = [
   },
 ];
 
+const PAYMENT_METHOD_SNIPPETS = [
+  {
+    code: "const payment = Mppx.create({ methods: [tempo.charge({ recipient })] })",
+    description: "Accept USDC.e payments on Tempo.",
+    imports: "tempo",
+    method: "Tempo",
+  },
+  {
+    code: 'const payment = Mppx.create({ methods: [stripe.charge({ client, networkId: "internal", paymentMethodTypes: ["card"] })] })',
+    description: "Accept card payments with Stripe.",
+    imports: "stripe",
+    method: "Stripe",
+  },
+  {
+    code: 'const payment = Mppx.create({ methods: [tempo.charge({ recipient }), stripe.charge({ client, networkId: "internal", paymentMethodTypes: ["card"] })] })',
+    description: "Offer Tempo and Stripe in one integration.",
+    imports: "tempo, stripe",
+    method: "Multi-method",
+  },
+];
+
 const TERMINAL_STEPS = [
   Terminal.commands(["./mpp.sh"]),
   Terminal.wizard([
@@ -241,6 +262,8 @@ export function LandingPage() {
         </div>
       </section>
 
+      <IntegrationCodeCarousel />
+
       <section className="marketing-services">
         <div className="marketing-section-heading">
           <div>
@@ -345,6 +368,76 @@ Object.assign(LandingPage, {
 
 function SectionLabel({ children }: { children: ReactNode }) {
   return <p className="marketing-section-label">{children}</p>;
+}
+
+function IntegrationCodeCarousel() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+  const prefersReducedMotion = useMediaQuery(
+    "(prefers-reduced-motion: reduce)",
+  );
+
+  useEffect(() => {
+    if (isPaused || prefersReducedMotion) return;
+
+    const interval = window.setInterval(() => {
+      setActiveIndex((index) => (index + 1) % PAYMENT_METHOD_SNIPPETS.length);
+    }, 4200);
+    return () => window.clearInterval(interval);
+  }, [isPaused, prefersReducedMotion]);
+
+  const activeSnippet = PAYMENT_METHOD_SNIPPETS[activeIndex];
+
+  return (
+    <section className="marketing-single-line">
+      <div className="marketing-single-line-intro">
+        <SectionLabel>MPPX</SectionLabel>
+        <h2>Integrate in a single line.</h2>
+        <p>
+          Add the payment methods your API accepts with a single MPPX setup.
+        </p>
+      </div>
+      <div className="marketing-code-carousel">
+        <div className="marketing-code-carousel-header">
+          <span>TypeScript</span>
+          <span>{activeSnippet.method}</span>
+          <button
+            aria-pressed={isPaused}
+            disabled={prefersReducedMotion}
+            onClick={() => setIsPaused((paused) => !paused)}
+            type="button"
+          >
+            {prefersReducedMotion ? "Paused" : isPaused ? "Play" : "Pause"}
+          </button>
+        </div>
+        <div className="marketing-code-carousel-content">
+          <div className="marketing-code-snippet" key={activeSnippet.method}>
+            <code>
+              <span className="marketing-code-keyword">import</span>
+              {" { Mppx, "}
+              <span className="marketing-code-method">
+                {activeSnippet.imports}
+              </span>
+              {" } "}
+              <span className="marketing-code-keyword">from</span>
+              {' "mppx/server"'}
+              {"\n\n"}
+              {activeSnippet.code}
+            </code>
+            <p>{activeSnippet.description}</p>
+          </div>
+        </div>
+        <div aria-hidden="true" className="marketing-code-carousel-dots">
+          {PAYMENT_METHOD_SNIPPETS.map((snippet, index) => (
+            <span
+              className={index === activeIndex ? "is-active" : undefined}
+              key={snippet.method}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
 }
 
 function DesignedBy() {
@@ -464,6 +557,7 @@ function LandingStyles() {
       .marketing-designed-by { position: relative; z-index: 1; }
       .marketing-hero-content { display: flex; flex-direction: column; gap: 2.25rem; max-width: 62rem; }
       .marketing-hero :is(h1, h2),
+      .marketing-single-line h2,
       .marketing-services h2,
       .marketing-blog h2 {
         color: var(--marketing-copy) !important;
@@ -543,6 +637,25 @@ function LandingStyles() {
       .marketing-integration-logo { align-items: center; border: 1px solid var(--marketing-border); display: flex; height: 4.5rem; justify-content: center; padding: 1rem; text-decoration: none !important; transition: background-color 150ms ease, border-color 150ms ease; }
       .marketing-integration-logo:is(:hover, :focus-visible) { background: var(--marketing-elevated); border-color: var(--marketing-border-hover); outline: none; }
       .marketing-integration-logo img { max-height: 1.75rem; max-width: 100%; opacity: 0.9; width: auto; }
+      .marketing-single-line { border-top: 1px solid var(--marketing-border); display: grid; gap: 2.5rem; margin-inline: auto; max-width: 1728px; padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 4vw, 3rem); }
+      .marketing-single-line h2 { margin: 0 !important; }
+      .marketing-single-line-intro > p { color: var(--marketing-muted); font-size: 1.125rem; line-height: 1.3; margin: 1.5rem 0 0; max-width: 25rem; }
+      .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); min-width: 0; }
+      .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-muted); display: flex; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: space-between; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }
+      .marketing-code-carousel-header span:last-child { color: var(--marketing-copy); }
+      .marketing-code-carousel-header button { background: transparent; border: 0; color: var(--marketing-muted); cursor: pointer; font: inherit; padding: 0; text-transform: inherit; }
+      .marketing-code-carousel-header button:hover { color: var(--marketing-copy); }
+      .marketing-code-carousel-header button:disabled { cursor: default; opacity: 0.65; }
+      .marketing-code-carousel-content { min-height: 12.5rem; overflow: hidden; padding: clamp(1rem, 3vw, 2rem); }
+      .marketing-code-snippet { animation: marketing-code-fade 520ms ease both; display: flex; flex-direction: column; gap: 1.5rem; min-height: 8.5rem; justify-content: space-between; }
+      .marketing-code-snippet code { color: #dedede; display: block; font-family: var(--font-mono, monospace); font-size: clamp(0.75rem, 1.4vw, 0.9375rem); line-height: 1.65; overflow-x: auto; padding-bottom: 0.25rem; white-space: pre; }
+      .marketing-code-keyword { color: #d9a6ff; }
+      .marketing-code-method { color: #98f3aa; }
+      .marketing-code-snippet p { color: var(--marketing-muted); font-size: 1rem; line-height: 1.25; margin: 0; }
+      .marketing-code-carousel-dots { border-top: 1px solid var(--marketing-border); display: flex; gap: 0.375rem; padding: 0.875rem 1rem; }
+      .marketing-code-carousel-dots span { background: var(--marketing-border); display: block; height: 2px; transition: background-color 300ms ease, width 300ms ease; width: 1.25rem; }
+      .marketing-code-carousel-dots .is-active { background: var(--marketing-copy); width: 3rem; }
+      @keyframes marketing-code-fade { from { opacity: 0; transform: translateY(0.5rem); } to { opacity: 1; transform: translateY(0); } }
       .marketing-services,
       .marketing-blog { border-top: 1px solid var(--marketing-border); padding-bottom: clamp(5rem, 10vw, 9rem); padding-top: clamp(1.5rem, 3vw, 2rem); }
       .marketing-section-heading { align-items: flex-end; display: flex; gap: 2rem; justify-content: space-between; }
@@ -588,6 +701,7 @@ function LandingStyles() {
         .marketing-hero,
         .marketing-terminal-section,
         .marketing-integrations,
+        .marketing-single-line,
         .marketing-services,
         .marketing-blog { padding-inline: 3rem; }
         .marketing-hero { min-height: 100svh; padding-bottom: 2.5rem; padding-top: 11.875rem; }
@@ -617,6 +731,7 @@ function LandingStyles() {
         .marketing-mobile-terminal-art { display: none; }
         .marketing-terminal-shell { height: 17.25rem; min-height: 0; }
         .marketing-integration-grid { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+        .marketing-single-line { align-items: start; gap: clamp(4rem, 10vw, 12rem); grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr); }
       }
       @media (min-width: 1280px) {
         .marketing-blog { gap: 0; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
@@ -638,6 +753,7 @@ function LandingStyles() {
         .marketing-hero,
         .marketing-terminal-section,
         .marketing-integrations,
+        .marketing-single-line,
         .marketing-services,
         .marketing-blog { padding-inline: 3rem; }
         .marketing-blog::before { inset-inline: 3rem; }
@@ -646,6 +762,7 @@ function LandingStyles() {
         .marketing-hero,
         .marketing-terminal-section,
         .marketing-integrations,
+        .marketing-single-line,
         .marketing-services,
         .marketing-blog { padding-inline: 1rem; }
         .marketing-designed-by { display: none; }
@@ -670,6 +787,10 @@ function LandingStyles() {
         .marketing-actions { flex-direction: column; gap: 0.5rem; }
         .marketing-actions .marketing-button { width: 100%; }
         .marketing-designed-by { display: none; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .marketing-code-snippet { animation: none; }
+        .marketing-code-carousel-dots span { transition: none; }
       }
     `}</style>
   );

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -692,6 +692,7 @@ function LandingStyles() {
       .marketing-integration-logo img { max-height: 1.75rem; max-width: 100%; opacity: 0.9; width: auto; }
       .marketing-single-line { border-top: 1px solid var(--marketing-border); display: grid; gap: 2.5rem; margin-inline: auto; max-width: 1728px; padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 4vw, 3rem); }
       .marketing-single-line h2 { margin: 0 !important; }
+      .marketing-single-line-intro { padding: clamp(1rem, 3vw, 2rem); }
       .marketing-single-line-intro > p { color: var(--marketing-muted); font-size: 1.125rem; line-height: 1.3; margin: 1.5rem 0 0; max-width: 25rem; }
       .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); display: flex; flex-direction: column; height: 31rem; min-width: 0; }
       .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-copy); display: flex; flex: none; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: flex-start; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -74,50 +74,57 @@ const PAYMENT_METHOD_SNIPPETS = [
   {
     code: `const payment = Mppx.create({
   methods: [
-    tempo.charge({ recipient }),
+    tempo.charge(),
   ],
 })`,
     comment: "Accept USDC.e payments on Tempo.",
-    imports: "tempo",
+    imports: 'import { Mppx, tempo } from "mppx/server"',
     method: "Tempo",
   },
   {
     code: `const payment = Mppx.create({
   methods: [
     stripe.charge({
-      client,
+      client: stripeClient,
       networkId: "internal",
       paymentMethodTypes: ["card"],
     }),
   ],
 })`,
     comment: "Accept card payments with Stripe.",
-    imports: "stripe",
+    imports: `import Stripe from "stripe"
+import { Mppx, stripe } from "mppx/server"
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)`,
     method: "Stripe",
   },
   {
     code: `const payment = Mppx.create({
   methods: [
-    bitcoin.charge({ recipient }),
+    spark.charge({ mnemonic: process.env.MNEMONIC! }),
   ],
 })`,
-    comment: "Accept Bitcoin payments.",
-    imports: "bitcoin",
+    comment: "Accept Bitcoin payments over Lightning.",
+    imports:
+      'import { Mppx, spark } from "@buildonspark/lightning-mpp-sdk/server"',
     method: "Bitcoin",
   },
   {
     code: `const payment = Mppx.create({
   methods: [
-    tempo.charge({ recipient }),
+    tempo.charge(),
     stripe.charge({
-      client,
+      client: stripeClient,
       networkId: "internal",
       paymentMethodTypes: ["card"],
     }),
+    spark.charge({ mnemonic: process.env.MNEMONIC! }),
   ],
 })`,
-    comment: "Offer Tempo and Stripe in one integration.",
-    imports: "tempo, stripe",
+    comment: "Offer Tempo, Stripe, and Bitcoin in one integration.",
+    imports: `import Stripe from "stripe"
+import { Mppx, tempo, stripe } from "mppx/server"
+import { spark } from "@buildonspark/lightning-mpp-sdk/server"
+const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)`,
     method: "Multi-method",
   },
 ];
@@ -432,8 +439,7 @@ function IntegrationCodeCarousel() {
 
   const activeSnippet = PAYMENT_METHOD_SNIPPETS[activeIndex];
   const source = `// ${activeSnippet.comment}
-import { Mppx, ${activeSnippet.imports} } from "mppx/server"
-
+${activeSnippet.imports}
 ${activeSnippet.code}`;
 
   useEffect(() => {

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -98,6 +98,16 @@ const PAYMENT_METHOD_SNIPPETS = [
   {
     code: `const payment = Mppx.create({
   methods: [
+    bitcoin.charge({ recipient }),
+  ],
+})`,
+    comment: "Accept Bitcoin payments.",
+    imports: "bitcoin",
+    method: "Bitcoin",
+  },
+  {
+    code: `const payment = Mppx.create({
+  methods: [
     tempo.charge({ recipient }),
     stripe.charge({
       client,

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -83,12 +83,10 @@ app.get(
     method: "Tempo",
   },
   {
-    code: `const mppx = Mppx.create({
-  methods: [stripe.charge({
-    networkId: 'internal',
-    paymentMethodTypes: ['card'],
-    secretKey: process.env.STRIPE_SECRET_KEY!,
-  })],
+    code: `const payments = await stripe.create({ client: stripeClient })
+
+const mppx = Mppx.create({
+  methods: [payments.spt.charge()],
 })
 
 app.get(

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -74,72 +74,47 @@ const PAYMENT_METHOD_SNIPPETS = [
   {
     code: `const mppx = Mppx.create({ methods: [tempo.charge()] })
 
-app.get(
-  '/premium',
-  mppx.charge({ amount: '1' }),
-  (c) => c.json({ data: 'paid content' }),
-    )`,
-    comment: "Accept USDC.e payments on Tempo.",
+app.get('/premium', mppx.charge({ amount: '1' }), (c) => c.text('Paid'))`,
     imports: `import { Mppx, tempo } from 'mppx/hono'`,
     method: "Tempo",
   },
   {
-    code: `const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
-const mppx = Mppx.create({
-  methods: [
-    stripe.charge({
-      client: stripeClient,
-      networkId: 'internal',
-      paymentMethodTypes: ['card'],
-    }),
-  ],
-})`,
-    route: `app.get(
-  '/premium',
-  mppx.charge({ amount: '1' }),
-  (c) => c.json({ data: 'paid content' }),
-    )`,
-    comment: "Accept card payments with Stripe.",
-    imports: `import Stripe from 'stripe'
-import { Mppx, stripe } from 'mppx/hono'`,
+    code: `const mppx = Mppx.create({
+  methods: [stripe.charge({
+    networkId: 'internal',
+    paymentMethodTypes: ['card'],
+    secretKey: process.env.STRIPE_SECRET_KEY!,
+  })],
+})
+
+app.get('/premium', mppx.charge({ amount: '1' }), (c) => c.text('Paid'))`,
+    imports: `import { Mppx, stripe } from 'mppx/hono'`,
     method: "Stripe",
   },
   {
     code: `const mppx = Mppx.create({
-  methods: [
-    spark.charge({ mnemonic: process.env.MNEMONIC! }),
-  ],
-})`,
-    route: `app.get(
-  '/premium',
-  mppx.charge({ amount: '1' }),
-  (c) => c.json({ data: 'paid content' }),
-    )`,
-    comment: "Accept Bitcoin payments over Lightning.",
+  methods: [spark.charge({ mnemonic: process.env.MNEMONIC! })],
+})
+
+app.get('/premium', mppx.charge({ amount: '1' }), (c) => c.text('Paid'))`,
     imports: `import { Mppx } from 'mppx/hono'
 import { spark } from '@buildonspark/lightning-mpp-sdk/server'`,
     method: "Bitcoin",
   },
   {
-    code: `const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
-const mppx = Mppx.create({
+    code: `const mppx = Mppx.create({
   methods: [
     tempo.charge(),
     stripe.charge({
-      client: stripeClient,
       networkId: 'internal',
       paymentMethodTypes: ['card'],
+      secretKey: process.env.STRIPE_SECRET_KEY!,
     }),
   ],
-})`,
-    route: `app.get(
-  '/premium',
-  mppx.charge({ amount: '1' }),
-  (c) => c.json({ data: 'paid content' }),
-    )`,
-    comment: "Offer Tempo and Stripe in one integration.",
-    imports: `import Stripe from 'stripe'
-import { Mppx, tempo, stripe } from 'mppx/hono'`,
+})
+
+app.get('/premium', mppx.charge({ amount: '1' }), (c) => c.text('Paid'))`,
+    imports: `import { Mppx, stripe, tempo } from 'mppx/hono'`,
     method: "Multi-method",
   },
 ];
@@ -453,10 +428,9 @@ function IntegrationCodeCarousel() {
   }, [prefersReducedMotion]);
 
   const activeSnippet = PAYMENT_METHOD_SNIPPETS[activeIndex];
-  const source = `// ${activeSnippet.comment}
-${activeSnippet.imports}
+  const source = `${activeSnippet.imports}
 
-${activeSnippet.code}${activeSnippet.route ? `\n\n${activeSnippet.route}` : ""}`;
+${activeSnippet.code}`;
 
   useEffect(() => {
     let cancelled = false;

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -72,20 +72,41 @@ const INTEGRATIONS = [
 
 const PAYMENT_METHOD_SNIPPETS = [
   {
-    code: "const payment = Mppx.create({ methods: [tempo.charge({ recipient })] })",
-    description: "Accept USDC.e payments on Tempo.",
+    code: `const payment = Mppx.create({
+  methods: [
+    tempo.charge({ recipient }),
+  ],
+})`,
+    comment: "Accept USDC.e payments on Tempo.",
     imports: "tempo",
     method: "Tempo",
   },
   {
-    code: 'const payment = Mppx.create({ methods: [stripe.charge({ client, networkId: "internal", paymentMethodTypes: ["card"] })] })',
-    description: "Accept card payments with Stripe.",
+    code: `const payment = Mppx.create({
+  methods: [
+    stripe.charge({
+      client,
+      networkId: "internal",
+      paymentMethodTypes: ["card"],
+    }),
+  ],
+})`,
+    comment: "Accept card payments with Stripe.",
     imports: "stripe",
     method: "Stripe",
   },
   {
-    code: 'const payment = Mppx.create({ methods: [tempo.charge({ recipient }), stripe.charge({ client, networkId: "internal", paymentMethodTypes: ["card"] })] })',
-    description: "Offer Tempo and Stripe in one integration.",
+    code: `const payment = Mppx.create({
+  methods: [
+    tempo.charge({ recipient }),
+    stripe.charge({
+      client,
+      networkId: "internal",
+      paymentMethodTypes: ["card"],
+    }),
+  ],
+})`,
+    comment: "Offer Tempo and Stripe in one integration.",
     imports: "tempo, stripe",
     method: "Multi-method",
   },
@@ -372,19 +393,18 @@ function SectionLabel({ children }: { children: ReactNode }) {
 
 function IntegrationCodeCarousel() {
   const [activeIndex, setActiveIndex] = useState(0);
-  const [isPaused, setIsPaused] = useState(false);
   const prefersReducedMotion = useMediaQuery(
     "(prefers-reduced-motion: reduce)",
   );
 
   useEffect(() => {
-    if (isPaused || prefersReducedMotion) return;
+    if (prefersReducedMotion) return;
 
     const interval = window.setInterval(() => {
       setActiveIndex((index) => (index + 1) % PAYMENT_METHOD_SNIPPETS.length);
     }, 4200);
     return () => window.clearInterval(interval);
-  }, [isPaused, prefersReducedMotion]);
+  }, [prefersReducedMotion]);
 
   const activeSnippet = PAYMENT_METHOD_SNIPPETS[activeIndex];
 
@@ -401,18 +421,14 @@ function IntegrationCodeCarousel() {
         <div className="marketing-code-carousel-header">
           <span>TypeScript</span>
           <span>{activeSnippet.method}</span>
-          <button
-            aria-pressed={isPaused}
-            disabled={prefersReducedMotion}
-            onClick={() => setIsPaused((paused) => !paused)}
-            type="button"
-          >
-            {prefersReducedMotion ? "Paused" : isPaused ? "Play" : "Pause"}
-          </button>
         </div>
         <div className="marketing-code-carousel-content">
           <div className="marketing-code-snippet" key={activeSnippet.method}>
             <code>
+              <span className="marketing-code-comment">
+                {`// ${activeSnippet.comment}`}
+              </span>
+              {"\n"}
               <span className="marketing-code-keyword">import</span>
               {" { Mppx, "}
               <span className="marketing-code-method">
@@ -424,7 +440,6 @@ function IntegrationCodeCarousel() {
               {"\n\n"}
               {activeSnippet.code}
             </code>
-            <p>{activeSnippet.description}</p>
           </div>
         </div>
         <div aria-hidden="true" className="marketing-code-carousel-dots">
@@ -643,15 +658,12 @@ function LandingStyles() {
       .marketing-code-carousel { background: #101010; border: 1px solid var(--marketing-border); min-width: 0; }
       .marketing-code-carousel-header { align-items: center; border-bottom: 1px solid var(--marketing-border); color: var(--marketing-muted); display: flex; font-family: var(--font-mono, monospace); font-size: 0.75rem; justify-content: space-between; line-height: 1rem; padding: 0.875rem 1rem; text-transform: uppercase; }
       .marketing-code-carousel-header span:last-child { color: var(--marketing-copy); }
-      .marketing-code-carousel-header button { background: transparent; border: 0; color: var(--marketing-muted); cursor: pointer; font: inherit; padding: 0; text-transform: inherit; }
-      .marketing-code-carousel-header button:hover { color: var(--marketing-copy); }
-      .marketing-code-carousel-header button:disabled { cursor: default; opacity: 0.65; }
-      .marketing-code-carousel-content { min-height: 12.5rem; overflow: hidden; padding: clamp(1rem, 3vw, 2rem); }
-      .marketing-code-snippet { animation: marketing-code-fade 520ms ease both; display: flex; flex-direction: column; gap: 1.5rem; min-height: 8.5rem; justify-content: space-between; }
-      .marketing-code-snippet code { color: #dedede; display: block; font-family: var(--font-mono, monospace); font-size: clamp(0.75rem, 1.4vw, 0.9375rem); line-height: 1.65; overflow-x: auto; padding-bottom: 0.25rem; white-space: pre; }
+      .marketing-code-carousel-content { min-height: 18rem; overflow: hidden; padding: clamp(1rem, 3vw, 2rem); }
+      .marketing-code-snippet { animation: marketing-code-fade 520ms ease both; min-height: 14rem; }
+      .marketing-code-snippet code { color: #dedede; display: block; font-family: var(--font-mono, monospace); font-size: clamp(0.75rem, 1.4vw, 0.9375rem); line-height: 1.5; overflow-x: auto; padding-bottom: 0.25rem; white-space: pre; }
+      .marketing-code-comment { color: var(--marketing-muted); }
       .marketing-code-keyword { color: #d9a6ff; }
       .marketing-code-method { color: #98f3aa; }
-      .marketing-code-snippet p { color: var(--marketing-muted); font-size: 1rem; line-height: 1.25; margin: 0; }
       .marketing-code-carousel-dots { border-top: 1px solid var(--marketing-border); display: flex; gap: 0.375rem; padding: 0.875rem 1rem; }
       .marketing-code-carousel-dots span { background: var(--marketing-border); display: block; height: 2px; transition: background-color 300ms ease, width 300ms ease; width: 1.25rem; }
       .marketing-code-carousel-dots .is-active { background: var(--marketing-copy); width: 3rem; }


### PR DESCRIPTION
## Motivation

Make payment-method setup immediately discoverable from the landing page.

## Summary

- Add a single-line MPPX integration section above Services
- Rotate Tempo, Stripe, and combined-method setup snippets
- Include fade, pause, and reduced-motion behavior

## Key design considerations

- Uses the existing landing-page visual system
- Keeps all MPPX snippets in TypeScript
- Displays valid payment-method configuration details