### PR TITLE
fix: unify docs layout and blog listings

### DIFF
--- a/scripts/remark-mpp-markdown.mjs
+++ b/scripts/remark-mpp-markdown.mjs
@@ -1,3 +1,5 @@
+import blogPosts from "../src/data/blog.json" with { type: "json" };
+
 /**
  * Replaces interactive documentation components with semantic Markdown nodes.
  *
@@ -82,7 +84,11 @@ function transformTabs(node, headingDepth) {
 }
 
 function blogPostList(node) {
-  const posts = requiredArray(node, "posts");
+  const hasPosts = node.attributes.some(
+    (attribute) =>
+      attribute.type === "mdxJsxAttribute" && attribute.name === "posts",
+  );
+  const posts = hasPosts ? requiredArray(node, "posts") : blogPosts;
   return {
     type: "list",
     ordered: false,

--- a/scripts/remark-mpp-markdown.test.mjs
+++ b/scripts/remark-mpp-markdown.test.mjs
@@ -53,6 +53,13 @@ function paragraph(children) {
 }
 
 describe("remarkMppMarkdown", () => {
+  it("renders the shared blog posts when posts are omitted", () => {
+    const [list] = transform([flow("BlogPostList")]).children;
+
+    expect(list.type).toBe("list");
+    expect(list.children).toHaveLength(7);
+  });
+
   it("replaces every audited component with semantic Markdown", () => {
     const tree = {
       type: "root",

--- a/src/components/BlogPostList.tsx
+++ b/src/components/BlogPostList.tsx
@@ -1,24 +1,14 @@
 "use client";
 
 import { Link } from "vocs";
-
-type BlogPost = {
-  date: string;
-  description: React.ReactNode;
-  title: string;
-  to: string;
-};
-
-function formatDate(date: string) {
-  return date.replace(/^[A-Za-z]+,\s*/, "");
-}
+import { BLOG_POSTS, type BlogPost, formatBlogPostDate } from "../data/blog";
 
 function BlogPostRow({ date, description, title, to }: BlogPost) {
   return (
     <Link className="blog-post-row" to={to}>
       <div className="blog-post-row-title">
         <h2>{title}</h2>
-        <p>{formatDate(date)}</p>
+        <p>{formatBlogPostDate(date)}</p>
       </div>
       <div className="blog-post-row-description">{description}</div>
       <span aria-hidden="true" className="blog-post-row-arrow">
@@ -41,7 +31,11 @@ function BlogPostRow({ date, description, title, to }: BlogPost) {
   );
 }
 
-export function BlogPostList({ posts }: { posts: BlogPost[] }) {
+export function BlogPostList({
+  posts = BLOG_POSTS,
+}: {
+  posts?: readonly BlogPost[];
+}) {
   return (
     <div className="blog-post-list">
       {posts.map((post) => (

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { BLOG_POSTS, formatBlogPostDate } from "../data/blog";
 import {
   type FeaturedService,
   fetchFeaturedServices,
@@ -29,44 +30,6 @@ const Link = lazy(async () => {
 }) as ComponentType<LinkProps>;
 
 const FEATURED_SERVICE_IDS = ["anthropic", "openai", "parallel", "fal"];
-
-const BLOG_POSTS = [
-  {
-    date: "June 17, 2026",
-    description:
-      "Pay-as-you-go API billing is now cheaper and easier to integrate.",
-    title: "An improved sessions experience",
-    to: "/blog/sessions-improved",
-  },
-  {
-    date: "June 8, 2026",
-    description:
-      "MPP now supports generic EVM payments and x402 exact flows from one SDK.",
-    title: "EVM and x402 support",
-    to: "/blog/evm-x402-support",
-  },
-  {
-    date: "May 21, 2026",
-    description:
-      "Core SDKs now expose typed payment hooks for logging and request context.",
-    title: "Payment hooks",
-    to: "/blog/payment-hooks",
-  },
-  {
-    date: "May 12, 2026",
-    description:
-      "Enable recurring access for paid plans, memberships, and API tiers.",
-    title: "Subscriptions",
-    to: "/blog/subscriptions",
-  },
-  {
-    date: "April 28, 2026",
-    description:
-      "Declare every payment method, currency, and intent for a route ahead of time.",
-    title: "Multi-method discovery",
-    to: "/blog/multi-method-discovery",
-  },
-];
 
 const INTEGRATION_LOGOS = [
   "amazon",
@@ -291,11 +254,11 @@ export function LandingPage() {
           </h2>
         </div>
         <div className="marketing-blog-list">
-          {BLOG_POSTS.map((post) => (
+          {BLOG_POSTS.slice(0, 5).map((post) => (
             <Link className="marketing-blog-row" key={post.to} to={post.to}>
               <div className="marketing-blog-row-title">
                 <h3>{post.title}</h3>
-                <p>{post.date}</p>
+                <p>{formatBlogPostDate(post.date)}</p>
               </div>
               <p className="marketing-blog-row-description">
                 {post.description}

--- a/src/data/blog.json
+++ b/src/data/blog.json
@@ -1,0 +1,44 @@
+[
+  {
+    "date": "Monday, July 27, 2026",
+    "description": "New mppx hooks connect agent runtimes to paid tools and HTTP services through MPP.",
+    "title": "mppx for agent SDKs and harnesses",
+    "to": "/blog/mppx-agent-runtimes"
+  },
+  {
+    "date": "Wednesday, June 17, 2026",
+    "description": "Pay-as-you-go API billing is now cheaper and easier to integrate.",
+    "title": "An improved sessions experience",
+    "to": "/blog/sessions-improved"
+  },
+  {
+    "date": "Monday, June 8, 2026",
+    "description": "MPP now supports generic EVM payments and x402 exact flows from one SDK.",
+    "title": "EVM and x402 support",
+    "to": "/blog/evm-x402-support"
+  },
+  {
+    "date": "Thursday, May 21, 2026",
+    "description": "Core SDKs now expose typed payment hooks for logging, monitoring, and request context.",
+    "title": "Payment hooks",
+    "to": "/blog/payment-hooks"
+  },
+  {
+    "date": "Tuesday, May 12, 2026",
+    "description": "Enable recurring access for paid plans, memberships, and API tiers.",
+    "title": "Subscriptions",
+    "to": "/blog/subscriptions"
+  },
+  {
+    "date": "Tuesday, April 28, 2026",
+    "description": "Declare every payment method, currency, and intent for a route ahead of time.",
+    "title": "Multi-method discovery",
+    "to": "/blog/multi-method-discovery"
+  },
+  {
+    "date": "Tuesday, April 21, 2026",
+    "description": "Two new MPP SDKs: mpp-go maintained by Tempo Labs and mpp-rb maintained by Stripe.",
+    "title": "Go and Ruby SDKs",
+    "to": "/blog/go-and-ruby-sdks"
+  }
+]

--- a/src/data/blog.test.ts
+++ b/src/data/blog.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { BLOG_POSTS, formatBlogPostDate } from "./blog";
+
+describe("BLOG_POSTS", () => {
+  it("contains unique posts in reverse chronological order", () => {
+    const routes = BLOG_POSTS.map((post) => post.to);
+    const timestamps = BLOG_POSTS.map((post) => Date.parse(post.date));
+
+    expect(new Set(routes).size).toBe(routes.length);
+    expect(timestamps).toEqual([...timestamps].sort((a, b) => b - a));
+  });
+});
+
+describe("formatBlogPostDate", () => {
+  it("removes the weekday", () => {
+    expect(formatBlogPostDate("Monday, July 27, 2026")).toBe("July 27, 2026");
+  });
+});

--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -1,0 +1,14 @@
+import posts from "./blog.json";
+
+export type BlogPost = {
+  date: string;
+  description: string;
+  title: string;
+  to: string;
+};
+
+export const BLOG_POSTS: readonly BlogPost[] = posts;
+
+export function formatBlogPostDate(date: string) {
+  return date.replace(/^[A-Za-z]+,\s*/, "");
+}

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -2574,6 +2574,11 @@ body {
   background: var(--mpp-canvas);
 }
 
+[data-v-surface-bg],
+[data-v-outline-mobile] {
+  background: var(--mpp-canvas) !important;
+}
+
 [data-layout="minimal"] {
   background: #101010 !important;
 }

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -2579,6 +2579,10 @@ body {
   background: var(--mpp-canvas) !important;
 }
 
+[data-v-surface-bg] {
+  width: calc(100vw - var(--vocs-spacing-gutter)) !important;
+}
+
 [data-layout="minimal"] {
   background: #101010 !important;
 }

--- a/src/pages/blog/index.mdx
+++ b/src/pages/blog/index.mdx
@@ -27,54 +27,5 @@ import { BlogPostList } from "../../components/BlogPostList";
 
 <div className="blog-index-content">
   <h2>See Updates</h2>
-  <BlogPostList posts={[
-  {
-    date: "Monday, July 27, 2026",
-    title: "mppx for agent SDKs and harnesses",
-    description: <>New mppx hooks connect agent runtimes to paid tools and HTTP services through MPP.</>,
-    to: "/blog/mppx-agent-runtimes",
-  },
-    {
-      date: "Wednesday, June 17, 2026",
-      title: "An improved sessions experience",
-      description: <>Pay-as-you-go API billing is now cheaper and easier to integrate.</>,
-      to: "/blog/sessions-improved",
-    },
-    {
-      date: "Wednesday, June 17, 2026",
-      title: "An improved sessions experience",
-      description: <>Pay-as-you-go API billing is now cheaper and easier to integrate.</>,
-      to: "/blog/sessions-improved",
-    },
-    {
-      date: "Monday, June 8, 2026",
-      title: "EVM and x402 support",
-      description: <>MPP now supports generic EVM payments and x402 exact flows from one SDK.</>,
-      to: "/blog/evm-x402-support",
-    },
-    {
-      date: "Thursday, May 21, 2026",
-      title: "Payment hooks",
-      description: <>Core SDKs now expose typed payment hooks for logging, monitoring, and request context.</>,
-      to: "/blog/payment-hooks",
-    },
-    {
-      date: "May 12, 2026",
-      title: "Subscriptions",
-      description: <>Enabling recurring access for paid plans, memberships, and API tiers.</>,
-      to: "/blog/subscriptions",
-    },
-    {
-      date: "Apr 28, 2026",
-      title: "Multi-method discovery",
-      description: <>MPP's discovery schema now supports multiple payment offers per route—declare every method, currency, and intent ahead of time.</>,
-      to: "/blog/multi-method-discovery",
-    },
-    {
-      date: "Apr 21, 2026",
-      title: "Go and Ruby SDKs",
-      description: <>Two new MPP SDKs: <code>mpp-go</code> maintained by Tempo Labs and <code>mpp-rb</code> maintained by Stripe.</>,
-      to: "/blog/go-and-ruby-sdks",
-    },
-  ]} />
+  <BlogPostList />
 </div>


### PR DESCRIPTION
## Motivation

The docs layout mixes dark canvas colors and lets the fixed surface extend past the viewport. The homepage and blog index also maintain separate post lists that drift out of sync.

## Summary

- Use one canvas color across docs surfaces
- Bound the docs surface to the available viewport width
- Share one reverse-chronological blog post source across both lists
- Remove the duplicate blog entry and include the latest post
- Preserve semantic Markdown output for the shared blog list

## Key design considerations

- Keep elevated controls and cards visually distinct from the canvas
- Use the Vocs gutter token so the surface follows framework breakpoints
- Show the five latest posts on the homepage and the full list on `/blog`