### PR TITLE
fix: hide footer on docs pages

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -2665,6 +2665,10 @@ nav[data-v-sidebar] button,
   padding: 5rem clamp(1rem, 4vw, 3rem) clamp(2rem, 4vw, 3rem) !important;
 }
 
+[data-v-sidebar] [data-v-footer] {
+  display: none;
+}
+
 @media (min-width: 1000px) {
   [data-v-logo]:has(> a > [data-v-logo]) {
     align-items: center;

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -2665,7 +2665,7 @@ nav[data-v-sidebar] button,
   padding: 5rem clamp(1rem, 4vw, 3rem) clamp(2rem, 4vw, 3rem) !important;
 }
 
-[data-v-sidebar] [data-v-footer] {
+[data-layout="full"][data-v-sidebar] [data-v-footer] {
   display: none;
 }
 


### PR DESCRIPTION
## Motivation

Documentation pages currently render the large marketing footer below page content, adding unnecessary visual weight to the docs experience.

## Summary

- Hide the marketing footer on layouts with documentation sidebars
- Keep the footer unchanged on marketing pages

## Key design considerations

- Scope the rule to Vocs layouts with `data-v-sidebar`
- Preserve the existing footer component, styles, and assets