### PR TITLE
Add El Nino Wiki to MPP Services

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1146,6 +1146,57 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── El Nino Wiki ───────────────────────────────────────────────────────
+  {
+    id: "elnino-wiki-heat-risk",
+    name: "El Nino Wiki",
+    url: "https://elnino.wiki",
+    serviceUrl: "https://mpp.elnino.wiki",
+    description:
+      "Structured heat-risk briefings from a supported city planning baseline or caller-supplied weather and exposure conditions.",
+    icon: "https://elnino.wiki/logo.png",
+    categories: ["data", "web"],
+    integration: "first-party",
+    tags: [
+      "weather",
+      "heat-risk",
+      "travel",
+      "worker-safety",
+      "structured-data",
+      "x402",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://elnino.wiki/docs",
+      llmsTxt: "https://elnino.wiki/llms.txt",
+      apiReference: "https://elnino.wiki/openapi.json",
+    },
+    provider: { name: "El Nino Wiki", url: "https://elnino.wiki" },
+    realm: "mpp.elnino.wiki",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /api/mpp/v1/preview",
+        desc: "Generate a concise heat-risk briefing",
+        amount: "20000",
+        unitType: "request",
+      },
+      {
+        route: "POST /api/mpp/v1/execute",
+        desc: "Generate a full heat-risk briefing with factor attribution",
+        amount: "1000000",
+        unitType: "request",
+      },
+      {
+        route: "POST /api/mpp/v1/premium",
+        desc: "Generate an exposure-sensitive heat-risk plan by time window",
+        amount: "3000000",
+        unitType: "request",
+      },
+    ],
+  },
+
   // ── Exa ────────────────────────────────────────────────────────────────
   {
     id: "exa",


### PR DESCRIPTION
## Summary

Adds El Nino Wiki, a production MPP service that returns structured, decision-ready heat-risk briefings for cities and caller-supplied conditions.

## Production evidence

- Service: https://mpp.elnino.wiki
- OpenAPI: https://mpp.elnino.wiki/openapi.json
- Documentation: https://elnino.wiki/docs
- Agent instructions: https://elnino.wiki/llms.txt
- MPPScan: https://www.mppscan.com/server/b5b5fad2657140252aadbb462e4d3d49d316a4d7233468ca43b47d1ac76e0576
- Tempo network: mainnet, chain ID 4217
- Payment method: Tempo charge in USDC.e
- Prices: 0.02 / 1 / 3 USDC.e per request
- Verified payment reference: mpp_bd5aa7f92390b020928f84ae39c378b4

## Validation

- [x] Production endpoint returns a valid MPP 402 challenge
- [x] Production Preview payment returned HTTP 200 with a Payment-Receipt
- [x] MPPScan imported all 17 discovered operations and indexed the payment
- [x] pnpm check:ci
- [x] pnpm check:types
- [x] pnpm build
- [x] pnpm test -- schemas/services.test.ts (9,395 tests passed)
