### PR TITLE
fix: preserve site layout on blog pages

### DIFF
--- a/src/pages/blog/_mdx-wrapper.tsx
+++ b/src/pages/blog/_mdx-wrapper.tsx
@@ -1,6 +1,11 @@
 import type { ReactNode } from "react";
+import { Layout } from "vocs";
 import { BlogPostLayout } from "../../components/BlogPostLayout.js";
 
 export default function BlogWrapper({ children }: { children: ReactNode }) {
-  return <BlogPostLayout>{children}</BlogPostLayout>;
+  return (
+    <Layout>
+      <BlogPostLayout>{children}</BlogPostLayout>
+    </Layout>
+  );
 }


### PR DESCRIPTION
## Summary

- Preserve the shared Vocs page shell around blog-specific MDX content.
- Restore the desktop header and mobile navigation across `/blog` and blog post routes.

## Verification

- `pnpm check:types`
- `pnpm exec vitest run src/components/Blog.test.tsx`
- `MPP_SECRET_KEY=<local test value> pnpm build`
- Browser-verified `/blog` at desktop and mobile widths, including the mobile menu.

Prompted by: parv