### PR TITLE
fix: match marketing page header colors

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -83,7 +83,7 @@ export function LandingPage() {
   }, []);
 
   return (
-    <div className="marketing-route not-prose bg-[#060606] text-offwhite">
+    <div className="marketing-route not-prose bg-[#060606] text-offwhite [--marketing-page-bg:#060606]">
       <Header />
       <main className="mx-auto w-full max-w-[1728px]">
         <section className="relative flex flex-col gap-8 px-4 pb-8 pt-6 md:px-12 min-[1000px]:min-h-[calc(100svh-70px)] min-[1000px]:justify-between min-[1000px]:gap-0 min-[1000px]:pb-10 min-[1000px]:pt-[120px]">

--- a/src/components/marketing/Header.tsx
+++ b/src/components/marketing/Header.tsx
@@ -123,7 +123,7 @@ export function Header({
           "fixed inset-x-0 top-0 z-50 w-full",
           overlay
             ? "bg-gradient-to-b from-[#101010] to-transparent"
-            : "bg-[#060606]",
+            : "bg-[var(--marketing-page-bg,#101010)]",
         )}
       >
         <div className="mx-auto flex w-full max-w-[1728px] items-center justify-between gap-4 px-4 py-4 md:px-12 md:py-5">


### PR DESCRIPTION
## Motivation

Keep marketing headers visually continuous with each page background.

## Summary

- Inherit the marketing page background in the shared header
- Preserve the homepage black surface while matching Services and Blog charcoal surfaces

## Key design considerations

- Use one page-level CSS variable so future marketing routes inherit the correct default