### PR TITLE
Add SameDayDesk to MPP services

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6406,6 +6406,12 @@ export const services: ServiceDef[] = [
         unitType: "request",
       },
       {
+        route: "GET /distribution/agent-surface-budget-audit",
+        desc: "Measure MCP and OpenAPI context burden and return progressive-discovery fixes",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
         route: "GET /commerce/payment-offer-preflight",
         desc: "Normalize payment terms and seller response readiness before authorization",
         amount: "5000",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6291,7 +6291,7 @@ export const services: ServiceDef[] = [
     url: "https://samedaydesk.com",
     serviceUrl: "https://agents.samedaydesk.com",
     description:
-      "Deterministic paid APIs for web extraction, company and wallet intelligence, repository risk, agent-work economics, machine-service discoverability, payment-offer preflight, and Morpho decision evidence.",
+      "Deterministic paid APIs for web and wallet intelligence, machine-service discovery and integrity, payment evidence, delegated-wallet policy checks, agent-work economics, and Morpho decision evidence.",
     icon: "https://samedaydesk.com/favicon.svg",
     categories: ["blockchain", "data", "web"],
     integration: "first-party",
@@ -6300,6 +6300,7 @@ export const services: ServiceDef[] = [
       "company-intelligence",
       "defi",
       "machine-commerce",
+      "payment-integrity",
       "repository-security",
       "web-extraction",
     ],
@@ -6323,13 +6324,13 @@ export const services: ServiceDef[] = [
       {
         route: "GET /extract",
         desc: "Extract structured metadata and readable content from a URL",
-        amount: "50000",
+        amount: "5000",
         unitType: "request",
       },
       {
         route: "GET /read",
         desc: "Read a URL as clean Markdown for LLM context",
-        amount: "50000",
+        amount: "5000",
         unitType: "request",
       },
       {
@@ -6393,6 +6394,12 @@ export const services: ServiceDef[] = [
         unitType: "request",
       },
       {
+        route: "POST /work/opportunity-preflight",
+        desc: "Evaluate agent-work opportunity economics from a JSON request",
+        amount: "50000",
+        unitType: "request",
+      },
+      {
         route: "GET /distribution/agent-discoverability-audit",
         desc: "Audit machine-service discovery rank and route coverage across agent catalogs",
         amount: "50000",
@@ -6400,8 +6407,56 @@ export const services: ServiceDef[] = [
       },
       {
         route: "GET /commerce/payment-offer-preflight",
-        desc: "Normalize x402 and MPP terms before buyer authorization",
+        desc: "Normalize payment terms and seller response readiness before authorization",
         amount: "5000",
+        unitType: "request",
+      },
+      {
+        route: "POST /commerce/payment-offer-preflight",
+        desc: "Normalize payment terms and seller response readiness from JSON input",
+        amount: "5000",
+        unitType: "request",
+      },
+      {
+        route: "GET /commerce/seller-integrity-audit",
+        desc: "Audit one exact seller route and return bounded repair actions",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "GET /commerce/contract-qualified-search",
+        desc: "Find machine services that guarantee buyer-required output paths",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "GET /commerce/settlement-proof",
+        desc: "Verify an exact claimed Base USDC settlement onchain",
+        amount: "5000",
+        unitType: "request",
+      },
+      {
+        route: "GET /chain/transaction-receipt",
+        desc: "Normalize a Base or Ethereum receipt and ERC-20 transfers",
+        amount: "2000",
+        unitType: "request",
+      },
+      {
+        route: "GET /chain/solana-transaction-receipt",
+        desc: "Normalize a finalized Solana receipt and SPL-token deltas",
+        amount: "2000",
+        unitType: "request",
+      },
+      {
+        route: "POST /security/wallet-policy-conformance",
+        desc: "Evaluate delegated-wallet policy conformance from safe observations",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "POST /security/stateful-wallet-policy-conformance",
+        desc: "Evaluate sequential delegated-wallet limit enforcement",
+        amount: "10000",
         unitType: "request",
       },
     ],

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6291,7 +6291,7 @@ export const services: ServiceDef[] = [
     url: "https://samedaydesk.com",
     serviceUrl: "https://agents.samedaydesk.com",
     description:
-      "Deterministic paid APIs for web extraction, company and wallet intelligence, repository risk, agent-work economics, and Morpho decision evidence.",
+      "Deterministic paid APIs for web extraction, company and wallet intelligence, repository risk, agent-work economics, machine-service discoverability, and Morpho decision evidence.",
     icon: "https://samedaydesk.com/favicon.svg",
     categories: ["blockchain", "data", "web"],
     integration: "first-party",
@@ -6389,6 +6389,12 @@ export const services: ServiceDef[] = [
       {
         route: "GET /work/opportunity-preflight",
         desc: "Evaluate agent-work opportunity economics before execution",
+        amount: "50000",
+        unitType: "request",
+      },
+      {
+        route: "GET /distribution/agent-discoverability-audit",
+        desc: "Audit machine-service discovery rank and route coverage across agent catalogs",
         amount: "50000",
         unitType: "request",
       },

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6284,6 +6284,117 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── SameDayDesk ──────────────────────────────────────────────────────
+  {
+    id: "samedaydesk",
+    name: "SameDayDesk",
+    url: "https://samedaydesk.com",
+    serviceUrl: "https://agents.samedaydesk.com",
+    description:
+      "Deterministic paid APIs for web extraction, company and wallet intelligence, repository risk, agent-work economics, and Morpho decision evidence.",
+    icon: "https://samedaydesk.com/favicon.svg",
+    categories: ["blockchain", "data", "web"],
+    integration: "first-party",
+    tags: [
+      "agentic-payments",
+      "company-intelligence",
+      "defi",
+      "machine-commerce",
+      "repository-security",
+      "web-extraction",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://samedaydesk.com/x402",
+      llmsTxt: "https://agents.samedaydesk.com/llms.txt",
+      apiReference: "https://agents.samedaydesk.com/openapi.json",
+    },
+    provider: { name: "SameDayDesk", url: "https://samedaydesk.com" },
+    realm: "agents.samedaydesk.com",
+    intent: "charge",
+    payments: [
+      {
+        method: "evm",
+        currency: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        decimals: 6,
+      },
+    ],
+    endpoints: [
+      {
+        route: "GET /extract",
+        desc: "Extract structured metadata and readable content from a URL",
+        amount: "50000",
+        unitType: "request",
+      },
+      {
+        route: "GET /read",
+        desc: "Read a URL as clean Markdown for LLM context",
+        amount: "50000",
+        unitType: "request",
+      },
+      {
+        route: "GET /scan",
+        desc: "Scan a public GitHub repository for supply-chain risk",
+        amount: "200000",
+        unitType: "request",
+      },
+      {
+        route: "GET /schemaforge",
+        desc: "Generate structured-data markup and a ranked site fix list",
+        amount: "250000",
+        unitType: "request",
+      },
+      {
+        route: "GET /enrich",
+        desc: "Enrich a domain with company, technology, contact, and DNS facts",
+        amount: "50000",
+        unitType: "request",
+      },
+      {
+        route: "GET /wallet-enrich",
+        desc: "Profile a Base address using public on-chain data",
+        amount: "50000",
+        unitType: "request",
+      },
+      {
+        route: "GET /deep-audit",
+        desc: "Audit a domain for company intelligence and AI-search readiness",
+        amount: "250000",
+        unitType: "request",
+      },
+      {
+        route: "GET /defi/morpho-position",
+        desc: "Inspect and stress-test a Base Morpho borrower position",
+        amount: "20000",
+        unitType: "request",
+      },
+      {
+        route: "GET /defi/morpho-protection",
+        desc: "Calculate deterministic Morpho position-protection actions",
+        amount: "100000",
+        unitType: "request",
+      },
+      {
+        route: "GET /defi/morpho-market-underwrite",
+        desc: "Underwrite a Base Morpho market with source-linked evidence",
+        amount: "250000",
+        unitType: "request",
+      },
+      {
+        route: "GET /defi/morpho-preliquidation-replay",
+        desc: "Replay a historical Morpho PreLiquidation transaction",
+        amount: "100000",
+        unitType: "request",
+      },
+      {
+        route: "GET /work/opportunity-preflight",
+        desc: "Evaluate agent-work opportunity economics before execution",
+        amount: "50000",
+        unitType: "request",
+      },
+    ],
+  },
+
   // ── ScreenshotOne ────────────────────────────────────────────────────
   {
     id: "screenshotone",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6291,7 +6291,7 @@ export const services: ServiceDef[] = [
     url: "https://samedaydesk.com",
     serviceUrl: "https://agents.samedaydesk.com",
     description:
-      "Deterministic paid APIs for web extraction, company and wallet intelligence, repository risk, agent-work economics, machine-service discoverability, and Morpho decision evidence.",
+      "Deterministic paid APIs for web extraction, company and wallet intelligence, repository risk, agent-work economics, machine-service discoverability, payment-offer preflight, and Morpho decision evidence.",
     icon: "https://samedaydesk.com/favicon.svg",
     categories: ["blockchain", "data", "web"],
     integration: "first-party",
@@ -6396,6 +6396,12 @@ export const services: ServiceDef[] = [
         route: "GET /distribution/agent-discoverability-audit",
         desc: "Audit machine-service discovery rank and route coverage across agent catalogs",
         amount: "50000",
+        unitType: "request",
+      },
+      {
+        route: "GET /commerce/payment-offer-preflight",
+        desc: "Normalize x402 and MPP terms before buyer authorization",
+        amount: "5000",
         unitType: "request",
       },
     ],

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -6307,7 +6307,7 @@ export const services: ServiceDef[] = [
     docs: {
       homepage: "https://samedaydesk.com/x402",
       llmsTxt: "https://agents.samedaydesk.com/llms.txt",
-      apiReference: "https://agents.samedaydesk.com/openapi.json",
+      apiReference: "https://agents.samedaydesk.com/mpp-openapi.json",
     },
     provider: { name: "SameDayDesk", url: "https://samedaydesk.com" },
     realm: "agents.samedaydesk.com",


### PR DESCRIPTION
## Summary

- add SameDayDesk as a first-party MPP service
- list twelve direct `evm/charge` endpoints on one origin
- use Base mainnet USDC with exact live atomic prices
- link the official MPP OpenAPI 3.1 discovery view and machine-readable docs

SameDayDesk is the merchant origin. This entry does not add a proxy, wrapper, custody layer, or credential requirement. Runtime `WWW-Authenticate: Payment` challenges remain authoritative.

## Validation

- `pnpm test schemas/services.test.ts` (9,440 tests passed)
- `pnpm generate:discovery`
- `pnpm check:types`
- `pnpm check:ci`
- `pnpm build`
- `npx mppx discover validate https://agents.samedaydesk.com/mpp-openapi.json` (OpenAPI 3.1.0, twelve paid operations, zero issues)