### PR TITLE
feat(services): add Leya — Latin American primary law and Guatemalan cadastre

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1430,6 +1430,57 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Leya ───────────────────────────────────────────────────────────────
+  {
+    id: "leya",
+    name: "Leya",
+    url: "https://leya.lawyer",
+    serviceUrl: "https://api.leya.lawyer",
+    description:
+      "Search and cite primary Latin American law — statutes, decrees, congressional initiatives, court rulings and official gazettes — plus Guatemalan cadastral parcels with protected-area, watershed and archaeological overlays.",
+
+    categories: ["data", "search"],
+    integration: "first-party",
+    tags: [
+      "legal",
+      "latin-america",
+      "guatemala",
+      "citations",
+      "cadastral",
+      "case-law",
+    ],
+    docs: {
+      homepage: "https://leya.lawyer/docs/api",
+      llmsTxt: "https://leya.lawyer/llms-full.txt",
+    },
+    provider: { name: "Leya", url: "https://leya.lawyer" },
+    realm: "leya.lawyer",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /v1/search",
+        desc: "Hybrid keyword and semantic search over primary Latin American legal sources, with stable document ids and source attribution",
+        amount: "30000",
+      },
+      {
+        route: "GET /v1/documents/:document_id",
+        desc: "Full text of one legal document",
+        amount: "10000",
+      },
+      {
+        route: "GET /v1/documents/:document_id/citation",
+        desc: "Formatted citation for a document, marked partial when the corpus lacks the metadata to complete it",
+        amount: "10000",
+      },
+      {
+        route: "GET /v1/parcels/:ccc",
+        desc: "Guatemalan cadastral parcel by código catastral, with the protected areas, watersheds and archaeological sites it intersects",
+        amount: "20000",
+      },
+    ],
+  },
+
   // ── Modal ──────────────────────────────────────────────────────────────
   {
     id: "modal",


### PR DESCRIPTION
## What

Adds **Leya** (https://leya.lawyer) to the service registry: search and citation of primary Latin American law (statutes, decrees, congressional initiatives, court rulings, official gazettes), plus Guatemalan cadastral parcels intersected with protected areas, watersheds and archaeological sites.

## Why it's novel

- The registry currently has one legal service (GovLaws, US federal regulation). Nothing covers Latin America — Leya is the first Spanish-language / civil-law primary-law source.
- The cadastral endpoint is a dataset that exists nowhere else: 630,961 RIC parcels with legal-designation overlays.
- Keyless: agents can call it with no signup, paying per request via MPP.

## Verification

- Live spec: https://api.leya.lawyer/openapi.json (carries `x-service-info` and per-operation `x-payment-info`; prices in the entry match the spec: $0.03 / $0.01 / $0.01 / $0.02 at 6 decimals)
- `llms.txt` / `llms-full.txt` served at https://leya.lawyer/llms-full.txt
- Payments verified with a real on-chain Tempo settlement
- `vitest run schemas/services.test.ts`: 9400 tests pass; `generate:discovery` and `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)