### PR TITLE
Add Peer Cash partner integration guide

### DIFF
--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -7,6 +7,7 @@ import type { PathsForPages } from 'waku/router'
 type Page =
   | { path: '/404'; render: 'static' }
   | { path: '/_api/api/og'; render: 'static' }
+  | { path: '/_root'; render: 'static' }
   | { path: '/_slots'; render: 'static' }
   | { path: '/advanced/discovery'; render: 'static' }
   | { path: '/advanced/identity'; render: 'static' }
@@ -17,6 +18,7 @@ type Page =
   | { path: '/blog/_mdx-wrapper'; render: 'static' }
   | { path: '/blog/evm-x402-support'; render: 'static' }
   | { path: '/blog/go-and-ruby-sdks'; render: 'static' }
+  | { path: '/blog'; render: 'static' }
   | { path: '/blog'; render: 'static' }
   | { path: '/blog/mppx-agent-runtimes'; render: 'static' }
   | { path: '/blog/mppx-identity-support'; render: 'static' }
@@ -43,6 +45,7 @@ type Page =
   | { path: '/guides/subscription-payments'; render: 'static' }
   | { path: '/guides/use-mpp-with-x402'; render: 'static' }
   | { path: '/'; render: 'static' }
+  | { path: '/'; render: 'static' }
   | { path: '/intents/charge'; render: 'static' }
   | { path: '/intents'; render: 'static' }
   | { path: '/intents/session'; render: 'static' }
@@ -52,6 +55,7 @@ type Page =
   | { path: '/partner-integrations/cloudflare-agents'; render: 'static' }
   | { path: '/partner-integrations/mcp-sdk'; render: 'static' }
   | { path: '/partner-integrations/openclaw'; render: 'static' }
+  | { path: '/partner-integrations/peer-cash'; render: 'static' }
   | { path: '/partner-integrations/vercel-ai-sdk'; render: 'static' }
   | { path: '/payment-methods/card/charge'; render: 'static' }
   | { path: '/payment-methods/card'; render: 'static' }
@@ -191,6 +195,7 @@ type Page =
   | { path: '/sdk/typescript/server/Transport.mcp'; render: 'static' }
   | { path: '/sdk/typescript/server/Transport.mcpSdk'; render: 'static' }
   | { path: '/sdk/typescript/server/Ws.serve'; render: 'static' }
+  | { path: '/services'; render: 'static' }
   | { path: '/services'; render: 'static' }
   | { path: '/tools/wallet'; render: 'static' }
   | { path: '/use-cases/agentic-payments'; render: 'static' }

--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -7,7 +7,6 @@ import type { PathsForPages } from 'waku/router'
 type Page =
   | { path: '/404'; render: 'static' }
   | { path: '/_api/api/og'; render: 'static' }
-  | { path: '/_root'; render: 'static' }
   | { path: '/_slots'; render: 'static' }
   | { path: '/advanced/discovery'; render: 'static' }
   | { path: '/advanced/identity'; render: 'static' }
@@ -18,7 +17,6 @@ type Page =
   | { path: '/blog/_mdx-wrapper'; render: 'static' }
   | { path: '/blog/evm-x402-support'; render: 'static' }
   | { path: '/blog/go-and-ruby-sdks'; render: 'static' }
-  | { path: '/blog'; render: 'static' }
   | { path: '/blog'; render: 'static' }
   | { path: '/blog/mppx-agent-runtimes'; render: 'static' }
   | { path: '/blog/mppx-identity-support'; render: 'static' }
@@ -44,7 +42,6 @@ type Page =
   | { path: '/guides/streamed-payments'; render: 'static' }
   | { path: '/guides/subscription-payments'; render: 'static' }
   | { path: '/guides/use-mpp-with-x402'; render: 'static' }
-  | { path: '/'; render: 'static' }
   | { path: '/'; render: 'static' }
   | { path: '/intents/charge'; render: 'static' }
   | { path: '/intents'; render: 'static' }
@@ -195,7 +192,6 @@ type Page =
   | { path: '/sdk/typescript/server/Transport.mcp'; render: 'static' }
   | { path: '/sdk/typescript/server/Transport.mcpSdk'; render: 'static' }
   | { path: '/sdk/typescript/server/Ws.serve'; render: 'static' }
-  | { path: '/services'; render: 'static' }
   | { path: '/services'; render: 'static' }
   | { path: '/tools/wallet'; render: 'static' }
   | { path: '/use-cases/agentic-payments'; render: 'static' }

--- a/src/pages/partner-integrations/peer-cash.mdx
+++ b/src/pages/partner-integrations/peer-cash.mdx
@@ -1,0 +1,102 @@
+---
+description: "Cash out settled MPP revenue with Peer Cash."
+imageDescription: "Prepare a fiat cash-out plan from settled MPP revenue"
+---
+
+# Peer Cash [Cash out settled MPP revenue]
+
+Use [Peer Cash](https://peer.xyz/cash-sdk) with the [Peer-owned MPP example](https://github.com/zkp2p/peer-cash/tree/main/examples/mpp-revenue-cashout) to accept USDC on Base through MPP, then prepare a separate fiat cash-out after the payment settles.
+
+:::note
+MPP settles merchant revenue first. Peer Cash only prepares a separate, unsigned seller cash-out plan as an explicit post-settlement step. The merchant wallet retains custody throughout and is the only signer.
+:::
+
+## How the cash-out works
+
+Peer Cash lists the merchant's USDC on the Peer P2P marketplace. A buyer pays the merchant fiat directly, the payment proof is verified, and the onchain escrow releases the USDC. The example returns unsigned transactions and same-index step descriptions for the merchant wallet to review and submit; it never accepts private keys, signs transactions, or broadcasts them.
+
+The payment and cash-out paths remain independent:
+
+- MPP verifies the payment and records the successful Receipt.
+- The merchant wallet retains custody of the settled USDC.
+- Peer Cash never receives a payer Credential or changes the MPP payment method.
+- The example never accepts private keys, signs transactions, or broadcasts them.
+
+## Run the example
+
+Clone the Peer Cash repository and enter the example directory.
+
+```bash [terminal]
+$ git clone https://github.com/zkp2p/peer-cash.git
+$ cd peer-cash/examples/mpp-revenue-cashout
+```
+
+:::code-group
+```bash [npm]
+$ npm install
+```
+```bash [pnpm]
+$ pnpm install
+```
+```bash [bun]
+$ bun install
+```
+:::
+
+Configure the merchant wallet, facilitator, and payout details. `MPPX_RECIPIENT` must be the merchant-controlled Base wallet that signs any prepared Peer Cash transactions.
+
+```bash [terminal]
+$ export MPPX_RECIPIENT=0xMerchantWallet
+$ export X402_FACILITATOR_URL=https://your-facilitator.example
+$ export MPP_SECRET_KEY=replace-with-at-least-32-random-characters
+$ export PEER_CASH_PLATFORM=revolut
+$ export PEER_CASH_CURRENCY=USD
+$ export PEER_CASH_PAYEE=your-handle
+$ export PEER_CASH_THRESHOLD_USDC=10
+```
+
+Start the public MPP API and the local cash-out planner.
+
+:::code-group
+```bash [npm]
+$ npm run dev
+```
+```bash [pnpm]
+$ pnpm run dev
+```
+```bash [bun]
+$ bun run dev
+```
+:::
+
+The public MPP API listens on port `5173`. The Peer Cash planner binds to `127.0.0.1:5174` so it is not exposed as a public payment route.
+
+## Accept MPP revenue
+
+The example protects `GET /api/report` with an MPP EVM charge for USDC on Base. A successful Receipt records the settled amount once, using its reference to reject duplicates.
+
+Use an MPP client funded with Base USDC to call the route:
+
+```bash [terminal]
+$ MPPX_PRIVATE_KEY=0x... bunx mppx http://localhost:5173/api/report
+```
+
+## Prepare a cash-out
+
+Inspect confirmed revenue on the local planner:
+
+```bash [terminal]
+$ curl http://127.0.0.1:5174/status
+```
+
+After confirmed, unreserved revenue reaches the threshold, prepare a cash-out for the full amount:
+
+```bash [terminal]
+$ curl -X POST http://127.0.0.1:5174/cashout \
+    -H 'content-type: application/json' \
+    -d '{}'
+```
+
+Pass `{"amountUsdc":"5.25"}` to prepare a smaller amount. The response contains unsigned transactions and same-index step descriptions. Review them, then sign and submit them with the merchant wallet.
+
+The example keeps settlement and reservation state in memory. Persist successful Receipts, reservations, submitted transactions, and confirmed cash-outs before exposing an equivalent operator endpoint in production.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -433,6 +433,10 @@ export default defineConfig({
             link: "/partner-integrations/openclaw",
           },
           {
+            text: "Peer Cash",
+            link: "/partner-integrations/peer-cash",
+          },
+          {
             text: "Vercel AI SDK",
             link: "/partner-integrations/vercel-ai-sdk",
           },


### PR DESCRIPTION
## Summary

- Add a Peer Cash partner integration guide backed by the merged Peer-owned MPP example.
- Keep the product boundary explicit: MPP settles Base USDC into the merchant wallet first, then Peer Cash prepares a separate unsigned seller cash-out plan.
- Register the guide in the Partner Integrations sidebar and generated page index.

## Context

This follows @brendanjryan's direction in [wevm/mppx#798](https://github.com/wevm/mppx/pull/798): vendor-specific examples are welcome in the vendor's own repository or documentation. The canonical example now lives at [zkp2p/peer-cash](https://github.com/zkp2p/peer-cash/tree/main/examples/mpp-revenue-cashout).

The guide does not introduce a Peer payment method or a payer-side flow. The public MPP route remains independent from the localhost-only cash-out planner, and only the merchant-controlled wallet can sign or submit the returned transactions.

## Validation

- `pnpm check:types`
- `pnpm check:markdown`
- `pnpm check:generated`
- `pnpm check:ci`
- `pnpm test` (9,699 tests)
- `pnpm build`
- Live-link checks for the Peer Cash SDK and canonical example
