### PR TITLE
fix: always issue Receipt when Picsum photo fetch fails

### DIFF
--- a/src/pages/_api/api/payment-link/photo-stripe.ts
+++ b/src/pages/_api/api/payment-link/photo-stripe.ts
@@ -1,4 +1,5 @@
 import { stripeMppx } from "../../../../mppx-payment-link-stripe.server";
+import { resolvePicsumPhotoUrl } from "../../../../picsum-photo";
 
 export async function GET(request: Request) {
   const result = await stripeMppx.charge({
@@ -10,15 +11,12 @@ export async function GET(request: Request) {
 
   if (result.status === 402) return result.challenge;
 
-  let imageUrl: string;
-  try {
-    const res = await fetch("https://picsum.photos/1024/1024");
-    if (!res.ok) throw new Error(`upstream responded ${res.status}`);
-    imageUrl = res.url;
-  } catch (error) {
-    console.error("[payment-link/photo-stripe] upstream fetch failed:", error);
-    return new Response("Failed to load photo from upstream", { status: 502 });
-  }
+  const { url: imageUrl, warning } = await resolvePicsumPhotoUrl(
+    1024,
+    "payment-link/photo-stripe",
+  );
+
+  const caption = warning ?? "Paid via MPP — $0.01";
 
   const html = `<!doctype html>
   <html lang="en">
@@ -58,7 +56,7 @@ export async function GET(request: Request) {
   </head>
   <body>
   <img src="${imageUrl}" alt="Random photo from Picsum" height="1024" width="1024" />
-  <p>Paid via MPP — $0.01</p>
+  <p>${caption}</p>
   </body>
   </html>`;
 

--- a/src/pages/_api/api/payment-link/photo.ts
+++ b/src/pages/_api/api/payment-link/photo.ts
@@ -1,4 +1,5 @@
 import { mppx } from "../../../../mppx-payment-link.server";
+import { resolvePicsumPhotoUrl } from "../../../../picsum-photo";
 
 export async function GET(request: Request) {
   const result = await mppx.charge({
@@ -8,15 +9,12 @@ export async function GET(request: Request) {
 
   if (result.status === 402) return result.challenge;
 
-  let imageUrl: string;
-  try {
-    const res = await fetch("https://picsum.photos/1024/1024");
-    if (!res.ok) throw new Error(`upstream responded ${res.status}`);
-    imageUrl = res.url;
-  } catch (error) {
-    console.error("[payment-link/photo] upstream fetch failed:", error);
-    return new Response("Failed to load photo from upstream", { status: 502 });
-  }
+  const { url: imageUrl, warning } = await resolvePicsumPhotoUrl(
+    1024,
+    "payment-link/photo",
+  );
+
+  const caption = warning ?? "Paid via MPP — $0.01";
 
   const html = `<!doctype html>
   <html lang="en">
@@ -56,7 +54,7 @@ export async function GET(request: Request) {
   </head>
   <body>
   <img src="${imageUrl}" alt="Random photo from Picsum" height="1024" width="1024" />
-  <p>Paid via MPP — $0.01</p>
+  <p>${caption}</p>
   </body>
   </html>`;
 

--- a/src/pages/_api/api/photo.ts
+++ b/src/pages/_api/api/photo.ts
@@ -1,4 +1,5 @@
 import { mppx } from "../../../mppx.server";
+import { resolvePicsumPhotoUrl } from "../../../picsum-photo";
 
 export async function GET(request: Request) {
   const result = await mppx.charge({
@@ -8,18 +9,8 @@ export async function GET(request: Request) {
 
   if (result.status === 402) return result.challenge;
 
-  let url: string;
-  try {
-    const res = await fetch("https://picsum.photos/1024/1024");
-    if (!res.ok) throw new Error(`upstream responded ${res.status}`);
-    url = res.url;
-  } catch (error) {
-    console.error("[photo] upstream fetch failed:", error);
-    return Response.json(
-      { error: "Failed to load photo from upstream" },
-      { status: 502 },
-    );
-  }
-
-  return result.withReceipt(Response.json({ url }));
+  const { url, warning } = await resolvePicsumPhotoUrl(1024, "photo");
+  return result.withReceipt(
+    Response.json(warning ? { url, warning } : { url }),
+  );
 }

--- a/src/pages/_api/api/sessions/photo.ts
+++ b/src/pages/_api/api/sessions/photo.ts
@@ -1,4 +1,5 @@
 import { mppx } from "../../../../mppx.server";
+import { resolvePicsumPhotoUrl } from "../../../../picsum-photo";
 
 export async function GET(request: Request) {
   const result = await mppx.session({
@@ -10,20 +11,10 @@ export async function GET(request: Request) {
 
   if (request.method === "POST") return result.withReceipt();
 
-  let url: string;
-  try {
-    const res = await fetch("https://picsum.photos/200/200");
-    if (!res.ok) throw new Error(`upstream responded ${res.status}`);
-    url = res.url;
-  } catch (error) {
-    console.error("[sessions/photo] upstream fetch failed:", error);
-    return Response.json(
-      { error: "Failed to load photo from upstream" },
-      { status: 502 },
-    );
-  }
-
-  return result.withReceipt(Response.json({ url }));
+  const { url, warning } = await resolvePicsumPhotoUrl(200, "sessions/photo");
+  return result.withReceipt(
+    Response.json(warning ? { url, warning } : { url }),
+  );
 }
 
 export const POST = GET;

--- a/src/photo.route.test.ts
+++ b/src/photo.route.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const withReceipt = vi.fn((response: Response) => {
+  const headers = new Headers(response.headers);
+  headers.set("x-test-receipt", "1");
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+});
+
+vi.mock("./mppx.server", () => ({
+  mppx: {
+    charge: () => async () => ({
+      status: 200 as const,
+      withReceipt,
+    }),
+  },
+}));
+
+describe("/api/photo", () => {
+  beforeEach(() => {
+    withReceipt.mockClear();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("issues a Receipt with a canned URL when Picsum fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+
+    const { GET } = await import("./pages/_api/api/photo");
+    const response = await GET(new Request("https://mpp.dev/api/photo"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-test-receipt")).toBe("1");
+    expect(withReceipt).toHaveBeenCalledOnce();
+    await expect(response.json()).resolves.toEqual({
+      url: "https://picsum.photos/id/237/1024/1024",
+      warning:
+        "Using canned photo because Picsum is unavailable right now.",
+    });
+  });
+
+  it("issues a Receipt with the upstream URL when Picsum succeeds", async () => {
+    const upstream = new Response(null, { status: 200 });
+    Object.defineProperty(upstream, "url", {
+      value: "https://fastly.picsum.photos/id/12/1024/1024.jpg",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(upstream);
+
+    // Re-import is cached; handler uses live fetch mock.
+    const { GET } = await import("./pages/_api/api/photo");
+    const response = await GET(new Request("https://mpp.dev/api/photo"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-test-receipt")).toBe("1");
+    await expect(response.json()).resolves.toEqual({
+      url: "https://fastly.picsum.photos/id/12/1024/1024.jpg",
+    });
+  });
+});

--- a/src/picsum-photo.test.ts
+++ b/src/picsum-photo.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PICSUM_UNAVAILABLE_WARNING,
+  resolvePicsumPhotoUrl,
+} from "./picsum-photo";
+
+describe("resolvePicsumPhotoUrl", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the upstream redirect URL on success", async () => {
+    const upstream = new Response(null, { status: 200 });
+    Object.defineProperty(upstream, "url", {
+      value: "https://fastly.picsum.photos/id/12/1024/1024.jpg",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(upstream);
+
+    await expect(resolvePicsumPhotoUrl(1024, "photo")).resolves.toEqual({
+      url: "https://fastly.picsum.photos/id/12/1024/1024.jpg",
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://picsum.photos/1024/1024",
+    );
+  });
+
+  it("returns a canned URL with warning when upstream responds non-OK", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 503 }),
+    );
+
+    await expect(resolvePicsumPhotoUrl(200, "sessions/photo")).resolves.toEqual(
+      {
+        url: "https://picsum.photos/id/237/200/200",
+        warning: PICSUM_UNAVAILABLE_WARNING,
+      },
+    );
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("returns a canned URL with warning when fetch throws", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+
+    await expect(
+      resolvePicsumPhotoUrl(1024, "payment-link/photo"),
+    ).resolves.toEqual({
+      url: "https://picsum.photos/id/237/1024/1024",
+      warning: PICSUM_UNAVAILABLE_WARNING,
+    });
+  });
+});

--- a/src/picsum-photo.ts
+++ b/src/picsum-photo.ts
@@ -1,0 +1,27 @@
+export type PicsumSize = 200 | 1024;
+
+const FALLBACK_URLS: Record<PicsumSize, string> = {
+  200: "https://picsum.photos/id/237/200/200",
+  1024: "https://picsum.photos/id/237/1024/1024",
+};
+
+export const PICSUM_UNAVAILABLE_WARNING =
+  "Using canned photo because Picsum is unavailable right now.";
+
+/** Fetch a Picsum redirect URL, or a canned URL so paid handlers can still issue a Receipt. */
+export async function resolvePicsumPhotoUrl(
+  size: PicsumSize,
+  logLabel: string,
+): Promise<{ url: string; warning?: string }> {
+  try {
+    const res = await fetch(`https://picsum.photos/${size}/${size}`);
+    if (!res.ok) throw new Error(`upstream responded ${res.status}`);
+    return { url: res.url };
+  } catch (error) {
+    console.error(`[${logLabel}] upstream fetch failed:`, error);
+    return {
+      url: FALLBACK_URLS[size],
+      warning: PICSUM_UNAVAILABLE_WARNING,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Paid photo demos (`/api/photo`, sessions, payment-link) no longer return 502 without a Receipt when Picsum fails after a successful charge/session
- Shared `resolvePicsumPhotoUrl` falls back to a canned URL + warning (same pattern as `demo/image`)
- Adds unit tests for the helper and `/api/photo` Receipt path

## Test plan
- [x] `pnpm exec vitest run src/picsum-photo.test.ts src/photo.route.test.ts`
- [x] `pnpm check`
- [ ] Confirm unpaid `/api/photo` still returns 402 when the local Vite server is reachable