### PR TITLE
docs: use Exa in the OpenClaw guide

### DIFF
--- a/src/pages/partner-integrations/openclaw.mdx
+++ b/src/pages/partner-integrations/openclaw.mdx
@@ -104,10 +104,10 @@ The gateway log confirms that payment-aware fetch is ready:
 Ask the agent to fetch a paid mainnet endpoint:
 
 ```text [prompt]
-Use mpp_fetch to GET https://kicksdb.mpp.tempo.xyz/v3/stockx/products?query=nike&limit=1
+Use mpp_fetch exactly once to POST https://exa.mpp.tempo.xyz/search with header content-type: application/json and body {"query":"What is Tempo blockchain?","numResults":2}. Report the HTTP status, payment receipt, and result titles and URLs.
 ```
 
-The plugin handles the `402`, signs the Challenge with the matching access key, and retries the request. It selects an access key from the Challenge's chain ID, so one gateway can handle mainnet and testnet requests.
+The plugin handles the `402`, signs the Challenge with the matching access key, and retries the request. This example spends USDC.e on Tempo mainnet and returns live Exa search results. The plugin selects an access key from the Challenge's chain ID, so one gateway can handle mainnet and testnet requests.
 
 :::info
 If the active OpenClaw tool profile filters plugin tools, add `mpp` to the existing `tools.alsoAllow` list.


### PR DESCRIPTION
## Summary

- replace the OpenClaw guide's paid KicksDB request with a working Exa search
- include the exact POST body and expected paid response details

## Validation

- `pnpm check:ci`
- `pnpm check:markdown`
- `pnpm check:types`
- `pnpm build` with an inert local build secret
- ran the documented prompt through a fresh OpenClaw setup: HTTP 200, a payment Receipt, and two live Exa results