### PR TITLE
Remove internal Stripe profile fallback

### DIFF
--- a/src/mppx-payment-link-stripe.server.ts
+++ b/src/mppx-payment-link-stripe.server.ts
@@ -10,7 +10,7 @@ export const stripeMppx = Mppx.create({
         createTokenUrl: "/api/demo/create-spt",
         publishableKey: import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY!,
       },
-      networkId: process.env.STRIPE_NETWORK_ID ?? "internal",
+      networkId: process.env.STRIPE_NETWORK_ID!,
       paymentMethodTypes: ["card"],
       secretKey: process.env.STRIPE_SECRET_KEY!,
     }),

--- a/src/mppx-stripe.server.ts
+++ b/src/mppx-stripe.server.ts
@@ -6,7 +6,7 @@ const realm = process.env.REALM ?? "mpp.tempo.xyz";
 export const stripeMppx = Mppx.create({
   methods: [
     stripe.spt({
-      networkId: process.env.STRIPE_NETWORK_ID ?? "internal",
+      networkId: process.env.STRIPE_NETWORK_ID!,
       paymentMethodTypes: ["card"],
       secretKey: process.env.STRIPE_SECRET_KEY!,
     }),


### PR DESCRIPTION
This fallback is unsafe and has confused many agents when building our own MPP integrations. Let's remove it since profile is non-optional!