### PR TITLE
services: add Leya — Latin American legal research

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1375,6 +1375,57 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Leya ───────────────────────────────────────────────────────────────
+  {
+    id: "leya",
+    name: "Leya",
+    url: "https://leya.lawyer",
+    serviceUrl: "https://api.leya.lawyer",
+    description:
+      "Search and cite primary Latin American law — statutes, decrees, congressional initiatives, court rulings and official gazettes — plus Guatemalan cadastral parcels with protected-area, watershed and archaeological overlays.",
+
+    categories: ["data", "search"],
+    integration: "first-party",
+    tags: [
+      "legal",
+      "latin-america",
+      "guatemala",
+      "citations",
+      "cadastral",
+      "case-law",
+    ],
+    docs: {
+      homepage: "https://leya.lawyer/docs/api",
+      llmsTxt: "https://leya.lawyer/llms-full.txt",
+    },
+    provider: { name: "Leya", url: "https://leya.lawyer" },
+    realm: "leya.lawyer",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /v1/search",
+        desc: "Hybrid keyword and semantic search over primary Latin American legal sources, with stable document ids and source attribution",
+        amount: "30000",
+      },
+      {
+        route: "GET /v1/documents/{document_id}",
+        desc: "Full text of one legal document",
+        amount: "10000",
+      },
+      {
+        route: "GET /v1/documents/{document_id}/citation",
+        desc: "Formatted citation for a document, marked partial when the corpus lacks the metadata to complete it",
+        amount: "10000",
+      },
+      {
+        route: "GET /v1/parcels/{ccc}",
+        desc: "Guatemalan cadastral parcel by código catastral, with the protected areas, watersheds and archaeological sites it intersects",
+        amount: "20000",
+      },
+    ],
+  },
+
   // ── Google Gemini ──────────────────────────────────────────────────────
   {
     id: "gemini",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1399,7 +1399,7 @@ export const services: ServiceDef[] = [
       llmsTxt: "https://leya.lawyer/llms-full.txt",
     },
     provider: { name: "Leya", url: "https://leya.lawyer" },
-    realm: "leya.lawyer",
+    realm: "api.leya.lawyer",
     intent: "charge",
     payments: [TEMPO_PAYMENT],
     endpoints: [


### PR DESCRIPTION
Adds **Leya** to the curated service directory.

Leya is a search API over primary Latin American legal sources — statutes, decrees, congressional initiatives (*iniciativas*), court rulings (*sentencias*), regulations and official gazettes — currently covering Guatemala and the Dominican Republic. Every result carries a stable document id, source attribution, a link to the official document, and corpus-freshness metadata, so an agent can cite real law instead of recalling it.

It also serves Guatemala's cadastral parcels from RIC (630,961 of them) intersected with protected areas, watersheds, sacred sites, archaeological sites and forestry-incentive zones — which is how you find out whether a parcel sits inside a national park.

### Checklist

- [x] **Live and accepting payments via MPP** — keyless on Tempo mainnet. An unauthenticated call to any `/v1` read returns a settleable 402:
  ```
  tempo request "https://api.leya.lawyer/v1/search?q=despido+injustificado&country=GT"
  ```
- [x] Entry added to `schemas/services.ts`
- [x] `pnpm check:types` passes
- [x] `pnpm build` passes

### Discovery

`https://api.leya.lawyer/openapi.json` follows `draft-payment-discovery-00`, with top-level `x-service-info` and per-operation `x-payment-info` priced in USDC.e base units.

Agent-facing docs at https://leya.lawyer/llms-full.txt.

### On novelty

The directory currently lists one legal service (GovLaws, US federal regulation). Leya covers Latin American jurisdictions instead, so it complements rather than duplicates it — and the cadastral overlay data has no equivalent in the list. Priced at parity with GovLaws for search (30000).