### PR TITLE
Add everstar city-map print service to directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11167,4 +11167,30 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── everstar (data-art prints) ──
+  {
+    id: "everstar-citymaps",
+    name: "everstar",
+    url: "https://everstar.loclx.io",
+    serviceUrl: "https://everstar.loclx.io",
+    description:
+      "Pay-per-render personalized art prints. City maps rendered from OpenStreetMap data and star maps from the Hipparcos catalog; receive a print-ready 300 DPI PNG (8x10, 11x14, 16x20, A3, A2).",
+    categories: ["media"],
+    integration: "third-party",
+    tags: ["maps", "art", "prints", "citymap", "starmap", "osm"],
+    docs: { homepage: "https://everstar.loclx.io" },
+    provider: { name: "everstar", url: "https://everstar.loclx.io" },
+    realm: "everstar.loclx.io",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /render",
+        desc: "Render a personalized city map or star map and return a print-ready PNG.",
+        amount: "250000",
+        unitType: "request",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- Add `everstar` to the mpp.dev service directory.
- everstar is a pay-per-render API for personalized data-art prints: city maps from OpenStreetMap and star maps from the Hipparcos catalog. Returns print-ready 300 DPI PNGs (8x10, 11x14, 16x20, A3, A2).
- Service is live and accepting MPP payments on Tempo mainnet (USDC.e).
- Also registered on MPPScan via the standard MPP discovery format (`/openapi.json` with `x-payment-info` + `/.well-known/x402`).

## Required checklist
- [x] Service is live and accepting payments via MPP (402 challenge → payment → 200 image/png)
- [x] Added entry to `schemas/services.ts`
- [ ] Types pass (`pnpm check:types`) — not run locally
- [ ] Build succeeds (`pnpm build`) — not run locally

## Review
- Category: media (printable data-art)
- Live URL: https://everstar.loclx.io
- Challenge validates with `mppx sign --dry-run` against Tempo mainnet.