### PR TITLE
docs: simplify HTTP 402 page heading

### DIFF
--- a/src/pages/protocol/http-402.mdx
+++ b/src/pages/protocol/http-402.mdx
@@ -3,7 +3,7 @@ description: "HTTP 402 Payment Required signals that a resource requires payment
 imageDescription: "What HTTP 402 means and how MPP uses it"
 ---
 
-# HTTP 402 Payment Required [The status code for payments on the web]
+# HTTP 402
 
 MPP services return HTTP `402` Payment Required to indicate that a resource requires payment for access. This is the foundation that enables [API monetization](/use-cases/api-monetization) and [micropayments](/use-cases/micropayments) at the protocol level.
 


### PR DESCRIPTION
## Summary

- Change the HTTP 402 page heading to exactly `HTTP 402`.

## Validation

- `pnpm check:markdown`
- `pnpm build`

Prompted by: @brendanjryan