### PR TITLE
perf: reduce initial page asset load

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -199,18 +199,31 @@ function useGoogleAnalytics() {
     if (!id) return;
     if (document.querySelector(`script[src*="googletagmanager"]`)) return;
 
-    const script = document.createElement("script");
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
-    script.async = true;
-    document.head.appendChild(script);
+    const inject = () => {
+      const script = document.createElement("script");
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
+      script.async = true;
+      document.head.appendChild(script);
 
-    window.dataLayer = window.dataLayer || [];
-    const gtag: (...args: unknown[]) => void = function () {
-      // biome-ignore lint/complexity/noArguments: gtag.js bootstrap requires the native arguments object
-      window.dataLayer.push(arguments);
+      window.dataLayer = window.dataLayer || [];
+      const gtag: (...args: unknown[]) => void = function () {
+        // biome-ignore lint/complexity/noArguments: gtag.js bootstrap requires the native arguments object
+        window.dataLayer.push(arguments);
+      };
+      gtag("js", new Date());
+      gtag("config", id);
     };
-    gtag("js", new Date());
-    gtag("config", id);
+
+    const idleCallback = window.requestIdleCallback?.(inject, {
+      timeout: 2_000,
+    });
+    const timeout =
+      idleCallback === undefined ? window.setTimeout(inject, 1_000) : undefined;
+
+    return () => {
+      if (idleCallback !== undefined) window.cancelIdleCallback(idleCallback);
+      if (timeout !== undefined) window.clearTimeout(timeout);
+    };
   }, []);
 }
 
@@ -987,34 +1000,6 @@ export default function Layout(
         rel="alternate"
         title="MPP Blog"
         type="application/rss+xml"
-      />
-      <link
-        rel="preload"
-        href="https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-Regular.woff2"
-        as="font"
-        type="font/woff2"
-        crossOrigin="anonymous"
-      />
-      <link
-        rel="preload"
-        href="https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-Bold.woff2"
-        as="font"
-        type="font/woff2"
-        crossOrigin="anonymous"
-      />
-      <link
-        rel="preload"
-        href="/fonts/Geist-Regular.woff2"
-        as="font"
-        type="font/woff2"
-        crossOrigin="anonymous"
-      />
-      <link
-        rel="preload"
-        href="/fonts/Geist-Medium.woff2"
-        as="font"
-        type="font/woff2"
-        crossOrigin="anonymous"
       />
       <MobileNavPortal />
       <LogoContextMenu />

--- a/vercel.test.ts
+++ b/vercel.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { config } from "./vercel";
+
+const CACHE_CONTROL =
+  "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000";
+
+describe("static asset caching", () => {
+  it.each([
+    "/fonts/:path*",
+    "/icons/:path*",
+    "/lottie/:path*",
+    "/marketing/:path*",
+    "/vendor/:path*",
+  ])("caches %s in browsers and at the CDN", (source) => {
+    const rule = config.headers.find(
+      (candidate) => candidate.source === source,
+    );
+
+    expect(rule?.headers).toContainEqual({
+      key: "Cache-Control",
+      value: CACHE_CONTROL,
+    });
+  });
+});

--- a/vercel.ts
+++ b/vercel.ts
@@ -45,11 +45,19 @@ const CACHE_HEADERS = [
   header("X-Content-Type-Options", "nosniff"),
 ];
 
-const ICON_CACHE_HEADERS = [
+const STATIC_ASSET_CACHE_HEADERS = [
   header(
     "Cache-Control",
     "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000",
   ),
+];
+
+const STATIC_ASSET_SOURCES = [
+  "/fonts/:path*",
+  "/icons/:path*",
+  "/lottie/:path*",
+  "/marketing/:path*",
+  "/vendor/:path*",
 ];
 
 const DOC_SECTIONS = [
@@ -89,7 +97,6 @@ export const config = {
       header("Access-Control-Allow-Origin", "*"),
       ...CACHE_HEADERS,
     ]),
-    headerRule("/icons/:path*", ICON_CACHE_HEADERS),
     headerRule("/robots.txt", CACHE_HEADERS),
     headerRule("/rss.xml", [
       header("Content-Type", "application/rss+xml; charset=utf-8"),
@@ -101,6 +108,9 @@ export const config = {
         "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
       ),
     ]),
+    ...STATIC_ASSET_SOURCES.map((source) =>
+      headerRule(source, STATIC_ASSET_CACHE_HEADERS),
+    ),
     headerRule("/openapi.json", [header("Link", OPENAPI_DISCOVERY_LINK_VALUE)]),
     ...DISCOVERY_PAGE_SOURCES.map((source) =>
       headerRule(source, [

--- a/vocs.config.test.ts
+++ b/vocs.config.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import config from "./vocs.config";
+
+function headFor(path: string) {
+  if (typeof config.head !== "function")
+    throw new Error("Expected route-aware head configuration");
+  return config.head(path, {});
+}
+
+describe("font preloads", () => {
+  it("does not preload unused fonts outside Services", () => {
+    expect(headFor("/blog")).toBeUndefined();
+    expect(headFor("/")?.link).toEqual([
+      {
+        as: "image",
+        fetchpriority: "high",
+        href: "/marketing/mpp-hero-poster.jpg",
+        rel: "preload",
+      },
+    ]);
+  });
+
+  it("preloads the Services display fonts", () => {
+    expect(headFor("/services")?.link).toEqual([
+      {
+        as: "font",
+        crossorigin: "anonymous",
+        href: "https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-Regular.woff2",
+        rel: "preload",
+        type: "font/woff2",
+      },
+      {
+        as: "font",
+        crossorigin: "anonymous",
+        href: "https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-Bold.woff2",
+        rel: "preload",
+        type: "font/woff2",
+      },
+    ]);
+  });
+});

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -15,19 +15,39 @@ export default defineConfig({
   accentColor: "#ffffff",
   colorScheme: "dark",
   baseUrl,
-  head: (path) =>
-    path === "/"
-      ? {
-          link: [
-            {
-              as: "image",
-              fetchpriority: "high",
-              href: "/marketing/mpp-hero-poster.jpg",
-              rel: "preload",
-            },
-          ],
-        }
-      : undefined,
+  head: (path) => {
+    if (path === "/")
+      return {
+        link: [
+          {
+            as: "image",
+            fetchpriority: "high",
+            href: "/marketing/mpp-hero-poster.jpg",
+            rel: "preload",
+          },
+        ],
+      };
+    if (path === "/services" || path.startsWith("/services/"))
+      return {
+        link: [
+          {
+            as: "font",
+            crossorigin: "anonymous",
+            href: "https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-Regular.woff2",
+            rel: "preload",
+            type: "font/woff2",
+          },
+          {
+            as: "font",
+            crossorigin: "anonymous",
+            href: "https://wgfdjv2jfqz2dlpx.public.blob.vercel-storage.com/fonts/VTCDuBois-Bold.woff2",
+            rel: "preload",
+            type: "font/woff2",
+          },
+        ],
+      };
+    return undefined;
+  },
   markdown: {
     outputRemarkPlugins: [
       // Production bundles may omit source MDX after Markdown artifacts exist.


### PR DESCRIPTION
## Summary

- Remove unused static Geist font preloads from every route
- Scope VTC Du Bois font preloads to Services routes
- Defer Google Analytics initialization until the browser is idle
- Cache fonts, icons, Lottie files, marketing media, and vendor assets in browsers and at the CDN

## Key design considerations

- Keep the Services display fonts preloaded where they affect above-the-fold rendering
- Bound browser caching to one day for versionless assets while allowing longer CDN reuse
- Preserve analytics behavior while moving its network and execution cost off the initial rendering path