### PR TITLE
docs: clarify TAP trust store example

### DIFF
--- a/src/pages/advanced/identity.mdx
+++ b/src/pages/advanced/identity.mdx
@@ -161,15 +161,14 @@ import * as Attestation from 'mppx/attestation'
 import * as Tap from 'mppx/attestation/tap'
 import { Mppx, tempo } from 'mppx/server'
 
-declare const agentPublicKey: CryptoKey
+declare const trustedAgentKeys: ReadonlyMap<string, CryptoKey>
 
 const payment = Mppx.create({
   // [!code hl:start]
   attestation: {
     tap: Tap.Server.verifier({
       keyResolver({ keyId }) {
-        if (keyId !== 'agent-provider-key-1') return undefined
-        return agentPublicKey
+        return trustedAgentKeys.get(keyId)
       },
       nonceStore: Attestation.NonceStore.memory(),
     }),
@@ -209,13 +208,12 @@ import * as Attestation from 'mppx/attestation'
 import * as Tap from 'mppx/attestation/tap'
 import { Mppx, tempo } from 'mppx/server'
 
-declare const agentPublicKey: CryptoKey
+declare const trustedAgentKeys: ReadonlyMap<string, CryptoKey>
 
 const nonceStore = Attestation.NonceStore.memory()
 const tap = Tap.Server.verifier({
   keyResolver({ keyId }) {
-    if (keyId !== 'agent-provider-key-1') return undefined
-    return agentPublicKey
+    return trustedAgentKeys.get(keyId)
   },
   nonceStore,
 })


### PR DESCRIPTION
## Motivation

Make the TAP key resolver clearly read as an application trust-store lookup.

## Summary

- replace single-key comparison examples with trustedAgentKeys lookups
- align both TAP server examples on the same trust-store pattern

## Key design considerations

- keep key retrieval application-defined while making the trust boundary explicit