### PR TITLE
fix: stabilize logo animation loading

### DIFF
--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -431,7 +431,7 @@ function SearchWithDropdown({
         placeholder="SEARCH SERVICES"
         style={{
           width: "100%",
-          padding: `0.4rem ${onDismiss && resultCount != null ? "5rem" : onDismiss ? "2rem" : "0.6rem"} 0.4rem 2rem`,
+          padding: `0.4rem ${onDismiss && resultCount != null ? "5rem" : onDismiss || !search ? "0.6rem" : "2rem"} 0.4rem 2rem`,
           fontSize: 14,
           borderRadius: 8,
           border: "1px solid var(--vocs-border-color-primary)",
@@ -442,6 +442,46 @@ function SearchWithDropdown({
           outline: "none",
         }}
       />
+      {search && !onDismiss && (
+        <button
+          aria-label="Clear service search"
+          onClick={() => {
+            setSearch("");
+            setPage(0);
+            setShowDropdown(false);
+            ref.current?.focus();
+          }}
+          style={{
+            alignItems: "center",
+            background: "transparent",
+            border: "none",
+            color: "var(--vocs-text-color-muted)",
+            display: "flex",
+            padding: 4,
+            position: "absolute",
+            right: 8,
+            top: "50%",
+            transform: "translateY(-50%)",
+            zIndex: 2,
+          }}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="none"
+            height="16"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width="16"
+          >
+            <path d="m18 6-12 12" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+      )}
       {onDismiss && resultCount != null && (
         <span
           style={{

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2934,8 +2934,13 @@ function TerminalComponent({
                 strokeWidth="2"
                 strokeLinecap="round"
               >
-                <title>Minimize</title>
+                <title>
+                  {isMarketingMinimized
+                    ? "Expand terminal"
+                    : "Minimize terminal"}
+                </title>
                 <path d="M5 12h14" />
+                {isMarketingMinimized && <path d="M12 5v14" />}
               </svg>
             </button>
           )}

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -28,6 +28,7 @@ if (typeof window !== "undefined") {
 const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY;
 
 type LottieAnimation = {
+  addEventListener: (event: string, callback: () => void) => void;
   destroy: () => void;
   goToAndPlay: (value: number, isFrame?: boolean) => void;
   setSpeed: (speed: number) => void;
@@ -104,6 +105,7 @@ function useLogoAnimation() {
 
     let animation: LottieAnimation | undefined;
     let cancelled = false;
+    let ready = false;
     let fallbackImages: HTMLImageElement[] = [];
     let container: HTMLSpanElement | undefined;
 
@@ -124,11 +126,8 @@ function useLogoAnimation() {
         container.dataset.mppLogoAnimation = "";
         logo.dataset.mppLogoHost = "";
         logo.appendChild(container);
-        fallbackImages.forEach((image) => {
-          image.style.visibility = "hidden";
-        });
         animation = player.loadAnimation({
-          autoplay: true,
+          autoplay: false,
           container,
           loop: false,
           path: "/lottie/02_MPP_Logo_Loading_Animation.json",
@@ -136,13 +135,21 @@ function useLogoAnimation() {
           rendererSettings: { preserveAspectRatio: "xMidYMid meet" },
         });
         animation.setSpeed(1.6);
+        animation.addEventListener("DOMLoaded", () => {
+          if (cancelled || !animation) return;
+          ready = true;
+          fallbackImages.forEach((image) => {
+            image.style.visibility = "hidden";
+          });
+          animation.goToAndPlay(7, true);
+        });
       } catch {
         // Keep the static logo when the optional animation cannot load.
       }
     };
 
     const replay = () => {
-      animation?.goToAndPlay(0, true);
+      if (ready) animation?.goToAndPlay(7, true);
     };
     const idleCallback = window.requestIdleCallback?.(() => void mount(), {
       timeout: 2_000,

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -131,6 +131,11 @@ html {
   overscroll-behavior: none;
 }
 
+button:not(:disabled),
+[role="button"]:not(:disabled) {
+  cursor: pointer;
+}
+
 /* Pagination: hide "Next" / "Previous" label text, keep only shortcut (Shift → / ←) */
 [data-v-pagination] a > span:last-of-type {
   font-size: 0;


### PR DESCRIPTION
## Motivation

Port the logo-loading stability work from the July 27 MPP snapshot without replacing the Vocs architecture.

## Summary

- Keep the static MPP mark visible until Lottie has rendered.
- Replay the trimmed animation from its later start frame after route changes.
- Restore pointer cursors for interactive controls globally.

## Key design considerations

- This branch is stacked on `brendanjryan/import-mpp-code` (PR #814).
- The later snapshot is a separate React/Tailwind implementation; this ports its equivalent behavior rather than its files.
