### PR TITLE
docs: announce relay integrations

### DIFF
--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -21,6 +21,7 @@ type Page =
   | { path: '/blog/mppx-agent-runtimes'; render: 'static' }
   | { path: '/blog/multi-method-discovery'; render: 'static' }
   | { path: '/blog/payment-hooks'; render: 'static' }
+  | { path: '/blog/relays'; render: 'static' }
   | { path: '/blog/sessions-improved'; render: 'static' }
   | { path: '/blog/subscriptions'; render: 'static' }
   | { path: '/brand'; render: 'static' }

--- a/src/pages/blog/relays.mdx
+++ b/src/pages/blog/relays.mdx
@@ -1,0 +1,74 @@
+---
+layout: minimal
+title: "Simplify MPP integrations with relays"
+outline: false
+showAskAi: false
+showFeedback: false
+showSearch: false
+description: "Delegate MPP payment validation and settlement without changing your application's payment flow."
+imageDescription: "Delegate MPP payment validation and settlement"
+publishedAt: "2026-07-27"
+---
+
+# Simplify MPP integrations with relays [Delegate payment validation and settlement]
+
+`mppx` now supports relays. A relay is a networked interface that abstracts payment-method settlement away from your application.
+
+## What a relay does
+
+A relay sits between your application and the payment settlement layer. It handles two lifecycle operations:
+
+- `validate` checks whether a Credential can be accepted without consuming it or changing payment state.
+- `broadcast` revalidates the Credential, submits the payment, and returns the information needed to create a Receipt.
+
+This gives applications one interface for payment finalization while relay operators handle the details of each payment method.
+
+## Add a relay
+
+### Tempo charges
+
+Pass a Tempo API key to `tempo.charge`. `mppx` sends Credential validation and broadcast requests to Tempo API:
+
+```ts twoslash [server.ts]
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.charge({
+      relay: {
+        apiKey: process.env.TEMPO_API_KEY!,
+      },
+    }),
+  ],
+})
+```
+
+You can point the same integration at a Tempo API-compatible service with `relay.apiBaseUrl`.
+
+### Any payment method
+
+For any payment method, connect your relay to the `validate` and `broadcast` hooks with `Method.toServer`:
+
+```ts [method.server.ts]
+import { Method } from 'mppx'
+import { charge } from './method'
+
+export const chargeServer = Method.toServer(charge, {
+  async broadcast({ credential, request }) {
+    return relay.broadcast({ credential, request })
+  },
+  async validate({ credential, request }) {
+    return relay.validate({ credential, request })
+  },
+})
+```
+
+## Author a relay
+
+MPP does not require a relay or standardize its API. Relay authors can choose their payment methods, policy, and transport.
+
+Implement a non-mutating `validate` operation and a terminal `broadcast` operation. Because conditions can change after validation, `broadcast` must repeat the relevant checks before it settles or accepts payment.
+
+## Learn more
+
+- [Relay integration guide](/advanced/relays)

--- a/src/pages/blog/relays.mdx
+++ b/src/pages/blog/relays.mdx
@@ -10,54 +10,56 @@ imageDescription: "Delegate MPP payment validation and settlement"
 publishedAt: "2026-07-27"
 ---
 
-# Simplify MPP integrations with relays [Delegate payment validation and settlement]
+# Simplify MPP integrations with relays [Delegate payment validation and settlement to an external service]
 
-`mppx` now supports relays. A relay is a networked interface that abstracts payment-method settlement away from your application.
+`mppx` now supports relays. A relay is a networked interface that abstracts payment-method settlement away from your application, reducing integration complexity and giving you new capabilities.
 
 ## What a relay does
 
 A relay sits between your application and the payment settlement layer. It handles two lifecycle operations:
 
-- `validate` checks whether a Credential can be accepted without consuming it or changing payment state.
-- `broadcast` revalidates the Credential, submits the payment, and returns the information needed to create a Receipt.
+- Validation checks whether a payment Credential is valid and can be accepted by the underlying payment rail.
+- `broadcast` revalidates the payment Credential, finalizes or accepts payment, and returns the information needed to create a Receipt.
 
-This gives applications one interface for payment finalization while relay operators handle the details of each payment method.
+Relays give applications one interface for payment finalization while relay operators handle the details of each payment method.
 
 ## Add a relay
 
 ### Tempo charges
 
-Pass a Tempo API key to `tempo.charge`. `mppx` sends Credential validation and broadcast requests to Tempo API:
+Pass a Tempo API key to `tempo.charge`. Your `mppx` integration automatically uses the Tempo relay.
 
 ```ts twoslash [server.ts]
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
   methods: [
+    // [!code hl:start]
     tempo.charge({
       relay: {
         apiKey: process.env.TEMPO_API_KEY!,
       },
     }),
+    // [!code hl:end]
   ],
 })
 ```
 
 You can point the same integration at a Tempo API-compatible service with `relay.apiBaseUrl`.
 
-### Any payment method
+### Other payment methods
 
-For any payment method, connect your relay to the `validate` and `broadcast` hooks with `Method.toServer`:
+For any other payment method, connect your relay to the `validate` and `broadcast` hooks with `Method.toServer`:
 
 ```ts [method.server.ts]
 import { Method } from 'mppx'
 import { charge } from './method'
 
 export const chargeServer = Method.toServer(charge, {
-  async broadcast({ credential, request }) {
+  async broadcast({ credential, request }) { // [!code hl]
     return relay.broadcast({ credential, request })
   },
-  async validate({ credential, request }) {
+  async validate({ credential, request }) { // [!code hl]
     return relay.validate({ credential, request })
   },
 })
@@ -65,9 +67,7 @@ export const chargeServer = Method.toServer(charge, {
 
 ## Author a relay
 
-MPP does not require a relay or standardize its API. Relay authors can choose their payment methods, policy, and transport.
-
-Implement a non-mutating `validate` operation and a terminal `broadcast` operation. Because conditions can change after validation, `broadcast` must repeat the relevant checks before it settles or accepts payment.
+MPP does not require relays or require them to conform to a single interface. Relay authors can define their own API shape, payment method support, and underlying functionality—as long as they preserve the core MPP control flow.
 
 ## Learn more
 

--- a/src/pages/blog/relays.mdx
+++ b/src/pages/blog/relays.mdx
@@ -7,7 +7,7 @@ showFeedback: false
 showSearch: false
 description: "Delegate MPP payment validation and settlement without changing your application's payment flow."
 imageDescription: "Delegate MPP payment validation and settlement"
-publishedAt: "2026-07-27"
+publishedAt: "2026-08-03"
 ---
 
 # Simplify MPP integrations with relays [Delegate payment validation and settlement to an external service]


### PR DESCRIPTION
## Motivation

Introduce relays and show developers how to delegate payment-method settlement from an MPP application.

## Summary

- Add a concise relay announcement to the MPP blog
- Add the announcement to the blog index

## Key design considerations

- Present relays as payment-method agnostic infrastructure
- Show both Tempo charge configuration and generic `Method.toServer` hooks
- Link to the relay integration guide for the complete reference