### PR TITLE
docs: add relay integration guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,9 @@ When editing Python or Rust pages, keep the structure aligned with the existing 
 - Python: <https://github.com/tempoxyz/pympp>
 - Rust: <https://github.com/tempoxyz/mpp-rs>
 
-## MPPX documentation sync
+## mppx documentation sync
 
-When updating MPPX interfaces, examples, reference pages, or the `mppx` dependency, review upstream `mppx/main` from the SHA in `.mppx-docs-sync`. After incorporating every relevant public change, update both `mppx_version` and `mppx_sha` in that bookmark to the reviewed upstream HEAD. Do not advance the bookmark before the docs are complete.
+When updating `mppx` interfaces, examples, reference pages, or the `mppx` dependency, review upstream `mppx/main` from the SHA in `.mppx-docs-sync`. After incorporating every relevant public change, update both `mppx_version` and `mppx_sha` in that bookmark to the reviewed upstream HEAD. Do not advance the bookmark before the docs are complete.
 
 ## Be Opinionated
 
@@ -215,6 +215,8 @@ Follow [Stripe's documentation style](https://stripe.com/docs). Key rules:
 **MPP core concepts as proper nouns**: Capitalize Challenge, Credential, and Receipt when referring to these as MPP protocol concepts or SDK types. For example: "Parse a Challenge", "Verify a Credential", "Return a Receipt". These are proper nouns within the MPP domain.
 
 **Terminology**: Use "stablecoins" instead of "crypto" when referring to on-chain payment methods. MPP uses stablecoins (USDC.e, USDT) on Tempo—not generic cryptocurrency. Always use "USDC.e" (not "USDC") when referring to the bridged USDC token on Tempo. The only exception is when referring to Circle's USDC stablecoin in general (not Tempo-specific) contexts.
+
+**`mppx`**: Always write the SDK and package name as lowercase `mppx`, including in prose and headings.
 
 **Session funds terminology**: Never use "escrow" in prose. Use "reserve" for the noun and "reserve" or "lock up" for the verb, depending on context. Only use `escrow` when documenting an actual code identifier, parameter, or contract name that contains that word.
 

--- a/src/components/MermaidDiagram.test.tsx
+++ b/src/components/MermaidDiagram.test.tsx
@@ -248,6 +248,18 @@ sequenceDiagram
     });
   });
 
+  it("parses emphasized messages without exposing the marker", () => {
+    const result = parse(`
+sequenceDiagram
+  A->>B: [!emphasis] Validate Credential
+`);
+
+    expect(result.steps[0]).toMatchObject({
+      emphasized: true,
+      label: "Validate Credential",
+    });
+  });
+
   it("skips comments", () => {
     const src = `
 sequenceDiagram
@@ -455,6 +467,19 @@ sequenceDiagram
     const svg = renderSimple();
     expect(svg).toContain("grad-success");
     expect(svg).toContain("url(#grad-success)");
+  });
+
+  it("renders emphasized messages with a heavier arrow and label", () => {
+    const parsed = parse(`
+sequenceDiagram
+  A->>B: [!emphasis] Finalize Credential
+`);
+    const svg = render(doLayout(parsed), th);
+
+    expect(svg).toMatch(/data-step="0"[\s\S]*stroke-width="2.4"/);
+    expect(svg).toMatch(
+      /data-step-label="0"[\s\S]*font-weight="600"[\s\S]*Finalize Credential/,
+    );
   });
 
   it("renders notes with data-step-note attributes", () => {

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -114,6 +114,7 @@ export type Step =
       label: string;
       num: string | null;
       dashed: boolean;
+      emphasized?: boolean;
     }
   | { type: "note"; over: string; text: string; num: string | null }
   | { type: "loop-start"; label: string }
@@ -178,13 +179,15 @@ export function parse(source: string): ParsedDiagram {
       ensure(mMsg[1]);
       ensure(mMsg[3]);
       const e = extractNum(mMsg[4].trim());
+      const emphasized = e.rest.startsWith("[!emphasis]");
       steps.push({
         type: "message",
         from: mMsg[1],
         to: mMsg[3],
-        label: e.rest,
+        label: emphasized ? e.rest.replace(/^\[!emphasis\]\s*/, "") : e.rest,
         num: e.num,
         dashed: mMsg[2] === "-->>",
+        ...(emphasized ? { emphasized: true } : {}),
       });
     }
   }
@@ -204,6 +207,7 @@ export interface LMsg {
   labelX: number;
   labelY: number;
   dashed: boolean;
+  emphasized?: boolean;
   si: number;
   isLast: boolean;
 }
@@ -309,6 +313,7 @@ export function doLayout(p: ParsedDiagram): Layout {
         labelX: (cx[fi] + cx[ti]) / 2,
         labelY: y - L.labelLineGap,
         dashed: s.dashed,
+        emphasized: s.emphasized,
         si,
         isLast: msgIdx === totalMsgs,
       });
@@ -600,7 +605,7 @@ export function render(
         '" stroke="' +
         lineStroke +
         '" stroke-width="' +
-        L.messageStroke +
+        (m.emphasized ? L.messageStroke * 2 : L.messageStroke) +
         '"' +
         da +
         "/>",
@@ -628,7 +633,9 @@ export function render(
         arrowFill +
         '" stroke="' +
         arrowStroke +
-        '" stroke-width="1.2" stroke-linejoin="round"/>',
+        '" stroke-width="' +
+        (m.emphasized ? "2.4" : "1.2") +
+        '" stroke-linejoin="round"/>',
     );
 
     // Compute label text width to place badge to its left
@@ -682,7 +689,7 @@ export function render(
         '" text-anchor="middle" dy="0.35em" font-size="' +
         L.labelFontSize +
         '" font-weight="' +
-        L.labelFontWeight +
+        (m.emphasized ? "600" : L.labelFontWeight) +
         '" fill="' +
         th.textMuted +
         '">' +

--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -11,6 +11,7 @@ type Page =
   | { path: '/advanced/identity'; render: 'static' }
   | { path: '/advanced/payment-hooks'; render: 'static' }
   | { path: '/advanced/refunds'; render: 'static' }
+  | { path: '/advanced/relays'; render: 'static' }
   | { path: '/advanced/security'; render: 'static' }
   | { path: '/blog/evm-x402-support'; render: 'static' }
   | { path: '/blog/go-and-ruby-sdks'; render: 'static' }

--- a/src/pages/advanced/relays.mdx
+++ b/src/pages/advanced/relays.mdx
@@ -1,0 +1,129 @@
+---
+description: "Delegate MPP payment validation and finalization to a relay service."
+imageDescription: "Delegate payment finalization to a relay"
+---
+
+import { MermaidDiagram } from '../../components/MermaidDiagram'
+
+# Relays [Delegate payment verification and broadcast]
+
+Relays are optional infrastructure that lets MPP-enabled services verify and settle payments behind a simple API.
+
+Relays let you support multiple payment methods and centralize capabilities such as risk management and reporting.
+
+## How relays work
+
+Relays sit between your application and the payment-method settlement layer, giving your application a consistent payment-method-agnostic interface.
+
+<MermaidDiagram chart={`sequenceDiagram
+    participant Client
+    participant API as Your API
+    participant Relay
+    participant Tempo as Settlement layer
+    Client->>API: Request
+    API-->>Client: 402 + Challenge
+    Client->>API: Retry + Credential
+    API->>Relay: [!emphasis] Validate Credential
+    Relay-->>API: Accepted
+    API->>Relay: [!emphasis] Finalize Credential
+    Relay->>Tempo: Broadcast transaction
+    Tempo-->>Relay: Confirmed transaction
+    Relay-->>API: Receipt
+    API-->>Client: 200 + Receipt
+`} />
+
+The relay flow has two lifecycle hooks:
+
+- `validate` (optional) checks whether a Credential is valid for the underlying payment rail. It does not reserve funds or make state changes.
+- `broadcast` submits a transaction to the underlying payment rail after performing the same validity checks as `validate`.
+
+MPP does not define a relay API shape or require functionality beyond these hooks. Relay authors can design and evolve their APIs as their offerings grow.
+
+## Use a relay in your application
+
+Relays preserve the core MPP control flow, so your service works the same with or without one.
+
+### Server integration
+
+Use `mppx`'s built-in `validate` and `broadcast` hooks to call a relay service.
+
+This example calls a networked relay from `validate` and `broadcast` instead of handling payment state locally, and assumes `relay` is an authenticated server-side client.
+
+```ts [methods.server.ts]
+import { Method, Receipt } from 'mppx'
+import * as Methods from './methods'
+
+export const charge = Method.toServer(Methods.charge, {
+  async validate({ credential, request }) {
+    const result = await relay.validate({ credential, request }) // [!code hl]
+    if (!result.accepted) throw new Error('Payment was rejected')
+
+    return {
+      challenge: credential.challenge,
+      credential,
+      details: result.details,
+      intent: credential.challenge.intent,
+      method: credential.challenge.method,
+      request,
+    }
+  },
+  async broadcast({ credential, request }) {
+    const result = await relay.finalize({ credential, request }) // [!code hl]
+
+    return Receipt.from({
+      method: credential.challenge.method,
+      reference: result.reference,
+      status: 'success',
+      timestamp: result.timestamp,
+    })
+  },
+})
+```
+
+### Use Tempo API
+
+If your application settles MPP charges on Tempo, use the [Tempo API](https://tempo.xyz/developers/docs/api/mpp) relay to validate and broadcast transactions.
+
+```ts twoslash [server.ts]
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.charge({
+      // [!code hl:start]
+      relay: {
+        apiKey: process.env.TEMPO_API_KEY!,
+      },
+      // [!code hl:end]
+    }),
+  ],
+})
+```
+
+For a Tempo API-compatible relay, set `apiBaseUrl` on `relay`.
+
+```ts twoslash [server.ts]
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.charge({
+      relay: {
+        apiBaseUrl: 'https://mpp.relay.com/tempo',
+        apiKey: process.env.TEMPO_API_KEY!,
+      },
+    }),
+  ],
+})
+```
+
+The default API base URL is `https://api.tempo.xyz`. You can also provide `fetch` in `relay` when your runtime needs a custom fetch implementation.
+
+## Author a relay
+
+MPP does not formally define relays. It leaves payment methods, API shapes, and transports such as HTTP, JSON-RPC, and gRPC to you.
+
+For a consistent integration experience, implement at least these hooks:
+
+- `validate` (optional) checks whether a Credential is valid for the underlying payment rail. It does not reserve funds or make state changes.
+- `broadcast` submits a transaction to the underlying payment rail after performing the same validity checks as `validate`.

--- a/src/pages/sdk/typescript/core/Method.toServer.mdx
+++ b/src/pages/sdk/typescript/core/Method.toServer.mdx
@@ -1,6 +1,6 @@
 # `Method.toServer` [Extend a method with server payment handling]
 
-Extends a payment method with server-side validation and broadcast logic.
+Extends a payment method with server-side validation and payment-finalization hooks.
 
 ## Usage
 
@@ -73,6 +73,12 @@ type ReturnType = Method.Server<method, defaults, transportOverride>
 
 A server-configured method that can be passed to `Mppx.create`.
 
+## Payment lifecycle
+
+Implement `validate` and `broadcast` for new server methods. `mppx` runs `validate` before the terminal `broadcast` hook. `validate` is a non-mutating pre-check; `broadcast` must revalidate its state before it reserves, signs, broadcasts, or otherwise accepts payment.
+
+Use this split when a method calls a relay or needs to apply policy between a Credential check and payment acceptance. `verify` is the deprecated combined hook for older methods and cannot be combined with `broadcast`.
+
 ## Parameters
 
 ### defaults (optional)
@@ -93,7 +99,7 @@ The base payment method definition (created with `Method.from`).
 
 - **Type:** `(parameters: { credential: Credential; request: request }) => Promise<Receipt>`
 
-Completes a validated payment and returns its Receipt.
+Completes payment and returns its Receipt. Revalidate any external or on-chain state before the terminal operation, because a previous `validate` result is advisory.
 
 ### request (optional)
 

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -96,7 +96,7 @@ const mppx = Mppx.create({
 
 ### With Tempo API relay
 
-Delegate Tempo charge validation and broadcast to Tempo API. The relay preserves this method's Challenge configuration and needs an API key with the `mpp:write` scope.
+Delegate Tempo charge validation and finalization to Tempo API. The relay preserves this method's Challenge configuration and needs an API key with the `mpp:write` scope. It broadcasts `pull` Credentials and recognizes `push` Credentials as already broadcast.
 
 ```ts twoslash
 import { Mppx, tempo } from 'mppx/server'
@@ -111,6 +111,8 @@ const mppx = Mppx.create({
   ],
 })
 ```
+
+See [Relays](/advanced/relays) for the lifecycle, custom API base URLs, and custom `validate` and `broadcast` hooks.
 
 ### With replay protection for zero-dollar auth
 
@@ -222,7 +224,7 @@ On-chain memo for the transaction.
 
 - **Type:** `{ apiBaseUrl?: string; apiKey: string; fetch?: typeof globalThis.fetch }`
 
-Delegates Tempo charge Credential validation and broadcast to Tempo API or a compatible MPP relay. `apiKey` needs the `mpp:write` scope. Defaults to `https://api.tempo.xyz`; set `apiBaseUrl` for a compatible relay.
+Delegates Tempo charge Credential validation and finalization to a compatible MPP relay. `apiKey` needs the `mpp:write` scope. Defaults to `https://api.tempo.xyz`; set `apiBaseUrl` for a compatible relay, including one behind a path prefix. The relay broadcasts `pull` Credentials and verifies `push` Credential hashes without broadcasting them again.
 
 ### store (optional)
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -396,6 +396,7 @@ export default defineConfig({
       {
         text: "Advanced Features",
         items: [
+          { text: "Relays", link: "/advanced/relays" },
           { text: "Discovery", link: "/advanced/discovery" },
           { text: "Identity", link: "/advanced/identity" },
           { text: "Payment hooks", link: "/advanced/payment-hooks" },


### PR DESCRIPTION
## Motivation

Document relay-based payment validation and finalization for mppx users and relay authors.

## Summary

- Add a Relays advanced-feature guide
- Document validate and broadcast lifecycle hooks
- Add Tempo API relay configuration and reference updates

## Key design considerations

- Lead with generic relay hooks, then the Tempo-specific implementation
- Keep the sequence diagram focused on one settlement exchange