### PR TITLE
docs: address Codex review feedback on NEAR Intents pages

### DIFF
--- a/src/pages/payment-methods/nearintents/charge.mdx
+++ b/src/pages/payment-methods/nearintents/charge.mdx
@@ -12,7 +12,7 @@ The NEAR Intents implementation of the [charge](/intents/charge) intent.
 
 The server requests a wet `EXACT_OUTPUT` quote from the [1Click API](https://docs.near-intents.org/integration/distribution-channels/1click-api/about-1click-api) for each Challenge and advertises the quote's **unique, single-use deposit address** as `recipient`. The client pays the source asset to that address on its origin chain and presents the confirmed transaction hash as a Credential (push mode). The server verifies the deposit by observing the 1Click status endpoint, drives the cross-chain swap to `SUCCESS`, and returns the resource with a Receipt carrying the origin and destination transaction hashes.
 
-This method is best for one-time purchases where the payer and the merchant sit on different chains — the merchant always receives an exact amount of its chosen asset.
+This method is best for one-time purchases where the payer and the merchant sit on different chains—the merchant always receives an exact amount of its chosen asset.
 
 ## Server
 
@@ -23,20 +23,20 @@ import { Mppx } from 'mppx/server'
 import { nearintents } from '@defuse-protocol/nearintents-mpp-sdk/server'
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY!,
   methods: [
     nearintents.charge({
-      // what the client pays with (CAIP-19) — its chain is the origin network
-      originAsset: 'eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
       // what the merchant receives, where, and exactly how much (EXACT_OUTPUT)
-      destinationAsset: 'near:mainnet/nep141:17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1',
-      destinationRecipient: 'merchant.near',
       amountOut: '1000000',
+      destinationAsset: 'near:mainnet/nep141:17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1', // USDC on NEAR
+      destinationRecipient: 'merchant.near',
+      oneClick: { jwt: process.env.ONE_CLICK_JWT },
+      // what the client pays with (CAIP-19); its chain is the origin network
+      originAsset: 'eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831', // USDC on Arbitrum One
       // merchant-controlled refund address on the origin chain
       refundTo: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-      oneClick: { jwt: process.env.ONE_CLICK_JWT },
     }),
   ],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 
 export async function handler(request: Request) {
@@ -50,20 +50,20 @@ export async function handler(request: Request) {
 
 ### With expiry
 
-The Challenge expiry MUST cover the origin chain's confirmation time — minutes for fast chains, 45–60 minutes for Bitcoin. Two values control it and **must be kept equal**: the mppx route `expires` (which stamps the Challenge) and the method's `expiresWindow` (which sizes the quote cache so the advertised `expires` never outlives the quote's deposit deadline).
+The Challenge expiry MUST cover the origin chain's confirmation time—minutes for fast chains, 45–60 minutes for Bitcoin. Two values control it and **must be kept equal**: the mppx route `expires` (which stamps the Challenge) and the method's `expiresWindow` (which sizes the quote cache so the advertised `expires` never outlives the quote's deposit deadline).
 
 ```ts
 import { Expires, Mppx } from 'mppx/server'
 import { nearintents } from '@defuse-protocol/nearintents-mpp-sdk/server'
 
 const mppx = Mppx.create({
-  secretKey: process.env.MPP_SECRET_KEY!,
   methods: [
     nearintents.charge({
       /* ... */
       expiresWindow: 45 * 60, // [!code hl]
     }),
   ],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 
 export async function handler(request: Request) {
@@ -86,7 +86,7 @@ const method = nearintents.charge({
   onEvent: (event) => logger.info(event), // [!code hl]
 })
 
-const mppx = Mppx.create({ secretKey, methods: [method] })
+const mppx = Mppx.create({ methods: [method], secretKey })
 mppx.on('payment.success', ({ receipt }) => logger.info(receipt))
 mppx.on('payment.failed', ({ error }) => logger.warn(error.type, error.message))
 ```
@@ -106,14 +106,14 @@ mppx.on('payment.failed', ({ error }) => logger.warn(error.type, error.message))
 | `externalId` | `string` | Optional | |
 | `oneClick` | `{ jwt?, baseUrl?, fetch?, networks?, nativeCoinTypes?, requestTimeoutMs? }` | Optional | public API, unauthenticated |
 | `store` | `Store.AtomicStore` | Optional | `Store.memory()` |
-| `expiresWindow` | `number` (seconds) | Optional | `300` — MUST equal the route `expires` |
+| `expiresWindow` | `number` (seconds) | Optional | `300`—MUST equal the route `expires` |
 | `quoteDeadlineBuffer` | `number` (seconds) | Optional | `900` |
 | `settlementTimeout` | `number` (seconds) | Optional | quote `timeEstimate` + 120 |
 | `pollInterval` | `number` (ms) | Optional | `2000` |
 | `onEvent` | `(event) => void` | Optional | |
 
 :::info
-The 1Click JWT (from the [NEAR Intents partner portal](https://partners.near-intents.org)) is server-side only and must never appear in any Challenge field. Unauthenticated requests work but incur a 0.2% fee. Replay protection requires an **atomic** store: the in-memory default is for a single instance; use a shared store (e.g. `Store.redis`) in multi-instance deployments.
+The 1Click JWT (from the [NEAR Intents partner portal](https://partners.near-intents.org)) is server-side only and must never appear in any Challenge field. Unauthenticated requests work but incur a 0.2% fee. Replay protection requires an **atomic** store: the in-memory default is for a single instance; use a shared store (for example `Store.redis`) in multi-instance deployments.
 :::
 
 ## Client
@@ -127,11 +127,12 @@ import { nearintents } from '@defuse-protocol/nearintents-mpp-sdk/client'
 const mppx = Mppx.create({
   methods: [
     nearintents.charge({
-      walletClient, // viem WalletClient (+ public actions) for eip155 origins
       policy: {
         allowedOriginNetworks: ['eip155:42161'],
-        maxAmountIn: { 'eip155:42161/erc20:0xaf88…5831': '5000000' },
+        // per-payment cap of 5 USDC on Arbitrum One
+        maxAmountIn: { 'eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831': '5000000' },
       },
+      walletClient, // viem WalletClient (+ public actions) for eip155 origins
     }),
   ],
   polyfill: false,
@@ -170,7 +171,7 @@ await mppx.fetch('https://api.example.com/resource', {
 | `source` | `string` (`did:pkh`) | Optional | derived from `walletClient` |
 
 :::warning
-A `policy` is **strongly recommended for autonomous payers**. The client always schema-validates the Challenge and refuses expired ones, but the value checks — allowed origin networks/assets, per-asset `maxAmountIn` caps, expected destination leg — only run when a policy is configured. The client pays before delivery; the policy is its safety surface.
+A `policy` is **strongly recommended for autonomous payers**. The client always schema-validates the Challenge and refuses expired ones, but the value checks—allowed origin networks/assets, per-asset `maxAmountIn` caps, expected destination leg—only run when a policy is configured. The client pays before delivery; the policy is its safety surface.
 :::
 
 ## Request fields
@@ -181,7 +182,7 @@ The Challenge request describes the payment the client makes on the origin chain
 | --- | --- | --- | --- |
 | `amount` | `string` | Required | Deposit amount the client is asked to send, in base units of `currency` (the quote's maximum input that guarantees `amountOut`) |
 | `currency` | `string` | Required | Source asset (CAIP-19); chain component MUST equal `methodDetails.originNetwork` |
-| `recipient` | `string` | Required | **Single-use 1Click deposit address** on the origin chain — the payee of the client's transfer |
+| `recipient` | `string` | Required | **Single-use 1Click deposit address** on the origin chain—the payee of the client's transfer |
 | `description` | `string` | Optional | Human-readable memo. MUST NOT be relied upon for verification |
 | `externalId` | `string` | Optional | Merchant reference (order ID, invoice number) |
 | `methodDetails.originNetwork` | `string` | Required | CAIP-2 chain where `recipient` lives and the deposit tx is anchored |
@@ -189,17 +190,17 @@ The Challenge request describes the payment the client makes on the origin chain
 | `methodDetails.destinationAsset` | `string` | Required | Destination asset (CAIP-19); chain component MUST equal `destinationNetwork` |
 | `methodDetails.destinationRecipient` | `string` | Required | Merchant address on the destination chain |
 | `methodDetails.amountOut` | `string` | Required | Exact amount the merchant receives (`EXACT_OUTPUT`) |
-| `methodDetails.minAmountIn` | `string` | Required | Minimum deposit the backend accepts — the verification threshold |
-| `methodDetails.depositMemo` | `string \| null` | Optional | Deposit memo required by some origin chains (e.g. Stellar) |
+| `methodDetails.minAmountIn` | `string` | Required | Minimum deposit the backend accepts—the verification threshold |
+| `methodDetails.depositMemo` | `string \| null` | Optional | Deposit memo required by some origin chains (for example Stellar) |
 | `methodDetails.slippageTolerance` | `number` | Optional | Basis points, applied to the input side |
 | `methodDetails.timeEstimate` | `number` | Optional | Estimated swap completion time in seconds |
 | `methodDetails.refundTo` | `string` | Required | Origin-chain address refunded on any non-success outcome |
-| `methodDetails.settlementBackend` | `string` | Optional | `"near-intents"` — trust-model disclosure |
+| `methodDetails.settlementBackend` | `string` | Optional | `"near-intents"`—trust-model disclosure |
 | `methodDetails.credentialTypes` | `array` | Optional | Only `"hash"` is valid for this method |
 
 ## Credential payload
 
-The Credential payload contains the client's origin-chain deposit transaction hash (push mode — the client broadcasts its own deposit).
+The Credential payload contains the client's origin-chain deposit transaction hash (push mode—the client broadcasts its own deposit).
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
@@ -208,11 +209,11 @@ The Credential payload contains the client's origin-chain deposit transaction ha
 
 ## Verification and settlement
 
-The server verifies and settles in one pass (status-observation mode — no per-chain RPC):
+The server verifies and settles in one pass (status-observation mode—no per-chain RPC):
 
 1. mppx recomputes the Challenge binding (HMAC) and rejects unknown, modified, or expired Challenges before the method runs.
 2. The deposit address must correspond to an active, non-settled quote in server state; `payload.hash` must not be consumed. The hash is claimed **in-flight atomically**, so concurrent presentations of the same Credential settle at most once.
-3. The server notifies 1Click of the deposit (accelerator) and polls the status endpoint until a terminal state — the backend detecting a qualifying deposit ≥ `minAmountIn` at `recipient` *is* the deposit confirmation.
+3. The server notifies 1Click of the deposit (accelerator) and polls the status endpoint until a terminal state—the backend detecting a qualifying deposit ≥ `minAmountIn` at `recipient` *is* the deposit confirmation.
 4. On `SUCCESS`, the presented `hash` must be among the origin-chain transactions the backend observed; the Receipt then carries `challengeId`, `originTxHash`, and the destination-chain delivery hash as `reference`. The merchant has received exactly `amountOut`.
 5. On any terminal state the hash is permanently consumed and the deposit address is spent; the backend refunds non-success deposits to `refundTo`.
 
@@ -221,8 +222,8 @@ The server verifies and settles in one pass (status-observation mode — no per-
 | `SUCCESS` | `200` + `Payment-Receipt` |
 | `INCOMPLETE_DEPOSIT` (below `minAmountIn`) | `402` `payment-insufficient` + fresh Challenge |
 | `FAILED` / `REFUNDED` | `402` `settlement-failed` + fresh Challenge |
-| 1Click unreachable | `503` — Credential **not** consumed; re-present it |
-| Settlement exceeds `settlementTimeout` | `504` — Credential **not** consumed; re-present it |
+| 1Click unreachable | `503`—Credential **not** consumed; re-present it |
+| Settlement exceeds `settlementTimeout` | `504`—Credential **not** consumed; re-present it |
 
 ## Specification
 

--- a/src/pages/payment-methods/nearintents/index.mdx
+++ b/src/pages/payment-methods/nearintents/index.mdx
@@ -10,7 +10,7 @@ import { NearIntentsChargeCard } from '../../../components/cards'
 
 The NEAR Intents payment method enables **cross-chain** MPP payments settled by the [NEAR Intents](https://near-intents.org) solver network through its [1Click API](https://docs.near-intents.org/integration/distribution-channels/1click-api/about-1click-api): the client pays a source asset on whatever chain it holds funds on (Bitcoin, Solana, any major EVM chain, NEAR, and [more](https://docs.near-intents.org/resources/chain-support)), and the merchant receives an **exact amount** of its chosen asset on its chosen chain. It supports the **charge** intent for one-time payments.
 
-The implementation is provided by [`@defuse-protocol/nearintents-mpp-sdk`](https://github.com/defuse-protocol/nearintents-mpp-sdk), which extends the [`mppx`](https://github.com/tempoxyz/mpp) SDK with NEAR Intents settlement alongside built-in methods like [EVM](/payment-methods/evm) and [Tempo](/payment-methods/tempo). Read the [NEAR Intents charge protocol spec](https://paymentauth.org/draft-nearintents-charge-00) for the wire format.
+The implementation is provided by [`@defuse-protocol/nearintents-mpp-sdk`](https://github.com/defuse-protocol/nearintents-mpp-sdk), which extends the [`mppx`](https://github.com/wevm/mppx) SDK with NEAR Intents settlement alongside built-in methods like [EVM](/payment-methods/evm) and [Tempo](/payment-methods/tempo). Read the [NEAR Intents charge protocol spec](https://paymentauth.org/draft-nearintents-charge-00) for the wire format.
 
 ## Installation
 
@@ -31,13 +31,13 @@ $ bun add @defuse-protocol/nearintents-mpp-sdk mppx
 NEAR Intents brings a distinct set of properties to MPP:
 
 - **Cross-chain by construction**—The payer's chain and the merchant's chain are independent. A client can pay native BTC while the merchant receives USDC on NEAR; the solver network executes the swap in between.
-- **Exact merchant amounts**—Quotes use `EXACT_OUTPUT`: the merchant receives a deterministic amount of its destination asset, with slippage applied to the input side and any excess refunded to the payer's refund address.
+- **Exact merchant amounts**—Quotes use `EXACT_OUTPUT`: the merchant receives a deterministic amount of its destination asset, with slippage applied to the input side and any excess refunded to the quote's merchant-configured `refundTo` address.
 - **Challenge-bound deposit addresses**—Every Challenge carries a **unique, single-use deposit address** minted for that quote. A deposit observed at that address is implicitly bound to the one Challenge that advertised it, giving hash credentials stronger practical binding than a static recipient address.
 - **Recoverable by design**—Every non-success settlement outcome refunds the deposit to a merchant-configured origin-chain address, and transient backend failures never consume the credential: the client simply re-presents it.
 - **Chain-agnostic identifiers**—Assets and chains are expressed as [CAIP-19](https://chainagnostic.org/CAIPs/caip-19) / [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) identifiers on the wire, compared by parsed components.
 
 :::info
-Settlement is **not trustless**: for the duration of the swap, deposits are custodied by the NEAR Intents settlement system, which either delivers the destination asset to the merchant or refunds the deposit — comparable to entrusting a payment processor with a transfer. Clients and autonomous agents applying per-method risk policies can identify this trust model from the `method` (`nearintents`) and `methodDetails.settlementBackend` (`"near-intents"`) fields.
+Settlement is **not trustless**: for the duration of the swap, deposits are custodied by the NEAR Intents settlement system, which either delivers the destination asset to the merchant or refunds the deposit—comparable to entrusting a payment processor with a transfer. Clients and autonomous agents applying per-method risk policies can identify this trust model from the `method` (`nearintents`) and `methodDetails.settlementBackend` (`"near-intents"`) fields.
 :::
 
 ## Intents


### PR DESCRIPTION
Implements the Codex suggestions from #816's review discussion: 
- correct the mppx repo link (wevm/mppx)
- shorten the charge page's OG description under 160 chars
- name the USDC token addresses inline
- alphabetize example object properties
- use the full CAIP-19 identifier in the maxAmountIn policy key
- fix the excess-refund wording (refunds go to the merchant-configured refundTo, per the spec)
- close up em dashes, and replace Latin abbreviations. 

The check-script allowlist suggestion is left to maintainers as it concerns repo tooling rather than the guide.