### PR TITLE
fix: match terminal expansion behavior

### DIFF
--- a/e2e/terminal.test.ts
+++ b/e2e/terminal.test.ts
@@ -144,6 +144,48 @@ describe("terminal", () => {
     await page.close();
   });
 
+  it("enlarges the marketing terminal into a closable viewport modal", async () => {
+    const page = await newPage();
+    await page.goto(pageUrl());
+
+    const terminal = page.getByRole("application", {
+      name: "MPP interactive terminal demo",
+    });
+    await playwrightExpect(terminal).toBeVisible({ timeout: 10_000 });
+    await page.waitForSelector("[data-wizard-ready]", { timeout: 10_000 });
+
+    await page
+      .getByRole("button", { name: "Enlarge terminal", exact: true })
+      .click();
+
+    const modal = page.locator(".terminal-fullscreen-panel");
+    await playwrightExpect(modal).toBeVisible();
+    await playwrightExpect(
+      page.getByRole("button", { name: "Close terminal", exact: true }),
+    ).toHaveCount(2);
+
+    const modalBox = await modal.boundingBox();
+    expect(modalBox).not.toBeNull();
+    expect(modalBox?.x).toBeGreaterThanOrEqual(16);
+    expect(modalBox?.y).toBeGreaterThanOrEqual(16);
+    expect(modalBox?.width).toBeLessThanOrEqual(1080);
+    expect(modalBox?.height).toBeLessThanOrEqual(640);
+    expect(await page.evaluate(() => document.body.style.overflow)).toBe(
+      "hidden",
+    );
+
+    await page
+      .getByRole("button", { name: "Close terminal", exact: true })
+      .last()
+      .click();
+    await playwrightExpect(
+      page.getByRole("button", { name: "Enlarge terminal", exact: true }),
+    ).toBeVisible();
+    expect(await page.evaluate(() => document.body.style.overflow)).toBe("");
+
+    await page.close();
+  });
+
   it("types out demo command and reaches wizard", async () => {
     const page = await newPage();
     await page.goto(pageUrl());

--- a/e2e/terminal.test.ts
+++ b/e2e/terminal.test.ts
@@ -153,16 +153,37 @@ describe("terminal", () => {
     });
     await playwrightExpect(terminal).toBeVisible({ timeout: 10_000 });
     await page.waitForSelector("[data-wizard-ready]", { timeout: 10_000 });
+    await page.getByRole("button", { name: /Chat with OpenAI/ }).click();
+    const prompt = page.getByRole("textbox");
+    await playwrightExpect(prompt).toBeVisible({ timeout: 5_000 });
+    await prompt.fill("preserve this prompt");
 
     await page
       .getByRole("button", { name: "Enlarge terminal", exact: true })
       .click();
 
-    const modal = page.locator(".terminal-fullscreen-panel");
+    const modal = page.getByRole("dialog", { name: "MPP terminal" });
     await playwrightExpect(modal).toBeVisible();
+    await playwrightExpect(prompt).toHaveValue("preserve this prompt");
     await playwrightExpect(
       page.getByRole("button", { name: "Close terminal", exact: true }),
     ).toHaveCount(2);
+    const closeButton = modal.getByRole("button", {
+      name: "Close terminal",
+      exact: true,
+    });
+    await playwrightExpect(closeButton).toBeFocused();
+    await playwrightExpect(
+      page.locator(".terminal-fullscreen"),
+    ).toHaveAttribute("tabindex", "-1");
+    expect(
+      await page.evaluate(() => {
+        const portal = document.querySelector("[data-terminal-portal]");
+        return Array.from(document.body.children)
+          .filter((element) => element !== portal)
+          .every((element) => (element as HTMLElement).inert);
+      }),
+    ).toBe(true);
 
     const modalBox = await modal.boundingBox();
     expect(modalBox).not.toBeNull();
@@ -174,14 +195,37 @@ describe("terminal", () => {
       "hidden",
     );
 
-    await page
-      .getByRole("button", { name: "Close terminal", exact: true })
-      .last()
-      .click();
-    await playwrightExpect(
-      page.getByRole("button", { name: "Enlarge terminal", exact: true }),
-    ).toBeVisible();
+    await modal.evaluate((element) => {
+      const focusable = Array.from(
+        element.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((candidate) => candidate.getClientRects().length > 0);
+      focusable.at(-1)?.focus();
+    });
+    await page.keyboard.press("Tab");
+    expect(
+      await modal.evaluate((element) =>
+        element.contains(document.activeElement),
+      ),
+    ).toBe(true);
+
+    await closeButton.click();
+    const enlargeButton = page.getByRole("button", {
+      name: "Enlarge terminal",
+      exact: true,
+    });
+    await playwrightExpect(enlargeButton).toBeVisible();
+    await playwrightExpect(enlargeButton).toBeFocused();
+    await playwrightExpect(prompt).toHaveValue("preserve this prompt");
     expect(await page.evaluate(() => document.body.style.overflow)).toBe("");
+    expect(
+      await page.evaluate(() =>
+        Array.from(document.body.children).every(
+          (element) => !(element as HTMLElement).inert,
+        ),
+      ),
+    ).toBe(true);
 
     await page.close();
   });

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2740,35 +2740,117 @@ function TerminalComponent({
   const autoScrollRef = useRef(true);
   const programmaticScrollRef = useRef(false);
   const scrollTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const inlinePortalHostRef = useRef<HTMLDivElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const fullscreenButtonRef = useRef<HTMLButtonElement>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(
+    null,
+  );
   const [showTopFade, setShowTopFade] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isFullscreenClosing, setIsFullscreenClosing] = useState(false);
+  const isFullscreenClosingRef = useRef(false);
+
+  useEffect(() => {
+    const inlineHost = inlinePortalHostRef.current;
+    if (!inlineHost) return;
+    const container = document.createElement("div");
+    container.className = "h-full w-full";
+    container.dataset.terminalPortal = "";
+    inlineHost.append(container);
+    setPortalContainer(container);
+    return () => container.remove();
+  }, []);
+
+  const moveTerminalInline = useCallback(() => {
+    const inlineHost = inlinePortalHostRef.current;
+    if (portalContainer && inlineHost) inlineHost.append(portalContainer);
+  }, [portalContainer]);
+
   const closeFullscreen = useCallback(() => {
-    if (!isFullscreen || isFullscreenClosing) return;
+    if (!isFullscreen || isFullscreenClosingRef.current) return;
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
       setIsFullscreen(false);
+      moveTerminalInline();
       return;
     }
+    isFullscreenClosingRef.current = true;
     setIsFullscreenClosing(true);
     window.setTimeout(() => {
+      isFullscreenClosingRef.current = false;
       setIsFullscreen(false);
       setIsFullscreenClosing(false);
+      moveTerminalInline();
     }, 300);
-  }, [isFullscreen, isFullscreenClosing]);
+  }, [isFullscreen, moveTerminalInline]);
+  const openFullscreen = useCallback(() => {
+    restoreFocusRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : fullscreenButtonRef.current;
+    if (portalContainer) document.body.append(portalContainer);
+    setIsFullscreen(true);
+  }, [portalContainer]);
   const [isMarketingMinimized, setIsMarketingMinimized] = useState(false);
 
   useEffect(() => {
-    if (!isFullscreen) return;
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeFullscreen();
+    if (!isFullscreen || !portalContainer) return;
+    const previousOverflow = document.body.style.overflow;
+    const backgroundElements = Array.from(document.body.children)
+      .filter(
+        (element): element is HTMLElement =>
+          element instanceof HTMLElement && element !== portalContainer,
+      )
+      .map((element) => ({ element, inert: element.inert }));
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeFullscreen();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const modal = modalRef.current;
+      if (!modal) return;
+      const focusable = Array.from(
+        modal.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((element) => element.getClientRects().length > 0);
+      const first = focusable[0];
+      const last = focusable.at(-1);
+      const active = document.activeElement;
+      if (!first || !last) {
+        event.preventDefault();
+        modal.focus();
+      } else if (
+        event.shiftKey &&
+        (active === first || !modal.contains(active))
+      ) {
+        event.preventDefault();
+        last.focus();
+      } else if (
+        !event.shiftKey &&
+        (active === last || !modal.contains(active))
+      ) {
+        event.preventDefault();
+        first.focus();
+      }
     };
+
+    for (const { element } of backgroundElements) element.inert = true;
     document.body.style.overflow = "hidden";
-    window.addEventListener("keydown", handleEsc);
+    fullscreenButtonRef.current?.focus();
+    window.addEventListener("keydown", handleKeyDown);
     return () => {
-      document.body.style.overflow = "";
-      window.removeEventListener("keydown", handleEsc);
+      document.body.style.overflow = previousOverflow;
+      for (const { element, inert } of backgroundElements) {
+        element.inert = inert;
+      }
+      window.removeEventListener("keydown", handleKeyDown);
+      restoreFocusRef.current?.focus();
+      restoreFocusRef.current = null;
     };
-  }, [closeFullscreen, isFullscreen]);
+  }, [closeFullscreen, isFullscreen, portalContainer]);
 
   useEffect(() => {
     const scrollEl = scrollRef.current;
@@ -2836,6 +2918,13 @@ function TerminalComponent({
   }, []);
 
   const isMarketingWidget = marketing && !isFullscreen;
+  const modalProps = isFullscreen
+    ? ({
+        "aria-label": "MPP terminal",
+        "aria-modal": true,
+        role: "dialog",
+      } as const)
+    : {};
 
   const terminalWindow = (
     <div
@@ -2983,9 +3072,10 @@ function TerminalComponent({
             </button>
           )}
           <button
+            ref={fullscreenButtonRef}
             type="button"
             onClick={() =>
-              isFullscreen ? closeFullscreen() : setIsFullscreen(true)
+              isFullscreen ? closeFullscreen() : openFullscreen()
             }
             style={{
               background: "transparent",
@@ -3291,29 +3381,51 @@ function TerminalComponent({
     </div>
   );
 
-  if (!isFullscreen) return terminalWindow;
-
-  return createPortal(
+  return (
     <>
-      <button
-        aria-label="Close terminal"
-        className={`terminal-fullscreen fixed inset-0 z-[70] bg-black/70 backdrop-blur-sm ${
-          isFullscreenClosing ? "is-closing" : ""
-        }`}
-        onClick={closeFullscreen}
-        type="button"
-      />
-      <div className="pointer-events-none fixed inset-0 z-[71] flex items-center justify-center p-4">
-        <div
-          className={`terminal-fullscreen-panel term-outline pointer-events-auto h-[min(85dvh,640px)] w-full max-w-[1080px] ${
-            isFullscreenClosing ? "is-closing" : ""
-          }`}
-        >
-          {terminalWindow}
-        </div>
-      </div>
-    </>,
-    document.body,
+      <div ref={inlinePortalHostRef} className="h-full w-full" />
+      {portalContainer &&
+        createPortal(
+          <>
+            <button
+              aria-label="Close terminal"
+              className={
+                isFullscreen
+                  ? `terminal-fullscreen fixed inset-0 z-[70] bg-black/70 backdrop-blur-sm ${
+                      isFullscreenClosing ? "is-closing" : ""
+                    }`
+                  : "hidden"
+              }
+              onClick={closeFullscreen}
+              tabIndex={-1}
+              type="button"
+            />
+            <div
+              className={
+                isFullscreen
+                  ? "pointer-events-none fixed inset-0 z-[71] flex items-center justify-center p-4"
+                  : "h-full w-full"
+              }
+            >
+              <div
+                ref={modalRef}
+                {...modalProps}
+                className={
+                  isFullscreen
+                    ? `terminal-fullscreen-panel term-outline pointer-events-auto h-[min(85dvh,640px)] w-full max-w-[1080px] ${
+                        isFullscreenClosing ? "is-closing" : ""
+                      }`
+                    : "h-full w-full"
+                }
+                tabIndex={isFullscreen ? -1 : undefined}
+              >
+                {terminalWindow}
+              </div>
+            </div>
+          </>,
+          portalContainer,
+        )}
+    </>
   );
 }
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { BlockCursorInput } from "./BlockCursorInput";
 import { SPINNER_FRAMES } from "./terminal-data";
 import {
@@ -2836,9 +2837,9 @@ function TerminalComponent({
 
   const isMarketingWidget = marketing && !isFullscreen;
 
-  return (
+  const terminalWindow = (
     <div
-      className={`terminal-theme ${isFullscreen ? "terminal-fullscreen" : ""} ${isFullscreenClosing ? "is-closing" : ""} ${className ?? ""}`}
+      className={`terminal-theme ${className ?? ""}`}
       data-marketing-minimized={
         marketing && isMarketingMinimized ? "" : undefined
       }
@@ -2846,23 +2847,9 @@ function TerminalComponent({
         fontFamily: 'var(--font-mono, "Geist Mono", monospace)',
         height: "100%",
         minHeight: 0,
+        pointerEvents: "auto",
         userSelect: "text",
         WebkitUserSelect: "text",
-        ...(isFullscreen
-          ? {
-              alignItems: "center",
-              backdropFilter: "blur(4px)",
-              backgroundColor: "rgb(0 0 0 / 70%)",
-              display: "flex",
-              justifyContent: "center",
-              position: "fixed",
-              inset: 0,
-              zIndex: 9999,
-              height: "100dvh",
-              width: "100vw",
-              padding: 16,
-            }
-          : {}),
       }}
     >
       <div
@@ -2881,9 +2868,8 @@ function TerminalComponent({
         }`}
         role="application"
         style={{
-          height: isFullscreen ? "min(85dvh, 640px)" : "100%",
+          height: "100%",
           minHeight: 0,
-          maxWidth: isFullscreen ? 1080 : undefined,
           width: "100%",
           borderColor: isMarketingWidget
             ? undefined
@@ -3018,7 +3004,7 @@ function TerminalComponent({
             onMouseLeave={(e) => {
               e.currentTarget.style.color = "var(--term-gray5)";
             }}
-            aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+            aria-label={isFullscreen ? "Close terminal" : "Enlarge terminal"}
           >
             {isFullscreen ? (
               <svg
@@ -3031,7 +3017,7 @@ function TerminalComponent({
                 strokeLinecap="round"
                 strokeLinejoin="round"
               >
-                <title>Exit fullscreen</title>
+                <title>Close terminal</title>
                 <path d="M8 3v3a2 2 0 0 1-2 2H3" />
                 <path d="M21 8h-3a2 2 0 0 1-2-2V3" />
                 <path d="M3 16h3a2 2 0 0 1 2 2v3" />
@@ -3048,7 +3034,7 @@ function TerminalComponent({
                 strokeLinecap="round"
                 strokeLinejoin="round"
               >
-                <title>Fullscreen</title>
+                <title>Enlarge terminal</title>
                 <path d="M8 3H5a2 2 0 0 0-2 2v3" />
                 <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
                 <path d="M3 16v3a2 2 0 0 0 2 2h3" />
@@ -3303,6 +3289,31 @@ function TerminalComponent({
         </div>
       </div>
     </div>
+  );
+
+  if (!isFullscreen) return terminalWindow;
+
+  return createPortal(
+    <>
+      <button
+        aria-label="Close terminal"
+        className={`terminal-fullscreen fixed inset-0 z-[70] bg-black/70 backdrop-blur-sm ${
+          isFullscreenClosing ? "is-closing" : ""
+        }`}
+        onClick={closeFullscreen}
+        type="button"
+      />
+      <div className="pointer-events-none fixed inset-0 z-[71] flex items-center justify-center p-4">
+        <div
+          className={`terminal-fullscreen-panel term-outline pointer-events-auto h-[min(85dvh,640px)] w-full max-w-[1080px] ${
+            isFullscreenClosing ? "is-closing" : ""
+          }`}
+        >
+          {terminalWindow}
+        </div>
+      </div>
+    </>,
+    document.body,
   );
 }
 

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -155,7 +155,7 @@ button:not(:disabled),
   animation: terminal-overlay-in 300ms cubic-bezier(0.19, 1, 0.22, 1) both;
 }
 
-.terminal-fullscreen > [data-terminal] {
+.terminal-fullscreen-panel {
   animation: terminal-modal-in 300ms cubic-bezier(0.19, 1, 0.22, 1) both;
 }
 
@@ -163,7 +163,7 @@ button:not(:disabled),
   animation-direction: reverse;
 }
 
-.terminal-fullscreen.is-closing > [data-terminal] {
+.terminal-fullscreen-panel.is-closing {
   animation-direction: reverse;
 }
 


### PR DESCRIPTION
## Motivation

Keep the marketing terminal usable when enlarged by matching the Opal modal behavior.

## Summary

- Render the enlarged terminal above its docked stacking context
- Add a full-viewport backdrop and centered, closable terminal panel
- Align expand and close labels with the Opal baseline
- Cover terminal enlargement and closing with an end-to-end test

## Key design considerations

- Preserve terminal state by portaling the existing terminal window instead of mounting a second instance
- Isolate modal pointer events from the docked terminal wrapper