### PR TITLE
Fix: Enforce production secrets and remove unsafe fallbacks

### DIFF
--- a/src/mppx-payment-link.server.ts
+++ b/src/mppx-payment-link.server.ts
@@ -5,9 +5,14 @@ import { tempoModerato } from "viem/chains";
 import { mppxSecretKey } from "./mppx-secret.server";
 
 const realm = process.env.REALM ?? "mpp.tempo.xyz";
+
+const feePayerKey = process.env.FEE_PAYER_PRIVATE_KEY;
+if (!feePayerKey && !import.meta.env.DEV) {
+  throw new Error("FEE_PAYER_PRIVATE_KEY is required outside development/test");
+}
+
 const account = privateKeyToAccount(
-  (process.env.FEE_PAYER_PRIVATE_KEY ??
-    "0x0000000000000000000000000000000000000000000000000000000000000001") as `0x${string}`,
+  (feePayerKey ?? "0x0000000000000000000000000000000000000000000000000000000000000001") as `0x${string}`
 );
 
 export const mppx = Mppx.create({

--- a/src/mppx-secret.server.ts
+++ b/src/mppx-secret.server.ts
@@ -2,23 +2,19 @@ const localExampleSecretKey = "local-development-only-example-key";
 
 export function resolveMppxSecretKey({
   isDevelopment,
-  lifecycleEvent,
   secretKey,
 }: {
   isDevelopment: boolean;
-  lifecycleEvent?: string;
   secretKey?: string;
 }) {
-  return (
-    secretKey ??
-    (isDevelopment || lifecycleEvent === "build"
-      ? localExampleSecretKey
-      : undefined)
-  );
+  if (!secretKey && !isDevelopment) {
+    throw new Error("MPP_SECRET_KEY is required outside development/test");
+  }
+  
+  return secretKey ?? localExampleSecretKey;
 }
 
 export const mppxSecretKey = resolveMppxSecretKey({
   isDevelopment: import.meta.env.DEV,
-  lifecycleEvent: process.env.npm_lifecycle_event,
   secretKey: process.env.MPP_SECRET_KEY,
 });


### PR DESCRIPTION
This PR removes unsafe fallback behaviors for critical secrets in production, ensuring the application fails closed if environment variables are misconfigured.

Updates:

mppx-payment-link.server.ts: Removed the hardcoded fallback private key (0x...01). It now explicitly throws an error if FEE_PAYER_PRIVATE_KEY is missing outside of development.

mppx-secret.server.ts: Dropped the lifecycleEvent === "build" condition. It no longer silently injects the local example key during production builds, throwing an error instead if MPP_SECRET_KEY is not provided.