### PR TITLE
docs: fix style guide findings

### DIFF
--- a/src/pages/payment-methods/nearintents/charge.mdx
+++ b/src/pages/payment-methods/nearintents/charge.mdx
@@ -113,7 +113,7 @@ mppx.on('payment.failed', ({ error }) => logger.warn(error.type, error.message))
 | `onEvent` | `(event) => void` | Optional | |
 
 :::info
-The 1Click JWT (from the [NEAR Intents partner portal](https://partners.near-intents.org)) is server-side only and must never appear in any Challenge field. Unauthenticated requests work but incur a 0.2% fee. Replay protection requires an **atomic** store: the in-memory default is for a single instance; use a shared store (e.g. `Store.redis`) in multi-instance deployments.
+The 1Click JWT (from the [NEAR Intents partner portal](https://partners.near-intents.org)) is server-side only and must never appear in any Challenge field. Unauthenticated requests work but incur a 0.2% fee. Replay protection requires an **atomic** store: the in-memory default is for a single instance; use a shared store (for example, `Store.redis`) in multi-instance deployments.
 :::
 
 ## Client
@@ -190,7 +190,7 @@ The Challenge request describes the payment the client makes on the origin chain
 | `methodDetails.destinationRecipient` | `string` | Required | Merchant address on the destination chain |
 | `methodDetails.amountOut` | `string` | Required | Exact amount the merchant receives (`EXACT_OUTPUT`) |
 | `methodDetails.minAmountIn` | `string` | Required | Minimum deposit the backend accepts — the verification threshold |
-| `methodDetails.depositMemo` | `string \| null` | Optional | Deposit memo required by some origin chains (e.g. Stellar) |
+| `methodDetails.depositMemo` | `string \| null` | Optional | Deposit memo required by some origin chains (for example, Stellar) |
 | `methodDetails.slippageTolerance` | `number` | Optional | Basis points, applied to the input side |
 | `methodDetails.timeEstimate` | `number` | Optional | Estimated swap completion time in seconds |
 | `methodDetails.refundTo` | `string` | Required | Origin-chain address refunded on any non-success outcome |

--- a/src/pages/protocol/http-402.mdx
+++ b/src/pages/protocol/http-402.mdx
@@ -3,7 +3,7 @@ description: "HTTP 402 Payment Required signals that a resource requires payment
 imageDescription: "What HTTP 402 means and how MPP uses it"
 ---
 
-# HTTP 402
+# HTTP 402 [Require payment before granting access]
 
 MPP services return HTTP `402` Payment Required to indicate that a resource requires payment for access. This is the foundation that enables [API monetization](/use-cases/api-monetization) and [micropayments](/use-cases/micropayments) at the protocol level.
 

--- a/src/pages/sdk/typescript/Html.init.mdx
+++ b/src/pages/sdk/typescript/Html.init.mdx
@@ -11,7 +11,7 @@ For a full guide on adding HTML support to a custom payment method, see [Custom 
 
 ## Usage
 
-```ts [example.ts]
+```ts twoslash [example.ts]
 import * as Html from 'mppx/html'
 
 const context = Html.init('tempo')

--- a/src/pages/sdk/typescript/server/Request.toNodeListener.mdx
+++ b/src/pages/sdk/typescript/server/Request.toNodeListener.mdx
@@ -4,17 +4,16 @@ Converts a Fetch API handler into a Node.js HTTP request listener. Useful for ru
 
 ## Usage
 
-```ts
+```ts twoslash [server.ts]
 import http from 'node:http'
-import { Mppx, Request, tempo } from 'mppx/server'
+import { Request } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo.charge()] })
+const listener = Request.toNodeListener((request) => {
+  const pathname = new URL(request.url).pathname
+  return new Response(`Requested ${pathname}`)
+})
 
-const server = http.createServer(
-  Request.toNodeListener(mppx.request),
-)
-
-server.listen(3000)
+http.createServer(listener).listen(3000)
 ```
 
 ### `Request.fromNodeListener`

--- a/src/pages/tools/wallet.mdx
+++ b/src/pages/tools/wallet.mdx
@@ -199,7 +199,7 @@ $ claude mcp add agentcash --scope user -- npx -y agentcash@latest
 - **300+ premium APIs** - enrichment, social data, image generation, web scraping, email, all accessible instantly
 - **No human required** - pay per request with USDC.e, no subscriptions or manual sign-up flows
 - **API and tool discovery** - any service that implements MPP is automatically discoverable and usable
-- **MPPScan integration** — easily discover and use services via [mppscan.com](https://www.mppscan.com/)
+- **MPPScan integration** — discover and use services via [mppscan.com](https://www.mppscan.com/)
 
 ## Link CLI
 


### PR DESCRIPTION
## Motivation

Bring selected documentation pages in line with the project style guide and ensure runnable SDK examples typecheck.

## Summary

- add the required HTTP 402 page tagline
- enable Twoslash for self-contained SDK usage examples
- update the Node listener example to the current API
- replace discouraged prose

## Key design considerations

- keep partial and dependency-specific TypeScript snippets as non-Twoslash examples
- preserve code identifiers while applying prose terminology rules