### PR TITLE
revert: restore intentional blog layout

### DIFF
--- a/src/pages/blog/_mdx-wrapper.tsx
+++ b/src/pages/blog/_mdx-wrapper.tsx
@@ -1,11 +1,6 @@
 import type { ReactNode } from "react";
-import { Layout } from "vocs";
 import { BlogPostLayout } from "../../components/BlogPostLayout.js";
 
 export default function BlogWrapper({ children }: { children: ReactNode }) {
-  return (
-    <Layout>
-      <BlogPostLayout>{children}</BlogPostLayout>
-    </Layout>
-  );
+  return <BlogPostLayout>{children}</BlogPostLayout>;
 }


### PR DESCRIPTION
## Summary

- Revert #835.
- Restore the intentional blog layout without the shared site header.

Prompted by: parv