### PR TITLE
docs: fix style guide regressions

### DIFF
--- a/src/pages/governance.mdx
+++ b/src/pages/governance.mdx
@@ -1,6 +1,6 @@
 ---
 description: "An overview of how the Machine Payments Protocol is developed, maintained, and extended"
-imageDescription: "An overview of how the Machine Payments Protocol is developed, maintained, and extended"
+imageDescription: "Shape an open, neutral standard for machine payments"
 ---
 
 # Governance [An overview of how the Machine Payments Protocol is developed, maintained, and extended]

--- a/src/pages/guides/managing-agent-spend.mdx
+++ b/src/pages/guides/managing-agent-spend.mdx
@@ -1,8 +1,9 @@
 ---
 description: "Manage agent spend with MPP."
+imageDescription: "Keep agent payments within clear limits"
 ---
 
-# Managing agent spend
+# Managing agent spend [Control automated payments with scoped budgets]
 
 By building spending controls on top of MPP, agents can pay in the background while staying within the budget, time window, and tools you intended.
 

--- a/src/pages/partner-integrations/cloudflare-agents.mdx
+++ b/src/pages/partner-integrations/cloudflare-agents.mdx
@@ -3,7 +3,7 @@ description: "Use MPP with the Cloudflare Agents SDK."
 imageDescription: "Connect Cloudflare Agents to paid MPP MCP tools and HTTP APIs"
 ---
 
-# Cloudflare Agents
+# Cloudflare Agents [Connect agents to paid MCP tools and APIs]
 
 Use [`McpClient.wrap`](/sdk/typescript/client/McpClient.wrap) and [`Mppx.create`](/sdk/typescript/client/Mppx.create) to let a [Cloudflare Agent](https://developers.cloudflare.com/agents/) pay for MCP tools and HTTP requests through MPP. Free calls pass through untouched; when a paid tool or a 402-protected request returns an MPP Challenge, the wrapped client creates a Credential, retries the call, and returns the result.
 

--- a/src/pages/partner-integrations/mcp-sdk.mdx
+++ b/src/pages/partner-integrations/mcp-sdk.mdx
@@ -1,8 +1,9 @@
 ---
 description: "Use MPP with the official TypeScript MCP SDK."
+imageDescription: "Connect MCP clients to paid tools and APIs"
 ---
 
-# Official MCP SDK
+# Official MCP SDK [Add payments to MCP clients]
 
 Use [`Mppx.create`](/sdk/typescript/client/Mppx.create) to let the [official TypeScript MCP SDK](https://github.com/modelcontextprotocol/typescript-sdk) pay for MCP tools and HTTP requests through MPP. Free calls pass through untouched; when a paid tool or a 402-protected request returns an MPP Challenge, the payment-aware fetch wrapper creates a Credential, retries the call, and returns the result.
 

--- a/src/pages/partner-integrations/openclaw.mdx
+++ b/src/pages/partner-integrations/openclaw.mdx
@@ -3,7 +3,7 @@ description: "Use the official MPP plugin to make OpenClaw HTTP requests payment
 imageDescription: "Connect OpenClaw to paid APIs with a scoped Tempo Wallet access key"
 ---
 
-# OpenClaw
+# OpenClaw [Connect OpenClaw to paid APIs]
 
 Install the official [`openclaw-mpp`](https://clawhub.ai/tempoxyz/plugins/openclaw-mpp) plugin from [ClawHub](https://clawhub.ai/) to let an OpenClaw instance call free and paid HTTP APIs through MPP. When a configured wallet receives an MPP Challenge, the plugin creates a Credential, retries the request, and returns the paid response.
 

--- a/src/pages/partner-integrations/vercel-ai-sdk.mdx
+++ b/src/pages/partner-integrations/vercel-ai-sdk.mdx
@@ -1,8 +1,9 @@
 ---
 description: "Use MPP with the Vercel AI SDK."
+imageDescription: "Connect Vercel AI SDK agents to paid tools and APIs"
 ---
 
-# Vercel AI SDK
+# Vercel AI SDK [Add payments to agents and tools]
 
 Use [`Mppx.create`](/sdk/typescript/client/Mppx.create) to let a [Vercel AI SDK agent](https://ai-sdk.dev/docs/agents/overview) pay for MCP tools and HTTP requests through MPP. Free calls pass through untouched; when a paid tool or a 402-protected request returns an MPP Challenge, the wrapped client creates a Credential, retries the call, and returns the result.
 

--- a/src/pages/payment-methods/nearintents/charge.mdx
+++ b/src/pages/payment-methods/nearintents/charge.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Accept one-time cross-chain payments settled by NEAR Intents: the client deposits on its origin chain, the merchant receives an exact amount on its destination chain."
+description: "Accept one-time cross-chain payments through NEAR Intents and settle an exact amount on the merchant's destination chain."
 imageDescription: "One-time cross-chain payments via 1Click deposit addresses"
 ---
 

--- a/src/pages/sdk/typescript/client/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session.mdx
@@ -267,12 +267,6 @@ Function that returns a viem client for the given chain ID.
 
 Maximum deposit in human-readable units. Caps server-suggested channel opens and automatic top-ups.
 
-### topUpAmount (optional)
-
-- **Type:** `string`
-
-Preferred automatic top-up size in human-readable units. When omitted, `mppx` uses a bounded server `suggestedDeposit`, then the exact shortfall.
-
 ### onChannelUpdate (optional)
 
 - **Type:** `(entry: ChannelEntry) => void`
@@ -284,6 +278,12 @@ Called whenever channel state changes.
 - **Type:** `ResolveAccount`
 
 Selects the account that signs this session Credential after the Challenge is known.
+
+### topUpAmount (optional)
+
+- **Type:** `string`
+
+Preferred automatic top-up size in human-readable units. When omitted, `mppx` uses a bounded server `suggestedDeposit`, then the exact shortfall.
 
 ## Credential context
 

--- a/src/pages/sdk/typescript/core/Method.toServer.mdx
+++ b/src/pages/sdk/typescript/core/Method.toServer.mdx
@@ -75,12 +75,6 @@ A server-configured method that can be passed to `Mppx.create`.
 
 ## Parameters
 
-### defaults (optional)
-
-- **Type:** `Partial<request>`
-
-Default request parameters merged into every Challenge issued for this method.
-
 ### method
 
 - **Type:** `Method`
@@ -89,37 +83,47 @@ The base payment method definition (created with `Method.from`).
 
 ### options
 
-### broadcast
+- **Type:** `Method.toServer.Options<method>`
+
+Server defaults and lifecycle callbacks for this payment method.
+
+#### broadcast
 
 - **Type:** `(parameters: { credential: Credential; request: request }) => Promise<Receipt>`
 
 Completes a validated payment and returns its Receipt.
 
-### request (optional)
+#### defaults (optional)
+
+- **Type:** `Partial<request>`
+
+Default request parameters merged into every Challenge issued for this method.
+
+#### request (optional)
 
 - **Type:** `(options: { credential?: Credential; request: request }) => request`
 
 Transform function called before Challenge creation. Use to modify or enrich request parameters.
 
-### respond (optional)
+#### respond (optional)
 
 - **Type:** `(parameters: { credential: Credential; input: Request; receipt: Receipt; request: request }) => Response | undefined`
 
 Called after payment succeeds. Return a `Response` to short-circuit the handler (for example, for channel open/close management responses). Return `undefined` to let the server handler serve content via `withReceipt(response)`. HTTP-only—MCP transports do not invoke this hook.
 
-### transport (optional)
+#### transport (optional)
 
 - **Type:** `Transport`
 
 Override the transport for this method.
 
-### validate (optional)
+#### validate (optional)
 
 - **Type:** `(parameters: { credential: Credential; request: request }) => Promise<Method.Validation>`
 
 Validates a Credential without settling, reserving, broadcasting, or otherwise consuming payment state.
 
-### verify (deprecated)
+#### verify (deprecated)
 
 - **Type:** `(parameters: { credential: Credential; request: request }) => Promise<Receipt>`
 


### PR DESCRIPTION
## Motivation

Restore documentation metadata and heading consistency, and make SDK parameter references match their public call signatures.

## Summary

- add missing social-card descriptions and bracketed H1 taglines
- shorten frontmatter fields to documented limits
- alphabetize Tempo session parameters
- document `Method.toServer` options under the correct parameter hierarchy


## Key design considerations

- keep social-card copy benefit-led and within character limits
- represent `Method.toServer` as `method` plus nested `options`
- preserve existing page content while changing only structure and metadata
