### PR TITLE
docs: remove signing account section from refunds page

### DIFF
--- a/src/pages/advanced/refunds.mdx
+++ b/src/pages/advanced/refunds.mdx
@@ -3,17 +3,11 @@ description: "Return funds to clients after a charge, or let sessions refund unu
 imageDescription: "Return funds to clients in charge and session flows"
 ---
 
-import { SigningAccountTabs } from '../../components/SigningAccountTabs'
 import { Tab, Tabs } from 'vocs'
 
 import { MermaidDiagram } from '../../components/MermaidDiagram'
 
 # Refunds [Return funds to clients]
-
-## Choose a signing account
-
-<SigningAccountTabs />
-
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Remove the signing-account chooser from the refunds documentation page.

## Validation

- `pnpm check:markdown`
- `pnpm check:generated`
- `pnpm check:types`

Prompted by: @brendanjryan