### PR TITLE
fix: improve code highlight contrast

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -1368,6 +1368,18 @@ pre[data-v] {
   padding-block: calc(var(--vocs-spacing) * 3) !important;
 }
 
+/* Code highlights — increase contrast against the dark code-block surface. */
+pre[data-v] > code > .line.highlighted {
+  background-color: light-dark(
+    var(--vocs-color-gray12),
+    var(--vocs-color-gray5)
+  );
+  border-left-color: light-dark(
+    var(--vocs-color-gray10),
+    var(--vocs-color-gray8)
+  );
+}
+
 pre[data-v]::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Motivation

Highlighted code lines blend into the dark code-block background, making examples harder to scan.

## Summary

- Increase highlighted-line background contrast in dark mode
- Strengthen the left highlight border

## Key design considerations

- Keep the treatment neutral so it does not imply a semantic state
- Preserve the existing light-theme colors