### PR TITLE
Add Agent Guild to the MPP service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -122,6 +122,136 @@ export interface ServiceDef {
 
 // prettier-ignore
 export const services: ServiceDef[] = [
+  // ── Agent Guild ───────────────────────────────────────────────────────
+  {
+    id: "agent-guild",
+    name: "Agent Guild",
+    url: "https://agent-guild-5d5r.onrender.com",
+    serviceUrl: "https://agent-guild-5d5r.onrender.com",
+    description:
+      "Trust and payment-safety decisions for autonomous agents, with signed offline-verifiable evidence.",
+    categories: ["ai", "data"],
+    integration: "third-party",
+    tags: [
+      "agent-reputation",
+      "agent-trust",
+      "delegation",
+      "verification",
+      "x402",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://agent-guild-5d5r.onrender.com",
+      llmsTxt: "https://agent-guild-5d5r.onrender.com/llms.txt",
+      apiReference: "https://agent-guild-5d5r.onrender.com/openapi.json",
+    },
+    provider: {
+      name: "Agent Guild",
+      url: "https://agent-guild-5d5r.onrender.com",
+    },
+    realm: "agent-guild-5d5r.onrender.com",
+    intent: "charge",
+    payments: [
+      {
+        method: "evm",
+        currency: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        decimals: 6,
+      },
+    ],
+    endpoints: [
+      {
+        route: "GET /check",
+        desc: "Find the safest agent for a capability",
+        dynamic: true,
+        amountHint: "$0.01-$1; live 402 is authoritative",
+      },
+      {
+        route: "GET /search",
+        desc: "Rank agents by attack-resistant trust",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "POST /check/decision",
+        desc: "Issue a signed offline-verifiable trust decision",
+        amount: "1000000",
+        unitType: "request",
+      },
+      {
+        route: "GET /agents/:agent_id/reputation",
+        desc: "Read an agent reputation summary",
+        dynamic: true,
+        amountHint: "$0-$0.005; live 402 is authoritative",
+      },
+      {
+        route: "GET /agents/:agent_id/journey",
+        desc: "Read an agent activity and outcome journey",
+        dynamic: true,
+        amountHint: "$0-$0.005; live 402 is authoritative",
+      },
+      {
+        route: "GET /agents/:agent_id/evidence",
+        desc: "Read evidence supporting an agent trust score",
+        dynamic: true,
+        amountHint: "$0-$0.005; live 402 is authoritative",
+      },
+      {
+        route: "GET /agents/:agent_id/flags",
+        desc: "Read fraud and conduct flags for an agent",
+        amount: "5000",
+        unitType: "request",
+      },
+      {
+        route: "GET /agents/:agent_id/risk-score",
+        desc: "Read a deterministic agent risk score",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "GET /flags",
+        desc: "Read the suspicious-activity feed",
+        amount: "5000",
+        unitType: "request",
+      },
+      {
+        route: "GET /preflight/deep",
+        desc: "Verify an endpoint before delegation or payment",
+        amount: "20000",
+        unitType: "request",
+      },
+      {
+        route: "POST /evidence/bundle",
+        desc: "Issue a signed offline-verifiable evidence bundle",
+        amount: "100000",
+        unitType: "request",
+      },
+      {
+        route: "POST /envelopes/issue",
+        desc: "Issue a signed machine-communication envelope",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "POST /wallet-binding/decision",
+        desc: "Issue a wallet payment-policy decision",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "POST /wallet-binding/protected-decision",
+        desc: "Issue a protected high-value payment decision",
+        dynamic: true,
+        amountHint: "$0.01-$10,000; live 402 is authoritative",
+      },
+      {
+        route: "POST /wallet-binding/protected-decision/tiers/:tier_id",
+        desc: "Issue a fixed-notional protected payment decision",
+        dynamic: true,
+        amountHint: "$2.50-$10,000; live 402 is authoritative",
+      },
+    ],
+  },
+
   // ── Apex DB ───────────────────────────────────────────────────────────
   {
     id: "apex-db",


### PR DESCRIPTION
Adds the live Agent Guild service to the MPP directory with its native `evm/charge` payment method on Base mainnet USDC.

The entry exposes all 15 production paid operations with exact fixed prices or honest dynamic ranges. Runtime HTTP 402 challenges remain authoritative.

Validation performed:
- official dependency-free discovery generator completed successfully
- generated Agent Guild entry contains 15 endpoints and the `evm` payment method
- `git diff --check` passes
- the live service is independently discoverable on MPPScan at https://www.mppscan.com/server/58ffd3e481d7a32982ade93b96d95955f29388437671a71f41d9a313d76c621b

The change is limited to `schemas/services.ts`.