### PR TITLE
docs: sync mppx main snapshot

### DIFF
--- a/.mppx-docs-sync
+++ b/.mppx-docs-sync
@@ -1,8 +1,9 @@
 # mppx documentation sync bookmark
 #
-# Tracks the last mppx commit SHA (on main) that was reviewed for documentation.
+# Tracks the installed mppx package version and the last main commit reviewed.
+# Timestamped versions identify prerelease snapshots published from main.
 # When updating docs from mppx changes, bump this SHA to HEAD of mppx main
 # after incorporating the new features/changes into the docs site.
 
-mppx_version=0.8.15
+mppx_version=0.0.0-main-20260803172527
 mppx_sha=e2b2a8a3d0aa46242ff264aa740951c5a43cf05f

--- a/.mppx-docs-sync
+++ b/.mppx-docs-sync
@@ -4,5 +4,5 @@
 # When updating docs from mppx changes, bump this SHA to HEAD of mppx main
 # after incorporating the new features/changes into the docs site.
 
-mppx_version=0.8.14
-mppx_sha=7a277bc68efdac57f43f56feaf1c1202bf574b5d
+mppx_version=0.8.15
+mppx_sha=e2b2a8a3d0aa46242ff264aa740951c5a43cf05f

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "hono": "^4.12.27",
     "lottie-web": "^5.13.0",
     "mermaid": "^11.15.0",
-    "mppx": "^0.8.14",
+    "mppx": "0.0.0-main-20260803172527",
     "nuqs": "2.9.1",
     "react": "^19",
     "react-dom": "^19",
@@ -79,6 +79,11 @@
     "yaml": "^2.9.0"
   },
   "packageManager": "pnpm@10.22.0",
+  "pnpm": {
+    "overrides": {
+      "mppx>ox": "0.14.33"
+    }
+  },
   "engines": {
     "node": ">=24"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@babel/core': 7.29.6
-  dompurify: 3.4.11
-  esbuild: 0.28.1
-  js-yaml: 4.2.0
-  qs: 6.15.2
-  undici: 6.27.0
-  ws: 8.21.0
+  mppx>ox: 0.14.33
 
 importers:
 
@@ -48,8 +42,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       mppx:
-        specifier: ^0.8.14
-        version: 0.8.14(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
+        specifier: 0.0.0-main-20260803172527
+        version: 0.0.0-main-20260803172527(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
       nuqs:
         specifier: 2.9.1
         version: 2.9.1(react@19.2.7)
@@ -222,7 +216,7 @@ packages:
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -486,16 +480,34 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -504,16 +516,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -522,10 +552,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -534,10 +576,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -546,10 +600,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -558,10 +624,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -570,10 +648,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
@@ -582,16 +672,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -600,10 +708,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -612,11 +732,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.28.1':
     resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
@@ -624,16 +756,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -960,10 +1110,6 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
-  '@modelcontextprotocol/core@2.0.0-beta.4':
-    resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==}
-    engines: {node: '>=20'}
-
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -974,8 +1120,8 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@modelcontextprotocol/server@2.0.0-beta.4':
-    resolution: {integrity: sha512-pjMZcNEt1dOq0aJCcY3b7w1Ayh+qmQN2xlfTELcGV9yiAjEGIczBPBLWWW0k0zzo5T8kiv15jtKPsWeHGxLvLg==}
+  '@modelcontextprotocol/server@2.0.0-alpha.4':
+    resolution: {integrity: sha512-/KEo3ZJ50HlagHp0lz2vPgfBZFtXHu6zTBXT9XqPc+4O9i4+IbBVWKq/a9yAfv/ifp0u3+mRo8SUk5kMKzhN8A==}
     engines: {node: '>=20'}
 
   '@napi-rs/wasm-runtime@1.1.4':
@@ -1616,67 +1762,67 @@ packages:
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
 
-  '@stripe/stripe-js@9.7.0':
-    resolution: {integrity: sha512-r1ElolvWXM4aYnZZVHvKW3EDL8JcwEuIgTuWxlB5lvC+YsvjkQ0gX35x9d8dTDubX395fViLVqkaolVs1PmIQQ==}
+  '@stripe/stripe-js@9.12.0':
+    resolution: {integrity: sha512-wCUYZNYo7E/6B3Rv2i/g/Rmj2mTiOX6HEwWYUWUuNUKwEhzTo/SXuQ1IoNo3mknWIHUQyqdakv1Nl2SiYPrCrw==}
     engines: {node: '>=12.16'}
 
-  '@stripe/stripe-js@9.9.0':
-    resolution: {integrity: sha512-Vwqe6Q5cU4i82tPyAv2BpaW/fQSNdOSO4/J8EeDLPp5/oIZiMmdB+Hgh863zFH+rtoxpuWGvD1L7QPh8k1Rdvw==}
+  '@stripe/stripe-js@9.7.0':
+    resolution: {integrity: sha512-r1ElolvWXM4aYnZZVHvKW3EDL8JcwEuIgTuWxlB5lvC+YsvjkQ0gX35x9d8dTDubX395fViLVqkaolVs1PmIQQ==}
     engines: {node: '>=12.16'}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@svgr/babel-plugin-remove-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0':
     resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0':
     resolution: {integrity: sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@svgr/babel-plugin-svg-dynamic-title@8.0.0':
     resolution: {integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@svgr/babel-plugin-svg-em-dimensions@8.0.0':
     resolution: {integrity: sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@svgr/babel-plugin-transform-react-native-svg@8.1.0':
     resolution: {integrity: sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@svgr/babel-plugin-transform-svg-component@8.0.0':
     resolution: {integrity: sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==}
     engines: {node: '>=12'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@svgr/babel-preset@8.1.0':
     resolution: {integrity: sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': ^7.0.0-0
 
   '@svgr/core@8.1.0':
     resolution: {integrity: sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==}
@@ -2390,8 +2536,8 @@ packages:
       zod:
         optional: true
 
-  abitype@1.2.4:
-    resolution: {integrity: sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==}
+  abitype@1.3.0:
+    resolution: {integrity: sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3.22.0 || ^4.0.0
@@ -3019,6 +3165,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
@@ -3359,8 +3510,8 @@ packages:
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
-  incur@0.4.13:
-    resolution: {integrity: sha512-BeKlYFLIsRCgC8IxsUd3S2/4kPeZaNf1Rbz+Kz41jQII4jOgr7j5w4KYe00aAEQa3V0Ur57BVxE5JDTx8L2s5Q==}
+  incur@0.4.26:
+    resolution: {integrity: sha512-63lwOc8+o1VeFkIW3sWWMrDSP5Dd1NsvucUWyxLUk+DoNRiNl7cj481nlLdlboXkq+tqYPBSlV/7XbylS2S4BA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3440,7 +3591,7 @@ packages:
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: 8.21.0
+      ws: '*'
 
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -3941,15 +4092,15 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  mppx@0.7.0:
-    resolution: {integrity: sha512-qOHQjD75wSHSZeXutngPXou8NEMIOw6RhZ/lQbo2JmDQWfOi40pLGpqXgHgwIjw4YcJHClFsI7mFXBK3Nj5WCQ==}
+  mppx@0.0.0-main-20260803172527:
+    resolution: {integrity: sha512-irtnMdfSYGYXnsw1O3nBCQGjANOAgYAwS/QigmdISLV0zcjBLpBxX788L+6Wzv85zg8O4sHswGBgNMJpUZYE7Q==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.18'
-      viem: '>=2.51.0'
+      hono: '>=4.12.25'
+      viem: '>=2.54.0'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -3960,15 +4111,15 @@ packages:
       hono:
         optional: true
 
-  mppx@0.8.14:
-    resolution: {integrity: sha512-rXeq9HvU5oKtJ5K89WdO1s40uCsimGPxyaRnY44jxtctKL20Wd9WmQYRWIIab73ruMmM9KnvevN1BkDKGRI+7A==}
+  mppx@0.7.0:
+    resolution: {integrity: sha512-qOHQjD75wSHSZeXutngPXou8NEMIOw6RhZ/lQbo2JmDQWfOi40pLGpqXgHgwIjw4YcJHClFsI7mFXBK3Nj5WCQ==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
       elysia: '>=1'
       express: '>=5'
-      hono: '>=4.12.25'
-      viem: '>=2.54.0'
+      hono: '>=4.12.18'
+      viem: '>=2.51.0'
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
@@ -4069,14 +4220,6 @@ packages:
   outvariant@1.4.0:
     resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
 
-  ox@0.14.27:
-    resolution: {integrity: sha512-+xhLHo/f+f4BH121/1Pomm/1vgBBda1wYiFpTvjSo8o5OcEj76Pf1hGPJiepoYMTQoTm2SKdSBvWkFWk5l07PA==}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   ox@0.14.29:
     resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
     peerDependencies:
@@ -4085,8 +4228,8 @@ packages:
       typescript:
         optional: true
 
-  ox@0.14.30:
-    resolution: {integrity: sha512-LI11uu+8iiM1B3CLckgd++YF1a0A2k5wDoM9ZeQMiL21BOzQs6L//BLS6hb1HSEKCyycdDIQLsVQx9MjpcC0hA==}
+  ox@0.14.33:
+    resolution: {integrity: sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -4739,6 +4882,14 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
+
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -4832,7 +4983,7 @@ packages:
       '@farmfe/core': '*'
       '@rspack/core': '*'
       bun-types-no-globals: '*'
-      esbuild: 0.28.1
+      esbuild: '*'
       rolldown: '*'
       rollup: '*'
       unloader: '*'
@@ -4923,7 +5074,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: 0.28.1
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -4966,7 +5117,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.3.0
-      esbuild: 0.28.1
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -5196,6 +5347,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -5659,79 +5822,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
   '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
   '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -6078,10 +6319,6 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@modelcontextprotocol/core@2.0.0-beta.4':
-    dependencies:
-      zod: 4.4.3
-
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
@@ -6106,9 +6343,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/server@2.0.0-beta.4':
+  '@modelcontextprotocol/server@2.0.0-alpha.4':
     dependencies:
-      '@modelcontextprotocol/core': 2.0.0-beta.4
       zod: 4.4.3
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -6793,9 +7029,9 @@ snapshots:
 
   '@stitches/core@1.2.8': {}
 
-  '@stripe/stripe-js@9.7.0': {}
+  '@stripe/stripe-js@9.12.0': {}
 
-  '@stripe/stripe-js@9.9.0': {}
+  '@stripe/stripe-js@9.7.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.6)':
     dependencies:
@@ -7560,7 +7796,7 @@ snapshots:
       typescript: 6.0.3
       zod: 4.4.3
 
-  abitype@1.2.4(typescript@6.0.3)(zod@4.4.3):
+  abitype@1.3.0(typescript@6.0.3)(zod@4.4.3):
     optionalDependencies:
       typescript: 6.0.3
       zod: 4.4.3
@@ -8128,6 +8364,35 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
   esbuild@0.28.1:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.1
@@ -8619,10 +8884,10 @@ snapshots:
 
   import-meta-resolve@4.2.0: {}
 
-  incur@0.4.13:
+  incur@0.4.26:
     dependencies:
       '@cfworker/json-schema': 4.1.1
-      '@modelcontextprotocol/server': 2.0.0-beta.4
+      '@modelcontextprotocol/server': 2.0.0-alpha.4
       '@scalar/openapi-types': 0.8.0
       '@toon-format/toon': 2.3.0
       tokenx: 1.3.0
@@ -8677,9 +8942,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isows@1.0.7(ws@8.21.0):
+  isows@1.0.7(ws@8.20.1):
     dependencies:
-      ws: 8.21.0
+      ws: 8.20.1
 
   jest-worker@27.5.1:
     dependencies:
@@ -9400,9 +9665,9 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 6.27.0
+      undici: 7.24.8
       workerd: 1.20260616.1
-      ws: 8.21.0
+      ws: 8.20.1
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -9428,11 +9693,12 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.0.0-main-20260803172527(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
-      '@stripe/stripe-js': 9.7.0
-      incur: 0.4.13
-      ox: 0.14.27(typescript@6.0.3)(zod@4.4.3)
+      '@stripe/stripe-js': 9.12.0
+      eventsource-parser: 3.1.0
+      incur: 0.4.26
+      ox: 0.14.33(typescript@6.0.3)(zod@4.4.3)
       viem: 2.54.0(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -9442,12 +9708,11 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.8.14(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
-      '@stripe/stripe-js': 9.9.0
-      eventsource-parser: 3.1.0
-      incur: 0.4.13
-      ox: 0.14.30(typescript@6.0.3)(zod@4.4.3)
+      '@stripe/stripe-js': 9.7.0
+      incur: 0.4.26
+      ox: 0.14.33(typescript@6.0.3)(zod@4.4.3)
       viem: 2.54.0(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -9515,21 +9780,6 @@ snapshots:
 
   outvariant@1.4.0: {}
 
-  ox@0.14.27(typescript@6.0.3)(zod@4.4.3):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.4(typescript@6.0.3)(zod@4.4.3)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - zod
-
   ox@0.14.29(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -9538,14 +9788,14 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
+      abitype: 1.3.0(typescript@6.0.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.14.30(typescript@6.0.3)(zod@4.4.3):
+  ox@0.14.33(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -9553,7 +9803,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.4(typescript@6.0.3)(zod@4.4.3)
+      abitype: 1.3.0(typescript@6.0.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 6.0.3
@@ -10360,6 +10610,10 @@ snapshots:
 
   undici@6.27.0: {}
 
+  undici@7.24.8: {}
+
+  undici@8.9.0: {}
+
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
@@ -10519,9 +10773,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
-      isows: 1.0.7(ws@8.21.0)
+      isows: 1.0.7(ws@8.20.1)
       ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
-      ws: 8.21.0
+      ws: 8.20.1
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -10535,7 +10789,7 @@ snapshots:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       supports-color: 10.2.2
-      undici: 6.27.0
+      undici: 8.9.0
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   vite-plugin-wasm@3.6.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
@@ -10935,7 +11189,7 @@ snapshots:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260616.1)
       blake3-wasm: 2.1.5
-      esbuild: 0.28.1
+      esbuild: 0.27.3
       miniflare: 4.20260616.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
@@ -10947,6 +11201,8 @@ snapshots:
       - utf-8-validate
 
   wrappy@1.0.2: {}
+
+  ws@8.20.1: {}
 
   ws@8.21.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11096,7 +11096,7 @@ snapshots:
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
       hono: 4.12.27
-      ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
+      ox: 0.14.33(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       react: 19.2.7
@@ -11113,7 +11113,7 @@ snapshots:
 
   webauthx@0.1.2(typescript@6.0.3)(zod@4.4.3):
     dependencies:
-      ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
+      ox: 0.14.33(typescript@6.0.3)(zod@4.4.3)
     transitivePeerDependencies:
       - typescript
       - zod

--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -138,6 +138,7 @@ type Page =
   | { path: '/sdk/typescript/core/Challenge.fromHeaders'; render: 'static' }
   | { path: '/sdk/typescript/core/Challenge.fromMethod'; render: 'static' }
   | { path: '/sdk/typescript/core/Challenge.fromResponse'; render: 'static' }
+  | { path: '/sdk/typescript/core/Challenge.fromResponseList'; render: 'static' }
   | { path: '/sdk/typescript/core/Challenge.meta'; render: 'static' }
   | { path: '/sdk/typescript/core/Challenge.serialize'; render: 'static' }
   | { path: '/sdk/typescript/core/Challenge.verify'; render: 'static' }

--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -107,10 +107,10 @@ This generates a `GET /openapi.json` endpoint with canonical `x-payment-info.off
 
 Pass a composed handler to `discovery()` when one route accepts multiple payment options. The generated operation preserves every nested offer in the same order as the runtime Challenges.
 
-```ts [server.ts]
+```ts twoslash [server.ts]
 import { Hono } from 'hono'
-import { Mppx, discovery } from 'mppx/hono'
-import { stripe, tempo } from 'mppx/server'
+import { discovery } from 'mppx/hono'
+import { Mppx, stripe, tempo } from 'mppx/server'
 
 const app = new Hono()
 const charge = tempo.charge({
@@ -130,7 +130,11 @@ const pay = mppx.compose(
   [card, { amount: '1', currency: 'usd', description: 'Premium report' }],
 )
 
-app.get('/v1/report', pay, (c) => c.json({ report: '...' }))
+app.get('/v1/report', async (c) => {
+  const result = await pay(c.req.raw)
+  if (result.status === 402) return result.challenge
+  return result.withReceipt(c.json({ report: '...' }))
+})
 
 discovery(app, mppx, {
   info: { title: 'Reports API', version: '1.0.0' },

--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -103,6 +103,43 @@ discovery(app, mppx, {
 
 This generates a `GET /openapi.json` endpoint with canonical `x-payment-info.offers[]` entries on each paid route.
 
+### Composed offers
+
+Pass a composed handler to `discovery()` when one route accepts multiple payment options. The generated operation preserves every nested offer in the same order as the runtime Challenges.
+
+```ts [server.ts]
+import { Hono } from 'hono'
+import { Mppx, discovery } from 'mppx/hono'
+import { stripe, tempo } from 'mppx/server'
+
+const app = new Hono()
+const charge = tempo.charge({
+  currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+  recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+})
+const card = stripe.charge({
+  decimals: 2,
+  networkId: 'acct_1234',
+  paymentMethodTypes: ['card'],
+  secretKey: 'sk_live_...',
+})
+const mppx = Mppx.create({ methods: [charge, card] })
+
+const pay = mppx.compose(
+  [charge, { amount: '0.01', description: 'Premium report' }],
+  [card, { amount: '1', currency: 'usd', description: 'Premium report' }],
+)
+
+app.get('/v1/report', pay, (c) => c.json({ report: '...' }))
+
+discovery(app, mppx, {
+  info: { title: 'Reports API', version: '1.0.0' },
+  routes: [{ handler: pay, method: 'get', path: '/v1/report' }],
+})
+```
+
+`mppx` derives discovery prices from each method's canonical Payment Request. Defaults and method transforms therefore match the Challenges returned by the paid route.
+
 ### Express
 
 ```ts [server.ts]

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -742,7 +742,9 @@ const receipt = await session.close()
 
 The examples above use Server-Sent Events (SSE) for streaming. If your use case benefits from a persistent bidirectional connection — for example, interactive chat or real-time sessions — you can stream over WebSocket instead. The session payment flow is the same (channel open, voucher signing, close), but vouchers and content travel over a single socket rather than separate HTTP requests.
 
-On the server, use [`tempo.Ws.serve()`](/sdk/typescript/server/Ws.serve) to bridge a WebSocket to the session payment flow. On the client, use [`session.ws()`](/sdk/typescript/client/Method.tempo.session-manager#sessionwsinput-init) instead of `session.sse()`.
+On the server, use [`mppx.session.serveWebSocket()`](/sdk/typescript/server/Ws.serve) to reuse the Session method's store and automatic settlement schedule. On the client, use [`session.ws()`](/sdk/typescript/client/Method.tempo.session-manager#sessionwsinput-init) instead of `session.sse()`.
+
+Configure `settlementSchedule` on `tempo.session()` for SSE or WebSocket streams. `mppx` evaluates the schedule after each committed nonzero stream charge.
 
 ## Next steps
 

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -51,6 +51,8 @@ Use `evm.charge` when you want one MPP route to serve native MPP charge Challeng
 When x402 options are enabled, `mppx` emits both `WWW-Authenticate` and `PAYMENT-REQUIRED` Challenges, accepts either `Authorization` or `PAYMENT-SIGNATURE` Credentials, and returns the matching Receipt header.
 :::
 
+This also applies to body-bearing routes such as `POST`. Standard x402 clients can pay when the route doesn't require MPP-specific request binding. If the Challenge includes a body digest, scope, opaque value, or metadata, the x402 Credential must include the `mppx` route-binding extension; otherwise, use a native MPP Credential.
+
 ### Run an inline x402 endpoint
 
 Configure `evm.charge` with a known x402 asset and a facilitator. The route stays an MPP flow, but also behaves as an x402-compatible server for existing clients.

--- a/src/pages/payment-methods/evm/charge.mdx
+++ b/src/pages/payment-methods/evm/charge.mdx
@@ -127,7 +127,9 @@ const method = evm.charge({
 
 ## x402 compatibility
 
-When `x402.facilitator` is configured, the server returns MPP and x402 Challenges and accepts both MPP and x402 Credentials inline. See [running x402 inline with mppx](/guides/use-mpp-with-x402#run-x402-inline-with-mppx) for the full guide.
+When `x402.facilitator` is configured, the server returns MPP and x402 Challenges and accepts both MPP and x402 Credentials inline for `GET` and body-bearing routes. Standard x402 Credentials work when the route doesn't require an MPP body digest, scope, opaque value, or metadata binding. Bound routes require the `mppx` route-binding extension.
+
+See [running x402 inline with mppx](/guides/use-mpp-with-x402#run-x402-inline-with-mppx) for the full guide.
 
 ## Related resources
 

--- a/src/pages/payment-methods/tempo/session.mdx
+++ b/src/pages/payment-methods/tempo/session.mdx
@@ -20,7 +20,7 @@ The `session` intent enables high-frequency, pay-as-you-go payments over unidire
 Payment sessions reduce payment verification to near constant time, making it possible to meter and bill at the granularity of individual LLM tokens, API calls, or bytes transferred.
 
 :::warning[Legacy integrations]
-`tempo.session` is the current Sessions implementation in `mppx`. The previous contract-backed implementation is Legacy Sessions, also called Sessions v1, and is available as `tempo.sessionLegacy`.
+`tempo.session` is the current Sessions implementation in `mppx`. The previous contract-backed implementation is Legacy Sessions, also called Sessions v1, and is available as `tempo.sessionLegacy`. Legacy server support requires `mppx` 0.8.15 or earlier.
 :::
 
 ## Which client API should I use?
@@ -153,6 +153,8 @@ const mppx = Mppx.create({
 ```
 
 Any threshold can trigger settlement. Use `amount` to settle after a token-denominated spend threshold, `units` to settle after metered usage, and `intervalMs` to settle after elapsed time since the previous scheduled settlement.
+
+The same schedule applies to ordinary HTTP responses, SSE streams, and session-bound WebSocket streams. `mppx` evaluates it after each committed charge.
 
 ### Manual settlement
 
@@ -511,7 +513,7 @@ See [`tempo.session.manager`](/sdk/typescript/client/Method.tempo.session-manage
 
 ## Migrate from Legacy Sessions
 
-Legacy Sessions, also called Sessions v1, is the contract-backed session flow. Use `tempo.sessionLegacy` only when you need compatibility with clients or servers that haven't moved to the latest implementation.
+Legacy Sessions, also called Sessions v1, is the contract-backed session flow. Use `tempo.sessionLegacy` only when you need compatibility with clients or servers that haven't moved to the latest implementation. Legacy server support requires `mppx` 0.8.15 or earlier.
 
 - Register `tempo.session` on the server for the latest implementation.
 - Keep `tempo.sessionLegacy` registered beside `tempo.session` during migration so existing clients keep working.
@@ -531,6 +533,8 @@ Legacy Sessions, also called Sessions v1, is the contract-backed session flow. U
 Current Sessions Challenges advertise `sessionProtocol: "v2"` in method details and use TIP-1034 reserve channels. Legacy Sessions Challenges use the contract-backed Sessions v1 flow. Channel state is not reusable across implementations; let old channels close or settle under `tempo.sessionLegacy`, and open new channels with `tempo.session`.
 
 ### Server
+
+Pin `mppx` to 0.8.15 or earlier for this migration configuration.
 
 ```ts twoslash
 import { Mppx, Store, tempo } from 'mppx/server'

--- a/src/pages/sdk/typescript/client/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session.mdx
@@ -190,6 +190,12 @@ Mppx.create({
 </Tab>
 </Tabs>
 
+## Automatic open retries
+
+When `Fetch.from` or `Mppx.create` opens a channel automatically, it keeps the new channel provisional until the server accepts the response or acknowledges the open with a matching Receipt or Session snapshot. A rejected or unacknowledged open is discarded, so the next paid request retries it. Concurrent automatic opens for the same payment scope and channel store are serialized.
+
+Direct Credential creation and `tempo.session.manager()` keep explicit lifecycle ownership.
+
 ## Return type
 
 ```ts

--- a/src/pages/sdk/typescript/client/Transport.from.mdx
+++ b/src/pages/sdk/typescript/client/Transport.from.mdx
@@ -9,8 +9,8 @@ import { Challenge } from 'mppx'
 import { Transport } from 'mppx/client'
 
 const http = Transport.from<RequestInit, Response>({
-  getChallenge(response) {
-    return Challenge.fromResponse(response)
+  getChallenges(response) {
+    return Challenge.fromResponseList(response)
   },
   isPaymentRequired(response) {
     return response.status === 402
@@ -28,28 +28,28 @@ const http = Transport.from<RequestInit, Response>({
 
 ```ts
 type Transport<request, response> = {
+  /** Extracts every Challenge from a payment-required response. */
+  getChallenges: (response: response, request?: request) => Challenge[] | Promise<Challenge[]>
+  /** Checks if a response indicates payment is required. */
+  isPaymentRequired: (response: response, request?: request) => boolean | Promise<boolean>
   /** Transport name for identification. */
   name: string
-  /** Checks if a response indicates payment is required. */
-  isPaymentRequired: (response: response) => boolean
-  /** Extracts the challenge from a payment-required response. */
-  getChallenge: (response: response) => Challenge
   /** Attaches a credential to a request. */
-  setCredential: (request: request, credential: string) => request
+  setCredential: (request: request, credential: string, options?: SetCredentialOptions) => request
 }
 ```
 
 ## Parameters
 
-### getChallenge
+### getChallenges
 
-- **Type:** `(response: Response) => Challenge`
+- **Type:** `(response: Response, request?: RequestInit) => Challenge[] | Promise<Challenge[]>`
 
-Function that extracts the Challenge from a payment-required response.
+Function that extracts every Challenge from a payment-required response. Return the Challenges in preference order.
 
 ### isPaymentRequired
 
-- **Type:** `(response: Response) => boolean`
+- **Type:** `(response: Response, request?: RequestInit) => boolean | Promise<boolean>`
 
 Function that checks if a response indicates payment is required.
 
@@ -61,6 +61,6 @@ Transport name for identification.
 
 ### setCredential
 
-- **Type:** `(request: Request, credential: string) => Request`
+- **Type:** `(request: RequestInit, credential: string, options?: SetCredentialOptions) => RequestInit`
 
 Function that attaches a Credential to a request.

--- a/src/pages/sdk/typescript/core/Challenge.fromResponseList.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.fromResponseList.mdx
@@ -1,0 +1,58 @@
+# `Challenge.fromResponseList` [Extract multiple Challenges]
+
+Extracts every Payment Challenge from a `402` Response.
+
+## Usage
+
+```ts twoslash
+import { Challenge } from 'mppx'
+
+const response = await fetch('/resource')
+if (response.status === 402) {
+  const challenges = Challenge.fromResponseList(response)
+}
+```
+
+The returned array preserves the order of the Payment Challenges in the `WWW-Authenticate` header.
+
+### With method type narrowing
+
+Use method definitions to get type-safe access to method-specific request fields.
+
+```ts twoslash
+import { Challenge } from 'mppx'
+import { Methods } from 'mppx/tempo'
+
+const response = await fetch('/resource')
+if (response.status === 402) {
+  const challenges = Challenge.fromResponseList(response, {
+    methods: [Methods.charge],
+  })
+}
+```
+
+## Return type
+
+```ts
+type ReturnType = Challenge[]
+```
+
+An ordered array of deserialized Challenges.
+
+## Parameters
+
+### options (optional)
+
+- **Type:** `{ methods?: readonly Method.Method[] }`
+
+Optional settings to narrow the Challenge types using method intents.
+
+### response
+
+- **Type:** `Response`
+
+The HTTP response. Its status must be `402`.
+
+## Errors
+
+Throws when the response isn't `402`, the `WWW-Authenticate` header is missing, or the header contains no Payment Challenges.

--- a/src/pages/sdk/typescript/server/Method.evm.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.evm.charge.mdx
@@ -108,7 +108,7 @@ Custom settlement callback. Use this instead of `x402.facilitator` when you sett
 
 - **Type:** `{ facilitator: string | Facilitator }`
 
-x402 compatibility options. Pass a facilitator URL to verify and settle x402 exact payments inline.
+x402 compatibility options. Pass a facilitator URL to verify and settle x402 exact payments inline. `mppx` advertises x402 for `GET` and body-bearing requests. Standard x402 Credentials work on routes without MPP-specific digest, scope, opaque, or metadata binding; bound routes require the `mppx` extension.
 
 ## Request parameters
 

--- a/src/pages/sdk/typescript/server/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.mdx
@@ -20,7 +20,7 @@ Use `tempo(...)` by default. Use `tempo.common(...)` only when you want to make 
 Register [`tempo.subscription`](/sdk/typescript/server/Method.tempo.subscription) separately for recurring payments.
 
 :::warning[Legacy Sessions]
-`tempo.session` is the current Sessions implementation. The previous contract-backed flow is Legacy Sessions, also called Sessions v1, and is available as `tempo.sessionLegacy`.
+`tempo.session` is the current Sessions implementation. The previous contract-backed flow is Legacy Sessions, also called Sessions v1, and is available as `tempo.sessionLegacy` in `mppx` 0.8.15 and earlier.
 :::
 
 ## Usage

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -14,7 +14,7 @@ Creates a Tempo Sessions server method for voucher verification, channel account
 :::
 
 :::warning[Legacy Sessions]
-The previous contract-backed implementation is Legacy Sessions, also called Sessions v1, and is available as `tempo.sessionLegacy`. Use Sessions for new integrations.
+The previous contract-backed implementation is Legacy Sessions, also called Sessions v1, and is available as `tempo.sessionLegacy` in `mppx` 0.8.15 and earlier. Use Sessions for new integrations.
 :::
 
 ## Usage
@@ -61,7 +61,7 @@ const mppx = Mppx.create({
 
 ### With Legacy Sessions
 
-Use `tempo.sessionLegacy()` only for clients that still send Legacy Sessions Credentials.
+Use `tempo.sessionLegacy()` only for clients that still send Legacy Sessions Credentials. Pin `mppx` to 0.8.15 or earlier when maintaining a Legacy Sessions server.
 
 ```ts twoslash
 import { Mppx, Store, tempo } from 'mppx/server'
@@ -82,7 +82,7 @@ const mppx = Mppx.create({
 
 ## Migrate from Legacy Sessions
 
-Register `tempo.session()` beside `tempo.sessionLegacy()` during migration so existing clients keep working while new clients use Sessions.
+Register `tempo.session()` beside `tempo.sessionLegacy()` during migration so existing clients keep working while new clients use Sessions. This server-side migration configuration requires `mppx` 0.8.15 or earlier.
 
 | Server methods | Compatible client methods |
 |---|---|
@@ -146,6 +146,12 @@ const mppx = Mppx.create({
 ```
 
 If the resolver returns a known channel ID, the server responds with `Payment-Session` and `Payment-Session-Snapshot`. If it returns `undefined`, the server returns `204` without a snapshot and the client falls back to opening a new channel.
+
+### Validate before broadcast
+
+Tempo Sessions support the split Credential lifecycle used by [`mppx.validateCredential`](/sdk/typescript/server/Mppx.validateCredential) and [`mppx.broadcastCredential`](/sdk/typescript/server/Mppx.broadcastCredential). Validation checks the Credential without changing channel state. Broadcasting validates again, accepts the voucher or management action, updates accounting, and returns a Receipt.
+
+Use the split lifecycle for custom transports or background workflows. Normal route handlers invoke it automatically.
 
 ## Return type
 
@@ -323,6 +329,25 @@ Suggested deposit amount communicated to clients in the Challenge.
 Unit type label, such as `"token"`, `"byte"`, or `"request"`.
 
 ## Related
+
+### `mppx.session.serveWebSocket`
+
+Serves a WebSocket route with the store and automatic settlement schedule configured by this Session method.
+
+```ts
+await mppx.session.serveWebSocket({
+  generate,
+  route,
+  socket,
+  url: 'wss://api.example.com/stream',
+})
+```
+
+See [`mppx.session.serveWebSocket`](/sdk/typescript/server/Ws.serve) for the full API.
+
+### `mppx.session.settleScheduled`
+
+Applies this method's `settlementSchedule` to a committed channel charge. The session-bound WebSocket and SSE transports call it automatically. Pass it to a custom streaming adapter's post-charge hook when you manage the transport yourself.
 
 ### Snapshot helpers
 

--- a/src/pages/sdk/typescript/server/Mppx.broadcastCredential.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.broadcastCredential.mdx
@@ -29,6 +29,8 @@ console.log(receipt.status)
 // @log: success
 ```
 
+Tempo charge and Session methods implement this lifecycle. For a Session Credential, broadcasting validates again, accepts the voucher or management action, updates channel accounting, and returns a Session Receipt.
+
 ## Return type
 
 ```ts

--- a/src/pages/sdk/typescript/server/Mppx.compose.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.compose.mdx
@@ -58,6 +58,24 @@ const paid = Mppx.compose(
 - **Credential present:** Dispatches to the handler matching the Credential's `method` and `intent`.
 - **Discovery enabled:** Exposes every configured offer to `discovery()` and proxy metadata, including offers from nested compositions.
 
+## Signatures
+
+### Instance
+
+```ts
+type InstanceCompose = (
+  ...entries: readonly [Method.Server | MethodHandler | string, Options][]
+) => ComposedHandler
+```
+
+### Static
+
+```ts
+type StaticCompose = (
+  ...handlers: readonly (ComposedHandler | ConfiguredHandler)[]
+) => ComposedHandler
+```
+
 ## Return type
 
 ```ts
@@ -71,6 +89,12 @@ type ReturnType = (input: Request) => Promise<
 
 ### ...entries
 
-- **Type:** `readonly [Method.Server | string, Options][]`
+- **Type:** `readonly [Method.Server | MethodHandler | string, Options][]`
 
 Each entry is a tuple of a method reference (or string key like `"tempo/charge"`) and the request options for that method. Requires at least one entry.
+
+### ...handlers
+
+- **Type:** `readonly (ComposedHandler | ConfiguredHandler)[]`
+
+Configured route handlers returned by an `mppx` method or another static composition. Requires at least one handler.

--- a/src/pages/sdk/typescript/server/Mppx.compose.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.compose.mdx
@@ -35,11 +35,28 @@ export async function handler(request: Request) {
 }
 ```
 
+### Nested compositions
+
+Use the static `Mppx.compose()` function to combine configured handlers or another composed handler. Credential dispatch and discovery metadata include every nested offer.
+
+```ts
+const stablecoins = Mppx.compose(
+  mppx.tempo.charge({ amount: '1', currency: pathUSD }),
+  mppx.tempo.charge({ amount: '1', currency: USDCe }),
+)
+
+const paid = Mppx.compose(
+  stablecoins,
+  mppx.stripe.charge({ amount: '1', currency: 'usd' }),
+)
+```
+
 ## Behavior
 
 - **No Credential present:** Calls all handlers and merges their `402` Challenges into a single response with multiple `WWW-Authenticate` headers.
 - **`Accept-Payment` present:** Ranks and filters the merged Challenges by the client's supported `method/intent` entries. Entries with `q=0` are excluded. If the header is invalid or filters out every Challenge, all Challenges are returned.
 - **Credential present:** Dispatches to the handler matching the Credential's `method` and `intent`.
+- **Discovery enabled:** Exposes every configured offer to `discovery()` and proxy metadata, including offers from nested compositions.
 
 ## Return type
 

--- a/src/pages/sdk/typescript/server/Mppx.validateCredential.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.validateCredential.mdx
@@ -30,6 +30,8 @@ console.log(validation.source)
 
 `validateCredential` is an advisory pre-check. Call `broadcastCredential` to accept payment.
 
+Tempo charge and Session methods implement this lifecycle. For a Session Credential, validation checks the channel, action, signature, and voucher state without accepting the voucher or updating channel accounting.
+
 ## Return type
 
 ```ts

--- a/src/pages/sdk/typescript/server/Ws.serve.mdx
+++ b/src/pages/sdk/typescript/server/Ws.serve.mdx
@@ -1,13 +1,13 @@
 import { SigningAccountTabs } from '../../../../components/SigningAccountTabs'
 
-# `tempo.Ws.serve` [WebSocket session payments]
+# `mppx.session.serveWebSocket` [WebSocket session payments]
 
 ## Choose a signing account
 
 <SigningAccountTabs />
 
 
-Bridges a WebSocket connection to a Tempo session payment flow. Credential verification is performed by routing each in-band authorization frame through `route` as a synthetic POST request that carries only the Authorization header. The synthetic request does not include cookies, bodies, query parameters, or other headers from the original WebSocket upgrade request.
+Bridges a WebSocket connection to a Tempo Session using the method's configured store and settlement schedule.
 
 ## Usage
 
@@ -16,31 +16,37 @@ import { Mppx, Store, tempo } from 'mppx/server'
 import { privateKeyToAccount } from 'viem/accounts'
 
 const words = ['hello', 'world']
+const store = Store.memory()
 
 const mppx = Mppx.create({
   methods: [
     tempo.session({
       account: privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'),
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      settlementSchedule: { units: 100 },
+      store,
     }),
   ],
 })
 
-declare const socket: Parameters<typeof tempo.Ws.serve>[0]['socket']
+const route = mppx.session({ amount: '0.001', unitType: 'word' })
+declare const socket: Parameters<typeof mppx.session.serveWebSocket>[0]['socket']
 
 // In your WebSocket handler:
-tempo.Ws.serve({
+await mppx.session.serveWebSocket({
   generate: async function* (stream) {
     for (const word of words) {
       await stream.charge()
       yield word
     }
   },
-  route: (request) => mppx.session({ amount: '0.001', currency: 'pathUSD', unitType: 'word' })(request),
+  route,
   socket,
-  store: Store.memory(),
   url: 'wss://api.example.com/stream',
 })
 ```
+
+The helper shares the `Store` and `settlementSchedule` configured by `tempo.session()`. It applies the schedule after every committed WebSocket charge.
 
 ## Return type
 
@@ -73,7 +79,7 @@ Polling interval in milliseconds for voucher balance checks.
 
 ### route
 
-- **Type:** `Parameters<typeof tempo.Ws.serve>[0]['route']`
+- **Type:** `Parameters<typeof mppx.session.serveWebSocket>[0]['route']`
 
 Session route handler. Receives synthetic POST requests constructed from in-band authorization frames. The synthetic request carries only the `Authorization` header—no cookies, bodies, query parameters, or other headers from the original WebSocket upgrade request.
 
@@ -89,27 +95,58 @@ const mppx = Mppx.create({
   ],
 })
 
-const route: Parameters<typeof tempo.Ws.serve>[0]['route'] = (request) =>
-  mppx.session({ amount: '0.001', currency: 'pathUSD', unitType: 'word' })(request)
+const route: Parameters<typeof mppx.session.serveWebSocket>[0]['route'] =
+  mppx.session({ amount: '0.001', unitType: 'word' })
 ```
 
 ### socket
 
-- **Type:** `Parameters<typeof tempo.Ws.serve>[0]['socket']`
+- **Type:** `Parameters<typeof mppx.session.serveWebSocket>[0]['socket']`
 
 WebSocket instance. Accepts a browser `WebSocket`, a `ws` library socket, or any object implementing `send`/`close` with either `addEventListener`/`removeEventListener` or `on`/`off`.
-
-### store
-
-- **Type:** `Store.Store | ChannelStore`
-
-Channel store for persisting session and channel state.
 
 ### url
 
 - **Type:** `string`
 
 URL used for constructing synthetic route requests. `ws://` and `wss://` schemes are normalized to `http://` and `https://`.
+
+## Advanced options
+
+Use `tempo.Ws.serve()` when a custom integration manages its own store or post-charge behavior. Pass `onChargeCommitted` to run a hook after each nonzero stream charge commits. The legacy `settleScheduled` option remains as a deprecated alias.
+
+```ts twoslash
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const store = Store.memory()
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account: privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'),
+      settlementSchedule: { units: 100 },
+      store,
+    }),
+  ],
+})
+
+const route = mppx.session({ amount: '0.001', unitType: 'word' })
+declare const socket: Parameters<typeof tempo.Ws.serve>[0]['socket']
+
+await tempo.Ws.serve({
+  generate: async function* () {
+    yield 'hello'
+    yield 'world'
+  },
+  onChargeCommitted: mppx.session.settleScheduled,
+  route,
+  socket,
+  store,
+  url: 'wss://api.example.com/stream',
+})
+```
+
+Credential verification routes each in-band authorization frame through `route` as a synthetic `POST` request carrying only the `Authorization` header. It doesn't include cookies, bodies, query parameters, or other headers from the original WebSocket upgrade request.
 
 ## Helper functions
 

--- a/src/pages/sdk/typescript/server/Ws.serve.mdx
+++ b/src/pages/sdk/typescript/server/Ws.serve.mdx
@@ -134,8 +134,10 @@ const route = mppx.session({ amount: '0.001', unitType: 'word' })
 declare const socket: Parameters<typeof tempo.Ws.serve>[0]['socket']
 
 await tempo.Ws.serve({
-  generate: async function* () {
+  generate: async function* (stream) {
+    await stream.charge()
     yield 'hello'
+    await stream.charge()
     yield 'world'
   },
   onChargeCommitted: mppx.session.settleScheduled,

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -769,7 +769,7 @@ export default defineConfig({
                     collapsed: true,
                     items: [
                       {
-                        text: "Ws.serve",
+                        text: "session.serveWebSocket",
                         link: "/sdk/typescript/server/Ws.serve",
                       },
                     ],

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -177,6 +177,10 @@ export default defineConfig({
       destination: "/sdk/typescript/core/Challenge.fromResponse",
     },
     {
+      source: "/sdk/typescript/Challenge.fromResponseList",
+      destination: "/sdk/typescript/core/Challenge.fromResponseList",
+    },
+    {
       source: "/sdk/typescript/Challenge.serialize",
       destination: "/sdk/typescript/core/Challenge.serialize",
     },
@@ -859,6 +863,10 @@ export default defineConfig({
                       {
                         text: ".fromResponse",
                         link: "/sdk/typescript/core/Challenge.fromResponse",
+                      },
+                      {
+                        text: ".fromResponseList",
+                        link: "/sdk/typescript/core/Challenge.fromResponseList",
                       },
                       {
                         text: ".meta",


### PR DESCRIPTION
## Motivation

Keep the MPP documentation aligned with the latest public `mppx` interfaces and behavior on `main`. These interfaces postdate the npm `0.8.15` release.

## Summary

- update TypeScript SDK references and guides for discovery, transports, x402 requests, Tempo sessions, validation, broadcasting, and WebSocket serving
- add `Challenge.fromResponseList` reference documentation and navigation
- retain and version-scope legacy session documentation
- pin the reviewed `0.0.0-main-20260803172527` snapshot and sync bookmark

## Key design considerations

- identify the timestamped prerelease package explicitly instead of implying npm `0.8.15` compatibility
- preserve legacy session migration guidance for `mppx` 0.8.15 and earlier
- keep composed discovery and WebSocket charging examples under twoslash validation