### PR TITLE
fix: match homepage header behavior

### DIFF
--- a/src/components/marketing/Dropdown.test.tsx
+++ b/src/components/marketing/Dropdown.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Dropdown } from "./Dropdown";
+
+afterEach(cleanup);
+
+describe("Dropdown", () => {
+  it("opens on click but not hover", () => {
+    const { container } = render(
+      <Dropdown
+        items={[{ href: "https://github.com/wevm/mppx", label: "mppx" }]}
+        label="GitHub"
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "GitHub" });
+    const menu = container.querySelector('[role="menu"]');
+
+    expect(menu).not.toBeNull();
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(menu?.classList.contains("hidden")).toBe(true);
+
+    fireEvent.mouseEnter(trigger);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(menu?.classList.contains("hidden")).toBe(true);
+
+    fireEvent.click(trigger);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(menu?.classList.contains("hidden")).toBe(false);
+  });
+});

--- a/src/components/marketing/Header.tsx
+++ b/src/components/marketing/Header.tsx
@@ -123,7 +123,7 @@ export function Header({
           "fixed inset-x-0 top-0 z-50 w-full",
           overlay
             ? "bg-gradient-to-b from-[#101010] to-transparent"
-            : "bg-[#101010]",
+            : "bg-[#060606]",
         )}
       >
         <div className="mx-auto flex w-full max-w-[1728px] items-center justify-between gap-4 px-4 py-4 md:px-12 md:py-5">


### PR DESCRIPTION
## Motivation

Match the homepage header color and GitHub interaction with the Opal reference site.

## Summary

- Match the fixed homepage header background to the landing-page canvas.
- Add regression coverage that keeps the GitHub dropdown closed on hover and opens it on click.

## Key design considerations

- Preserve the existing gradient treatment for overlay headers.
- Preserve the dropdown's click and keyboard interaction model.