### PR TITLE
fix: prevent code operator ligature bleed

### DIFF
--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -1344,6 +1344,7 @@ pre,
 code,
 .vocs_Code,
 [data-v-code] {
+  font-variant-ligatures: none;
   letter-spacing: 0;
   font-family: var(--font-mono) !important;
 }


### PR DESCRIPTION
## Motivation

Geist Mono operator ligatures can extend into adjacent syntax and create visual bleed in code blocks.

## Summary

- Disable ligatures across code text
- Keep operators within their normal character bounds

## Key design considerations

- Apply the rule to the existing shared code typography selectors so inline and block code render consistently