### PR TITLE
perf: speed up blog and services navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ src/generated/
 # Generated from schemas/services.ts — run `pnpm generate:discovery` to rebuild
 schemas/discovery.json
 schemas/discovery.example.json
+public/services/catalog.json
 public/services/llms.txt
 
 # Licensed font files (served via Vercel Blob in production)

--- a/scripts/generate-discovery.ts
+++ b/scripts/generate-discovery.ts
@@ -1,6 +1,5 @@
 /**
- * Generates schemas/discovery.json (full) and schemas/discovery.example.json (slim)
- * from schemas/services.ts.
+ * Generates the service catalog, schemas, and llms.txt from schemas/services.ts.
  *
  * Usage: node scripts/generate-discovery.ts
  */
@@ -22,6 +21,10 @@ const OUTPUT_EXAMPLE = resolve(SCHEMAS_DIR, "discovery.example.json");
 const OUTPUT_LLMS_TXT = resolve(
   import.meta.dirname,
   "../public/services/llms.txt",
+);
+const OUTPUT_PUBLIC_CATALOG = resolve(
+  import.meta.dirname,
+  "../public/services/catalog.json",
 );
 
 /** Services included in the slim example (covers fixed, dynamic, free, and mixed intents) */
@@ -221,6 +224,7 @@ export function buildService(svc: ServiceDef): Record<string, unknown> {
 }
 
 function writeJson(path: string, data: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
 }
 
@@ -286,6 +290,9 @@ function generate(): void {
   // Full registry (checked in, used by API)
   writeJson(OUTPUT_FULL, { version: 1, services: allBuilt });
 
+  // Static catalog used by the services UI to avoid a serverless cold start.
+  writeJson(OUTPUT_PUBLIC_CATALOG, { version: 1, services: allBuilt });
+
   // Slim example (checked in, used by schema tests)
   const exampleServices = allBuilt.filter((s) =>
     EXAMPLE_IDS.has(s.id as string),
@@ -312,6 +319,9 @@ function generate(): void {
   }
   console.log(
     `Generated ${OUTPUT_FULL} (${services.length} services, ${totalEps} endpoints)`,
+  );
+  console.log(
+    `Generated ${OUTPUT_PUBLIC_CATALOG} (${services.length} services)`,
   );
   console.log(
     `Generated ${OUTPUT_EXAMPLE} (${exampleServices.length} services)`,

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -381,7 +381,12 @@ function ServiceCard({ service }: { service: FeaturedService }) {
   return (
     <article className="marketing-service-card">
       <div className="marketing-service-card-header">
-        <img alt="" src={serviceIconUrl(service)} />
+        <img
+          alt=""
+          decoding="async"
+          loading="lazy"
+          src={serviceIconUrl(service)}
+        />
         <div>
           <h3>{service.name}</h3>
           <span>{category}</span>

--- a/src/components/ServiceDiscovery.tsx
+++ b/src/components/ServiceDiscovery.tsx
@@ -750,13 +750,15 @@ export function ServiceDiscovery({
                 >
                   {iconUrl && !brokenIcons.current.has(service.id) ? (
                     <img
-                      src={iconUrl}
                       alt=""
                       className="discovery-card-icon-img"
+                      decoding="async"
+                      loading="lazy"
                       onError={() => {
                         brokenIcons.current.add(service.id);
                         forceIconUpdate((n) => n + 1);
                       }}
+                      src={iconUrl}
                     />
                   ) : (
                     <div className="discovery-card-icon-fallback">

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -3184,12 +3184,14 @@ function ServiceIcon({ service: s }: { service: Service }) {
     >
       {s.id && !imgError ? (
         <img
-          src={serviceIconUrl(s)}
           alt=""
-          width={36}
-          height={36}
           className="svc-icon-img"
+          decoding="async"
+          height={36}
+          loading="lazy"
           onError={() => setImgError(true)}
+          src={serviceIconUrl(s)}
+          width={36}
         />
       ) : (
         <FallbackIcon name={s.name} />

--- a/src/data/registry.test.ts
+++ b/src/data/registry.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function createStorage() {
+  const entries = new Map<string, string>();
+  return {
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => entries.set(key, value),
+  };
+}
+
+function service(id: string, name = id) {
+  return {
+    endpoints: [],
+    id,
+    methods: {},
+    name,
+    url: `https://${id}.example.com`,
+  };
+}
+
+describe("service registry cache", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("deduplicates catalog requests and uses the static catalog", async () => {
+    vi.stubGlobal("sessionStorage", createStorage());
+    const fetchMock = vi.fn(async () =>
+      Response.json({ services: [service("openai", "OpenAI (New)")] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchServices } = await import("./registry");
+    const [first, second] = await Promise.all([
+      fetchServices(),
+      fetchServices(),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith("/services/catalog.json");
+    expect(first).toEqual(second);
+    expect(first[0]?.name).toBe("OpenAI");
+  });
+
+  it("restores the catalog from session storage after a reload", async () => {
+    const storage = createStorage();
+    vi.stubGlobal("sessionStorage", storage);
+    const fetchMock = vi.fn(async () =>
+      Response.json({ services: [service("anthropic")] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const firstModule = await import("./registry");
+    await firstModule.fetchServices();
+    vi.resetModules();
+    const secondModule = await import("./registry");
+    const services = await secondModule.fetchServices();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(services).toEqual([service("anthropic")]);
+  });
+
+  it("caches and deduplicates featured service requests", async () => {
+    vi.stubGlobal("sessionStorage", createStorage());
+    const fetchMock = vi.fn(async () =>
+      Response.json({ services: [service("parallel", "Parallel (New)")] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchFeaturedServices } = await import("./registry");
+    const [first, second] = await Promise.all([
+      fetchFeaturedServices(["parallel"]),
+      fetchFeaturedServices(["parallel"]),
+    ]);
+    const third = await fetchFeaturedServices(["parallel"]);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith("/api/services?ids=parallel");
+    expect(first).toEqual(second);
+    expect(second).toEqual(third);
+    expect(first[0]?.name).toBe("Parallel");
+  });
+});

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -1,14 +1,14 @@
 // ---------------------------------------------------------------------------
 // API config
-// Uses the local /api/services route which proxies discovery.json (same origin,
-// no CORS). In production this serves from the same Vercel deployment.
-// To point at an external API instead, change API_URL to the full URL.
+// The directory uses a generated static catalog to avoid serverless cold starts.
+// The public /api/services endpoint remains available for external consumers.
 // ---------------------------------------------------------------------------
 
 import { useEffect, useState } from "react";
 
 const API_URL = "/api/services";
-const CACHE_TTL_MS = 60_000;
+const CACHE_TTL_MS = 5 * 60_000;
+const CATALOG_URL = "/services/catalog.json";
 
 // ---------------------------------------------------------------------------
 // Types (mirrors the discovery JSON Schema)
@@ -80,9 +80,14 @@ export type FeaturedService = Pick<
 
 let cached: { data: Service[]; ts: number } | null = null;
 let inflight: Promise<Service[]> | null = null;
+const featuredCached = new Map<
+  string,
+  { data: FeaturedService[]; ts: number }
+>();
+const featuredInflight = new Map<string, Promise<FeaturedService[]>>();
 
-async function fetchFromApi(): Promise<Service[]> {
-  const res = await fetch(API_URL);
+async function fetchCatalog(): Promise<Service[]> {
+  const res = await fetch(CATALOG_URL);
   if (!res.ok) throw new Error(`API ${res.status}: ${res.statusText}`);
   const json = await res.json();
   return json.services;
@@ -94,10 +99,10 @@ async function fetchFromApi(): Promise<Service[]> {
 
 const SESSION_KEY = "mpp-services-cache";
 
-function readSessionCache(): Service[] | null {
+function readSessionCache<T>(key: string): T | null {
   if (typeof sessionStorage === "undefined") return null;
   try {
-    const raw = sessionStorage.getItem(SESSION_KEY);
+    const raw = sessionStorage.getItem(key);
     if (!raw) return null;
     const { data, ts } = JSON.parse(raw);
     if (Date.now() - ts < CACHE_TTL_MS) return data;
@@ -105,13 +110,10 @@ function readSessionCache(): Service[] | null {
   return null;
 }
 
-function writeSessionCache(data: Service[]) {
+function writeSessionCache<T>(key: string, data: T) {
   if (typeof sessionStorage === "undefined") return;
   try {
-    sessionStorage.setItem(
-      SESSION_KEY,
-      JSON.stringify({ data, ts: Date.now() }),
-    );
+    sessionStorage.setItem(key, JSON.stringify({ data, ts: Date.now() }));
   } catch {}
 }
 
@@ -206,7 +208,7 @@ export async function fetchServices(): Promise<Service[]> {
     return cached.data;
   }
 
-  const fromSession = readSessionCache();
+  const fromSession = readSessionCache<Service[]>(SESSION_KEY);
   if (fromSession) {
     cached = { data: fromSession, ts: Date.now() };
     return fromSession;
@@ -214,14 +216,14 @@ export async function fetchServices(): Promise<Service[]> {
 
   if (inflight) return inflight;
 
-  inflight = fetchFromApi()
+  inflight = fetchCatalog()
     .then((services) => {
       const cleaned = services.map((s) => ({
         ...s,
         name: s.name.replace(/ \(New\)$/i, ""),
       }));
       cached = { data: cleaned, ts: Date.now() };
-      writeSessionCache(cleaned);
+      writeSessionCache(SESSION_KEY, cleaned);
       inflight = null;
       return cleaned;
     })
@@ -236,15 +238,45 @@ export async function fetchServices(): Promise<Service[]> {
 export async function fetchFeaturedServices(
   ids: readonly string[],
 ): Promise<FeaturedService[]> {
-  const search = new URLSearchParams({ ids: ids.join(",") });
-  const response = await fetch(`${API_URL}?${search}`);
-  if (!response.ok) {
-    throw new Error(`API ${response.status}: ${response.statusText}`);
+  const idsKey = ids.join(",");
+  const memoryEntry = featuredCached.get(idsKey);
+  if (memoryEntry && Date.now() - memoryEntry.ts < CACHE_TTL_MS) {
+    return memoryEntry.data;
   }
 
-  const json = (await response.json()) as { services: FeaturedService[] };
-  return json.services.map((service) => ({
-    ...service,
-    name: service.name.replace(/ \(New\)$/i, ""),
-  }));
+  const cacheKey = `${SESSION_KEY}:featured:${idsKey}`;
+  const sessionEntry = readSessionCache<FeaturedService[]>(cacheKey);
+  if (sessionEntry) {
+    featuredCached.set(idsKey, { data: sessionEntry, ts: Date.now() });
+    return sessionEntry;
+  }
+
+  const pending = featuredInflight.get(idsKey);
+  if (pending) return pending;
+
+  const search = new URLSearchParams({ ids: idsKey });
+  const request = fetch(`${API_URL}?${search}`)
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`API ${response.status}: ${response.statusText}`);
+      }
+
+      const json = (await response.json()) as {
+        services: FeaturedService[];
+      };
+      const services = json.services.map((service) => ({
+        ...service,
+        name: service.name.replace(/ \(New\)$/i, ""),
+      }));
+      featuredCached.set(idsKey, { data: services, ts: Date.now() });
+      writeSessionCache(cacheKey, services);
+      featuredInflight.delete(idsKey);
+      return services;
+    })
+    .catch((error) => {
+      featuredInflight.delete(idsKey);
+      throw error;
+    });
+  featuredInflight.set(idsKey, request);
+  return request;
 }

--- a/src/pages/_api/api/icon.ts
+++ b/src/pages/_api/api/icon.ts
@@ -5,12 +5,14 @@ import { list } from "@vercel/blob";
 const BLOB_TOKEN = process.env.BLOB_READ_WRITE_TOKEN;
 
 const CACHE_HEADERS = {
-  "Cache-Control": "public, s-maxage=86400, stale-while-revalidate",
+  "Cache-Control":
+    "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000",
 };
 
 const FALLBACK_HEADERS = {
+  "Cache-Control":
+    "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
   "Content-Type": "image/svg+xml",
-  "Cache-Control": "public, s-maxage=3600, stale-while-revalidate",
 };
 
 function letterSvg(id: string): string {

--- a/src/pages/_api/api/services.ts
+++ b/src/pages/_api/api/services.ts
@@ -1,5 +1,8 @@
 import discovery from "../../../../schemas/discovery.json";
 
+const CACHE_CONTROL =
+  "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400";
+
 export function GET(request: Request) {
   const ids = new URL(request.url).searchParams
     .get("ids")
@@ -28,11 +31,11 @@ export function GET(request: Request) {
 
     return Response.json(
       { services },
-      { headers: { "Cache-Control": "public, max-age=60" } },
+      { headers: { "Cache-Control": CACHE_CONTROL } },
     );
   }
 
   return Response.json(discovery, {
-    headers: { "Cache-Control": "public, max-age=60" },
+    headers: { "Cache-Control": CACHE_CONTROL },
   });
 }

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -239,12 +239,6 @@ function useRouteFade() {
       )
         return;
 
-      if (url.pathname === "/blog" && link.closest("[data-v-gutter-top]")) {
-        event.preventDefault();
-        window.location.assign(url.href);
-        return;
-      }
-
       window.dispatchEvent(new Event("mpp:route"));
       document.documentElement.dataset.routeTransition = "";
       window.setTimeout(() => {

--- a/vercel.ts
+++ b/vercel.ts
@@ -45,6 +45,13 @@ const CACHE_HEADERS = [
   header("X-Content-Type-Options", "nosniff"),
 ];
 
+const ICON_CACHE_HEADERS = [
+  header(
+    "Cache-Control",
+    "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000",
+  ),
+];
+
 const DOC_SECTIONS = [
   "advanced",
   "blog",
@@ -82,10 +89,17 @@ export const config = {
       header("Access-Control-Allow-Origin", "*"),
       ...CACHE_HEADERS,
     ]),
+    headerRule("/icons/:path*", ICON_CACHE_HEADERS),
     headerRule("/robots.txt", CACHE_HEADERS),
     headerRule("/rss.xml", [
       header("Content-Type", "application/rss+xml; charset=utf-8"),
       ...CACHE_HEADERS,
+    ]),
+    headerRule("/services/catalog.json", [
+      header(
+        "Cache-Control",
+        "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      ),
     ]),
     headerRule("/openapi.json", [header("Link", OPENAPI_DISCOVERY_LINK_VALUE)]),
     ...DISCOVERY_PAGE_SOURCES.map((source) =>


### PR DESCRIPTION
## Motivation

Blog navigation forced a full document reload, while the services directory loaded its catalog through a serverless function and requested offscreen icons immediately. These paths made routine navigation feel slow.

## Summary

- Preserve client-side navigation when opening Blog
- Generate and serve the service catalog as a cacheable static asset
- Cache and deduplicate full and featured service lists in memory and session storage
- Add browser and CDN caching for service catalogs, API responses, and icons
- Defer offscreen service icons and cover cache behavior with focused tests

## Key design considerations

- Keep `/api/services` available for external consumers and filtered featured-service requests
- Generate the static catalog from the same service source during every build to prevent drift
- Bound client caches to five minutes while using stale-while-revalidate at the CDN layer