### PR TITLE
Add ThaiChain Bridge to service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11167,4 +11167,45 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+  // ── ThaiChain Bridge ─────────────────────────────────────────────────
+  {
+    id: "thaichain-bridge",
+    name: "ThaiChain Bridge",
+    url: "https://thaichain.org",
+    serviceUrl: "https://bridge.thaichain.org",
+    description:
+      "Bridge USDC from Tempo to ThaiChain with multi-sig relayer confirmation. Pay with USDC.e on Tempo, receive Wrapped USDC on ThaiChain.",
+    categories: ["blockchain"],
+    integration: "first-party",
+    tags: ["bridge", "usdc", "tempo", "thaichain", "cross-chain", "multi-sig"],
+    status: "active",
+    docs: {
+      homepage: "https://thaichain.org",
+      apiReference: "https://bridge.thaichain.org/openapi.json",
+    },
+    provider: { name: "ThaiChain", url: "https://thaichain.org" },
+    realm: "bridge.thaichain.org",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /api/bridge",
+        desc: "Bridge USDC from Tempo to ThaiChain",
+        amountHint: "1-10000 USDC (0.3% fee)",
+        dynamic: true,
+      },
+      {
+        route: "GET /api/bridge/:id/status",
+        desc: "Check bridge request status",
+      },
+      {
+        route: "GET /api/bridge/stats",
+        desc: "Get bridge statistics",
+      },
+      {
+        route: "GET /api/bridge/health",
+        desc: "Health check",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary

Add ThaiChain Bridge to the MPP service directory.

## Service Details

**ThaiChain Bridge** enables USDC bridging from Tempo to ThaiChain with:
- Multi-sig relayer confirmation (2/3)
- 0.3% fee (30 bps)
- Amount range: 1-10,000 USDC
- Live and accepting payments via MPP

**Service URL:** https://bridge.thaichain.org  
**MPPScan:** https://www.mppscan.com/server/ec64708ec64e602ff11c05ca8266dc295c691083607a0577df9fc292fd6aacf5  
**OpenAPI:** https://bridge.thaichain.org/openapi.json

## Checklist

- [x] Service is live and accepting payments via MPP
- [x] Added entry to `schemas/services.ts`
- [x] Types pass: `pnpm check:types`
- [x] Build succeeds: `pnpm build`
- [x] Registered on MPPScan

## Endpoints

- `POST /api/bridge` - Bridge USDC from Tempo to ThaiChain (dynamic pricing, 0.3% fee)
- `GET /api/bridge/:id/status` - Check bridge request status
- `GET /api/bridge/stats` - Get bridge statistics
- `GET /api/bridge/health` - Health check

## Testing

The service has been tested end-to-end with successful bridges:
- Bridge ID: `2b344e89-3854-4b1c-a9ae-2ef0b9ac9329`
- Status: completed
- ThaiChain TX: `0x32344d3fae5cd074f813fcec804e7ac5e8fa3d98a7e44aa4b2096b1ee0e1fa51`