### PR TITLE
Add HookMPP to the service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -615,6 +615,45 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── HookMPP ────────────────────────────────────────────────────────────
+  {
+    id: "hookmpp",
+    name: "HookMPP",
+    url: "https://hookmpp.dev",
+    serviceUrl: "https://hookmpp.dev",
+    description:
+      "Purchase short-lived webhook callback inboxes without an account, API key, or public server.",
+    icon: "https://hookmpp.dev/favicon.ico",
+    categories: ["compute", "web"],
+    integration: "first-party",
+    tags: ["webhooks", "callbacks", "inboxes", "async", "agents", "ephemeral"],
+    status: "active",
+    docs: {
+      homepage: "https://hookmpp.dev",
+      llmsTxt: "https://hookmpp.dev/llms.txt",
+      apiReference: "https://hookmpp.dev/openapi.json",
+    },
+    provider: { name: "HookMPP", url: "https://hookmpp.dev" },
+    realm: "hookmpp.dev",
+    intent: "charge",
+    payments: [
+      {
+        method: "tempo",
+        currency: "0x20c0000000000000000000000000000000000000",
+        decimals: 6,
+      },
+    ],
+    endpoints: [
+      {
+        route: "POST /api/inboxes",
+        desc: "Create an ephemeral webhook inbox",
+        dynamic: true,
+        amountHint: "$0.01–$0.20, depending on the selected profile",
+        unitType: "inbox",
+      },
+    ],
+  },
+
   // ── Allium ──────────────────────────────────────────────────────────────
   {
     id: "allium",


### PR DESCRIPTION
## Summary
- add the live HookMPP disposable webhook-inbox service
- publish its first-party MPP endpoint, profile price range, pathUSD payment configuration, and discovery URLs

## Service-directory checklist
- [x] Live and accepting MPP payments at https://hookmpp.dev
- [x] Added to `schemas/services.ts`
- [x] `pnpm check:types`
- [x] `pnpm build`
- [x] Registered on MPPScan (origin ID `80534a42c4d713f029e76ff6ddc70a159491f901187a4bce99c404436f0353ee`)

## Additional verification
- `pnpm check:ci`
- `pnpm test` (9,718 tests)
- live MPPScan discovery recognizes `POST /api/inboxes` as `0.01-0.20 USD [mpp]`
- HookMPP production CI, deploy, and smoke checks passed in https://github.com/carlulsoe/hookmpp/pull/6