### PR TITLE
docs: use pathUSD in server quickstart prompt

### DIFF
--- a/src/components/QuickstartPrompt.tsx
+++ b/src/components/QuickstartPrompt.tsx
@@ -12,7 +12,7 @@ Make a request to https://mpp.dev/api/ping/paid to test.`;
 
 export const SERVER_PROMPT = `Reference https://mpp.dev/quickstart/server.md
 
-Add mppx to my server with a /api/test route that charges $0.01 per request using the Tempo payment method with USDC.e.
+Add mppx to my server with a /api/test route that charges $0.01 per request using the Tempo payment method with pathUSD.
 Run \`npx mppx validate <your-server>\` to validate the implementation as you develop.`;
 
 export const ClientPrompt = withMarkdown(


### PR DESCRIPTION
## Summary

- update the server quickstart coding-agent prompt to use pathUSD instead of USDC.e

## Validation

- `pnpm check:ci`
- `pnpm generate:discovery && pnpm check:types`

Prompted by: @brendanjryan