### PR TITLE
fix: match homepage footer canvas

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -378,6 +378,7 @@ function LandingStyles() {
         backdrop-filter: blur(14px);
         -webkit-backdrop-filter: blur(14px);
       }
+      :has(.landing-page) [data-v-footer] { background: #060606 !important; }
 
       .landing-page {
         --marketing-bg: #060606;


### PR DESCRIPTION
## Motivation

The homepage footer inherits the docs canvas color, creating a visible seam against the darker homepage.

## Summary

- Apply the homepage `#060606` canvas color to its footer

## Key design considerations

- Keep the change scoped to pages containing the homepage
- Preserve the existing homepage and header colors
- Leave docs, blog, and services on the shared `#101010` canvas