### PR TITLE
fix: allow local builds without MPP secret

### DIFF
--- a/src/mppx-secret.server.test.ts
+++ b/src/mppx-secret.server.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveMppxSecretKey } from "./mppx-secret.server";
+
+describe("resolveMppxSecretKey", () => {
+  it.each([
+    {
+      expected: "configured-key",
+      isDevelopment: false,
+      lifecycleEvent: "build",
+      secretKey: "configured-key",
+    },
+    {
+      expected: "configured-key",
+      isDevelopment: true,
+      lifecycleEvent: "dev",
+      secretKey: "configured-key",
+    },
+    {
+      expected: "local-development-only-example-key",
+      isDevelopment: false,
+      lifecycleEvent: "build",
+      secretKey: undefined,
+    },
+    {
+      expected: "local-development-only-example-key",
+      isDevelopment: true,
+      lifecycleEvent: "dev",
+      secretKey: undefined,
+    },
+    {
+      expected: undefined,
+      isDevelopment: false,
+      lifecycleEvent: "start",
+      secretKey: undefined,
+    },
+  ])("returns $expected for development=$isDevelopment and lifecycle=$lifecycleEvent", ({
+    expected,
+    isDevelopment,
+    lifecycleEvent,
+    secretKey,
+  }) => {
+    expect(
+      resolveMppxSecretKey({
+        isDevelopment,
+        lifecycleEvent,
+        secretKey,
+      }),
+    ).toBe(expected);
+  });
+});

--- a/src/mppx-secret.server.ts
+++ b/src/mppx-secret.server.ts
@@ -1,5 +1,24 @@
-import { randomBytes } from "node:crypto";
+const localExampleSecretKey = "local-development-only-example-key";
 
-export const mppxSecretKey =
-  process.env.MPP_SECRET_KEY ??
-  (import.meta.env.DEV ? randomBytes(32).toString("base64") : undefined);
+export function resolveMppxSecretKey({
+  isDevelopment,
+  lifecycleEvent,
+  secretKey,
+}: {
+  isDevelopment: boolean;
+  lifecycleEvent?: string;
+  secretKey?: string;
+}) {
+  return (
+    secretKey ??
+    (isDevelopment || lifecycleEvent === "build"
+      ? localExampleSecretKey
+      : undefined)
+  );
+}
+
+export const mppxSecretKey = resolveMppxSecretKey({
+  isDevelopment: import.meta.env.DEV,
+  lifecycleEvent: process.env.npm_lifecycle_event,
+  secretKey: process.env.MPP_SECRET_KEY,
+});


### PR DESCRIPTION
## Motivation

Local development and builds fail when `MPP_SECRET_KEY` isn't configured, even though production runtime is the only context that requires a real secret.

## Summary

- Use a deterministic example key during Vite development and the package build lifecycle
- Preserve an explicitly configured `MPP_SECRET_KEY`
- Cover secret resolution behavior with table-driven tests

## Key design considerations

- Keep production runtime fail-closed when no key is configured
- Scope the fallback to development and build initialization