### PR TITLE
docs: update mppx identity post date

### DIFF
--- a/src/pages/blog/mppx-identity-support.mdx
+++ b/src/pages/blog/mppx-identity-support.mdx
@@ -7,7 +7,7 @@ showFeedback: false
 showSearch: false
 description: "Verify agent identity across HTTP requests and payment retries with mppx."
 imageDescription: "Verify agent identity across HTTP requests"
-publishedAt: "2026-08-11"
+publishedAt: "2026-08-12"
 ---
 
 # Expanding identity support in mppx [Verify agent identity through the lifecycle of a payment]


### PR DESCRIPTION
## Why

Align the mppx identity blog post date with its intended publication date.

## What

Update `publishedAt` from `2026-08-11` to `2026-08-12`.