### PR TITLE
feat: add Reletter MPP service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11167,4 +11167,44 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+  // ── Reletter ────────────────────────────────────────────────────────
+  {
+    id: "reletter",
+    name: "Reletter",
+    url: "https://reletter.com",
+    serviceUrl: "https://api.reletter.com",
+    description:
+      "Newsletter data API for apps, agents, and outreach tools. Search 7M+ newsletters and full-text archives with subscriber numbers, contacts, rankings, and audience data.",
+    categories: ["data", "search"],
+    integration: "first-party",
+    tags: [
+      "newsletters",
+      "email",
+      "search",
+      "contacts",
+      "audience-data",
+      "marketing",
+      "research",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://reletter.com",
+      llmsTxt: "https://reletter.com/llms.txt",
+      apiReference: "https://api.reletter.com/openapi.json",
+    },
+    provider: { name: "Reletter", url: "https://reletter.com" },
+    realm: "api.reletter.com",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT, STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /api/payments/buy/",
+        desc: "Purchase a Reletter API request bundle and receive an API key",
+        dynamic: true,
+        amountHint: "Varies by request bundle",
+        unitType: "request bundle",
+        docs: "https://reletter.com/llms-full.txt",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
Adds Reletter as a first-party MPP service.

Reletter is the newsletter data API for apps, agents, and outreach tools. Search 7M+ Substack, LinkedIn, Ghost, Beehiiv, and Kit newsletters; retrieve subscriber numbers, contacts, full-text posts, rankings, and audience data; and monitor mentions in near real time. Use it via REST, Python/CLI, or the remote MCP server. Agents can buy request bundles programmatically through HTTP 402 using MPP, with no browser signup required.

- Homepage: https://reletter.com
- MPP endpoint: https://api.reletter.com/api/payments/buy/
- Payment methods: Tempo and Stripe
- Documentation: https://reletter.com/llms.txt
- OpenAPI: https://api.reletter.com/openapi.json