### PR TITLE
fix: link service arrows to provider websites

### DIFF
--- a/src/components/ServicesPage.test.tsx
+++ b/src/components/ServicesPage.test.tsx
@@ -6,6 +6,7 @@ import {
   CATEGORY_LABELS,
   formatPrice,
   PAGE_SIZE,
+  providerUrl,
 } from "./ServicesPage";
 
 // ---------------------------------------------------------------------------
@@ -184,6 +185,23 @@ describe("PAGE_SIZE", () => {
 
   it("is 60", () => {
     expect(PAGE_SIZE).toBe(60);
+  });
+});
+
+describe("providerUrl", () => {
+  it("uses the provider website when present", () => {
+    expect(
+      providerUrl({
+        provider: { name: "Modal", url: "https://modal.com" },
+        url: "https://api.modal.com",
+      }),
+    ).toBe("https://modal.com");
+  });
+
+  it("falls back to the upstream URL without provider metadata", () => {
+    expect(providerUrl({ url: "https://api.example.com" })).toBe(
+      "https://api.example.com",
+    );
   });
 });
 

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -66,6 +66,8 @@ export function formatPrice(endpoint: Endpoint): string {
 const categoryLabel = (service: Service) =>
   service.categories?.[0] ? CATEGORY_LABELS[service.categories[0]] : "Service";
 const serviceUrl = (service: Service) => service.serviceUrl ?? service.url;
+export const providerUrl = (service: Pick<Service, "provider" | "url">) =>
+  service.provider?.url ?? service.url;
 const endpointUrl = (service: Service, endpoint: Endpoint) =>
   new URL(
     endpoint.path,
@@ -157,7 +159,7 @@ function ServiceTableRow({ service }: { service: Service }) {
             <a
               aria-label={`Open ${service.name}`}
               className={action}
-              href={service.url}
+              href={providerUrl(service)}
               onClick={(event) => event.stopPropagation()}
               rel="noopener noreferrer"
               target="_blank"


### PR DESCRIPTION
## Summary

- Link the services list arrow to `provider.url` so Modal opens `https://modal.com` instead of the upstream API root.
- Fall back to `service.url` when provider metadata is unavailable.
- Add regression coverage for provider URL selection.

## Tests

- `./node_modules/.bin/vitest run src/components/ServicesPage.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/biome check src/components/ServicesPage.tsx src/components/ServicesPage.test.tsx`
- `git diff --check`

Prompted by: @brendanjryan