### PR TITLE
fix: align home page with reference design

### DIFF
--- a/e2e/terminal.test.ts
+++ b/e2e/terminal.test.ts
@@ -164,6 +164,23 @@ describe("terminal", () => {
 
     const modal = page.getByRole("dialog", { name: "MPP terminal" });
     await playwrightExpect(modal).toBeVisible();
+    const fullscreenTerminal = modal.locator("[data-terminal]");
+    await playwrightExpect(fullscreenTerminal).toHaveCSS(
+      "background-color",
+      "rgb(25, 25, 25)",
+    );
+    const openingFrames = await fullscreenTerminal.evaluate((element) =>
+      element
+        .getAnimations()
+        .at(-1)
+        ?.effect?.getKeyframes()
+        .map(({ clipPath, translate }) => ({ clipPath, translate })),
+    );
+    expect(openingFrames?.at(0)?.clipPath).not.toBe("inset(0px)");
+    expect(openingFrames?.at(-1)).toEqual({
+      clipPath: "inset(0px)",
+      translate: "0px",
+    });
     await playwrightExpect(prompt).toHaveValue("preserve this prompt");
     await playwrightExpect(
       page.getByRole("button", { name: "Close terminal", exact: true }),
@@ -211,6 +228,18 @@ describe("terminal", () => {
     ).toBe(true);
 
     await closeButton.click();
+    const closingFrames = await fullscreenTerminal.evaluate((element) =>
+      element
+        .getAnimations()
+        .at(-1)
+        ?.effect?.getKeyframes()
+        .map(({ clipPath, translate }) => ({ clipPath, translate })),
+    );
+    expect(closingFrames?.at(0)).toEqual({
+      clipPath: "inset(0px)",
+      translate: "0px",
+    });
+    expect(closingFrames?.at(-1)?.clipPath).not.toBe("inset(0px)");
     const enlargeButton = page.getByRole("button", {
       name: "Enlarge terminal",
       exact: true,

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -100,7 +100,7 @@ export function LandingPage() {
           </video>
 
           <div className="relative z-10 flex max-w-[560px] flex-col gap-8 md:max-w-[978px] md:gap-[38px]">
-            <h1 className="font-sans !text-[28px] font-normal !leading-[1.1] !tracking-[-0.56px] text-offwhite min-[640px]:!text-[32px] min-[640px]:!tracking-[-0.64px] min-[1000px]:!text-[48px] min-[1000px]:!leading-none min-[1000px]:!tracking-[-1.44px]">
+            <h1 className="font-sans !text-[28px] !font-normal !leading-[1.1] !tracking-[-0.56px] text-offwhite min-[640px]:!text-[32px] min-[640px]:!tracking-[-0.64px] min-[1000px]:!text-[48px] min-[1000px]:!leading-none min-[1000px]:!tracking-[-1.44px]">
               MPP lets agents pay for services on the
               <br className="hidden min-[1000px]:block" /> web, extensible to
               any payment method.

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -6,6 +6,7 @@ import {
   Fragment,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -79,6 +80,47 @@ export function timeAgo(iso: string) {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+const fullscreenMotion = {
+  duration: 300,
+  easing: "cubic-bezier(0.19, 1, 0.22, 1)",
+} as const;
+
+function animateFullscreenTransition(
+  terminal: HTMLElement,
+  fullscreenRect: DOMRect,
+  inlineRect: DOMRect,
+  opening: boolean,
+) {
+  const frames: Keyframe[] = [
+    {
+      clipPath: "inset(0px 0px 0px 0px)",
+      translate: "0px 0px",
+    },
+    {
+      clipPath: `inset(0px ${fullscreenRect.width - inlineRect.width}px ${fullscreenRect.height - inlineRect.height}px 0px)`,
+      translate: `${inlineRect.left - fullscreenRect.left}px ${inlineRect.top - fullscreenRect.top}px`,
+    },
+  ];
+  if (opening) frames.reverse();
+  const options: KeyframeAnimationOptions = opening
+    ? fullscreenMotion
+    : { ...fullscreenMotion, fill: "forwards" };
+  const animations = [terminal.animate(frames, options)];
+  const controls = terminal.querySelector<HTMLElement>("[data-term-controls]");
+  if (opening && controls) {
+    animations.push(
+      controls.animate(
+        [
+          { translate: `${inlineRect.width - fullscreenRect.width}px 0px` },
+          { translate: "0px 0px" },
+        ],
+        options,
+      ),
+    );
+  }
+  return animations;
 }
 
 // ---------------------------------------------------------------------------
@@ -2750,6 +2792,8 @@ function TerminalComponent({
   const [showTopFade, setShowTopFade] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isFullscreenClosing, setIsFullscreenClosing] = useState(false);
+  const fullscreenAnimationsRef = useRef<Animation[]>([]);
+  const inlineTerminalRectRef = useRef<DOMRect | null>(null);
   const isFullscreenClosingRef = useRef(false);
 
   useEffect(() => {
@@ -2768,31 +2812,87 @@ function TerminalComponent({
     if (portalContainer && inlineHost) inlineHost.append(portalContainer);
   }, [portalContainer]);
 
+  const finishFullscreenClose = useCallback(() => {
+    for (const animation of fullscreenAnimationsRef.current) {
+      animation.cancel();
+    }
+    fullscreenAnimationsRef.current = [];
+    isFullscreenClosingRef.current = false;
+    setIsFullscreen(false);
+    setIsFullscreenClosing(false);
+    moveTerminalInline();
+  }, [moveTerminalInline]);
+
   const closeFullscreen = useCallback(() => {
     if (!isFullscreen || isFullscreenClosingRef.current) return;
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      setIsFullscreen(false);
-      moveTerminalInline();
+    const terminal =
+      portalContainer?.querySelector<HTMLElement>("[data-terminal]");
+    const inlineRect = inlineTerminalRectRef.current;
+    if (
+      !terminal ||
+      !inlineRect ||
+      window.innerWidth < 1_000 ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      finishFullscreenClose();
       return;
     }
     isFullscreenClosingRef.current = true;
     setIsFullscreenClosing(true);
-    window.setTimeout(() => {
-      isFullscreenClosingRef.current = false;
-      setIsFullscreen(false);
-      setIsFullscreenClosing(false);
-      moveTerminalInline();
-    }, 300);
-  }, [isFullscreen, moveTerminalInline]);
+    for (const animation of fullscreenAnimationsRef.current) {
+      animation.cancel();
+    }
+    const animations = animateFullscreenTransition(
+      terminal,
+      terminal.getBoundingClientRect(),
+      inlineRect,
+      false,
+    );
+    fullscreenAnimationsRef.current = animations;
+    animations[0].onfinish = finishFullscreenClose;
+  }, [finishFullscreenClose, isFullscreen, portalContainer]);
   const openFullscreen = useCallback(() => {
     restoreFocusRef.current =
       document.activeElement instanceof HTMLElement
         ? document.activeElement
         : fullscreenButtonRef.current;
+    const terminal =
+      portalContainer?.querySelector<HTMLElement>("[data-terminal]");
+    inlineTerminalRectRef.current = terminal?.getBoundingClientRect() ?? null;
     if (portalContainer) document.body.append(portalContainer);
     setIsFullscreen(true);
   }, [portalContainer]);
   const [isMarketingMinimized, setIsMarketingMinimized] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!isFullscreen || isFullscreenClosing || !portalContainer) return;
+    const terminal =
+      portalContainer.querySelector<HTMLElement>("[data-terminal]");
+    const inlineRect = inlineTerminalRectRef.current;
+    if (
+      !terminal ||
+      !inlineRect ||
+      window.innerWidth < 1_000 ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+    fullscreenAnimationsRef.current = animateFullscreenTransition(
+      terminal,
+      terminal.getBoundingClientRect(),
+      inlineRect,
+      true,
+    );
+  }, [isFullscreen, isFullscreenClosing, portalContainer]);
+
+  useEffect(() => {
+    if (!isFullscreen) return;
+    const clearInlineRect = () => {
+      inlineTerminalRectRef.current = null;
+    };
+    window.addEventListener("resize", clearInlineRect);
+    return () => window.removeEventListener("resize", clearInlineRect);
+  }, [isFullscreen]);
 
   useEffect(() => {
     if (!isFullscreen || !portalContainer) return;
@@ -3390,10 +3490,8 @@ function TerminalComponent({
             <button
               aria-label="Close terminal"
               className={
-                isFullscreen
-                  ? `terminal-fullscreen fixed inset-0 z-[70] bg-black/70 backdrop-blur-sm ${
-                      isFullscreenClosing ? "is-closing" : ""
-                    }`
+                isFullscreen && !isFullscreenClosing
+                  ? "terminal-fullscreen fixed inset-0 z-[70] bg-black/70 backdrop-blur-sm"
                   : "hidden"
               }
               onClick={closeFullscreen}
@@ -3412,9 +3510,7 @@ function TerminalComponent({
                 {...modalProps}
                 className={
                   isFullscreen
-                    ? `terminal-fullscreen-panel term-outline pointer-events-auto h-[min(85dvh,640px)] w-full max-w-[1080px] ${
-                        isFullscreenClosing ? "is-closing" : ""
-                      }`
+                    ? "terminal-fullscreen-panel term-outline pointer-events-auto h-[min(85dvh,640px)] w-full max-w-[1080px]"
                     : "h-full w-full"
                 }
                 tabIndex={isFullscreen ? -1 : undefined}

--- a/src/components/marketing/LogoLottie.test.tsx
+++ b/src/components/marketing/LogoLottie.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadLottiePlayer } from "../../lib/lottie";
+import { LogoLottie } from "./LogoLottie";
+
+vi.mock("../../lib/lottie", () => ({ loadLottiePlayer: vi.fn() }));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("LogoLottie", () => {
+  it("plays the complete animation from the first frame", async () => {
+    const animationData = {
+      layers: [{ nm: "Block 1" }, { nm: "Block 2" }, { nm: "M" }],
+    };
+    const animation = {
+      addEventListener: vi.fn(
+        (event: string, listener: () => void) =>
+          event === "DOMLoaded" && listener(),
+      ),
+      destroy: vi.fn(),
+      goToAndPlay: vi.fn(),
+      goToAndStop: vi.fn(),
+      setSpeed: vi.fn(),
+      totalFrames: 90,
+    };
+    const loadAnimation = vi.fn(
+      (_config: { animationData: unknown }) => animation,
+    );
+    vi.mocked(loadLottiePlayer).mockResolvedValue({
+      loadAnimation,
+    } as never);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        json: async () => animationData,
+        ok: true,
+      })),
+    );
+
+    render(<LogoLottie />);
+
+    await waitFor(() => expect(loadAnimation).toHaveBeenCalledOnce());
+    expect(loadAnimation.mock.calls[0]?.[0]?.animationData).toBe(animationData);
+    expect(animation.setSpeed).toHaveBeenCalledWith(2);
+    expect(animation.goToAndPlay).toHaveBeenCalledWith(0, true);
+  });
+});

--- a/src/components/marketing/LogoLottie.tsx
+++ b/src/components/marketing/LogoLottie.tsx
@@ -2,10 +2,6 @@ import { useEffect, useRef } from "react";
 import { type LottieAnimation, loadLottiePlayer } from "../../lib/lottie";
 import { cx } from "./cx";
 
-type LottieData = {
-  layers: Array<{ nm?: string }>;
-};
-
 export function LogoLottie({ className }: { className?: string }) {
   const animationRef = useRef<LottieAnimation | undefined>(undefined);
   const fallbackRef = useRef<HTMLImageElement>(null);
@@ -19,18 +15,13 @@ export function LogoLottie({ className }: { className?: string }) {
       loadLottiePlayer(),
       fetch("/lottie/02_MPP_Logo_Loading_Animation.json").then((response) => {
         if (!response.ok) throw new Error("Unable to load logo animation");
-        return response.json() as Promise<LottieData>;
+        return response.json();
       }),
     ])
       .then(([lottie, animationData]) => {
         if (cancelled || !hostRef.current) return;
         const animation = lottie.loadAnimation({
-          animationData: {
-            ...animationData,
-            layers: animationData.layers.filter(
-              (layer) => !layer.nm?.startsWith("Block "),
-            ),
-          },
+          animationData,
           autoplay: false,
           container: hostRef.current,
           loop: false,
@@ -45,7 +36,7 @@ export function LogoLottie({ className }: { className?: string }) {
           if (reduced) {
             animation.goToAndStop(animation.totalFrames - 1, true);
           } else {
-            animation.goToAndPlay(7, true);
+            animation.goToAndPlay(0, true);
           }
           window.dispatchEvent(new Event("mpp:logo-lines"));
         });
@@ -54,7 +45,7 @@ export function LogoLottie({ className }: { className?: string }) {
 
     const replay = () => {
       if (!reduced) {
-        animationRef.current?.goToAndPlay(7, true);
+        animationRef.current?.goToAndPlay(0, true);
         window.dispatchEvent(new Event("mpp:logo-lines"));
       }
     };

--- a/src/pages/_root.css
+++ b/src/pages/_root.css
@@ -151,36 +151,6 @@ button:not(:disabled),
   cursor: pointer;
 }
 
-.terminal-fullscreen {
-  animation: terminal-overlay-in 300ms cubic-bezier(0.19, 1, 0.22, 1) both;
-}
-
-.terminal-fullscreen-panel {
-  animation: terminal-modal-in 300ms cubic-bezier(0.19, 1, 0.22, 1) both;
-}
-
-.terminal-fullscreen.is-closing {
-  animation-direction: reverse;
-}
-
-.terminal-fullscreen-panel.is-closing {
-  animation-direction: reverse;
-}
-
-@keyframes terminal-overlay-in {
-  from {
-    background-color: rgb(0 0 0 / 0%);
-    backdrop-filter: blur(0);
-  }
-}
-
-@keyframes terminal-modal-in {
-  from {
-    opacity: 0;
-    transform: translate(18vw, 25vh) scale(0.55);
-  }
-}
-
 body.marketing-home {
   --marketing-footer-bg: #060606;
   background: #060606;
@@ -1824,7 +1794,7 @@ a[href*="/payment-methods/tempo"][class*="vocs:rounded-md"]
 .terminal-theme {
   /* Backgrounds */
   --term-bg1: light-dark(oklch(0.94 0 0), oklch(0.14 0 0));
-  --term-bg2: light-dark(oklch(1 0 0), oklch(0.15 0 0));
+  --term-bg2: light-dark(oklch(1 0 0), #191919);
 
   /* Gray Scale — dark values tuned for darker --term-bg2 */
   --term-gray1: light-dark(oklch(0.955 0 0), oklch(0.18 0 0));
@@ -3017,7 +2987,7 @@ nav[data-v-sidebar] button,
 .services-agent-discovery {
   box-sizing: border-box;
   margin: 0 auto;
-  max-width: 1600px;
+  max-width: 1728px;
   padding: 0 3rem 5rem;
   width: 100%;
 }


### PR DESCRIPTION
## Summary

- Match the hero weight, logo animation layers and timing, and terminal surface color
- Reproduce the terminal fullscreen transition from its inline position
- Align Agent discovery with the services content width
- Add regression coverage for the logo and terminal motion

## Key design considerations

- Derive fullscreen keyframes from measured inline and modal bounds
- Preserve reduced-motion and narrow-viewport behavior