### PR TITLE
docs: streamline Tempo agent setup

### DIFF
--- a/scripts/check-agent-setup.test.ts
+++ b/scripts/check-agent-setup.test.ts
@@ -1,0 +1,50 @@
+import { readdir, readFile } from "node:fs/promises";
+import { extname, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const SOURCE_ROOT = resolve(ROOT, "src");
+
+async function sourceFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = resolve(directory, entry.name);
+      if (entry.isDirectory()) return sourceFiles(path);
+      return [".mdx", ".ts", ".tsx"].includes(extname(entry.name))
+        ? [path]
+        : [];
+    }),
+  );
+  return files.flat();
+}
+
+describe("agent setup documentation", () => {
+  it("shows the canonical prompt before manual setup and alternatives", async () => {
+    const page = await readFile(
+      resolve(SOURCE_ROOT, "pages/quickstart/agent.mdx"),
+      "utf8",
+    );
+    const prompt = page.indexOf("<AgentSetupPrompt />");
+    const manualSetup = page.indexOf("## Manual setup");
+    const alternatives = page.indexOf("## Other MPP clients and integrations");
+
+    expect(prompt).toBeGreaterThan(-1);
+    expect(manualSetup).toBeGreaterThan(prompt);
+    expect(alternatives).toBeGreaterThan(manualSetup);
+  });
+
+  it("does not publish retired Tempo CLI commands", async () => {
+    const violations: string[] = [];
+
+    for (const file of await sourceFiles(SOURCE_ROOT)) {
+      const content = await readFile(file, "utf8");
+      for (const command of ["tempo add wallet", "tempo run"]) {
+        if (content.includes(command))
+          violations.push(`${relative(ROOT, file)}: ${command}`);
+      }
+    }
+
+    expect(violations, violations.join("\n")).toHaveLength(0);
+  });
+});

--- a/src/components/AgentSetupPrompt.test.tsx
+++ b/src/components/AgentSetupPrompt.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AGENT_SETUP_PROMPT, AgentSetupPrompt } from "./AgentSetupPrompt";
+
+afterEach(cleanup);
+
+describe("AgentSetupPrompt", () => {
+  it("copies the canonical prompt and confirms the next action", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<AgentSetupPrompt />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy prompt" }));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(AGENT_SETUP_PROMPT),
+    );
+    expect(screen.getByText("Copied — paste into your agent")).not.toBeNull();
+  });
+
+  it("links to manual setup from embedded marketing surfaces", () => {
+    render(
+      <AgentSetupPrompt
+        manualSetupHref="/quickstart/agent#manual-setup"
+        variant="marketing"
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Manual setup" }).getAttribute("href"),
+    ).toBe("/quickstart/agent#manual-setup");
+    expect(
+      screen.getByRole("button", { name: "Copy prompt" }).textContent,
+    ).toBe("");
+  });
+});

--- a/src/components/AgentSetupPrompt.tsx
+++ b/src/components/AgentSetupPrompt.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { code, withMarkdown } from "./markdown";
+import { Icon } from "./marketing/Icon";
+
+export const AGENT_SETUP_PROMPT =
+  "Read https://tempo.xyz/SKILL.md and set up tempo";
+
+type AgentSetupPromptProps = {
+  manualSetupHref?: string;
+  variant?: "docs" | "marketing";
+};
+
+/** Displays the canonical Tempo setup prompt with a copy action. */
+export const AgentSetupPrompt = withMarkdown(
+  function AgentSetupPrompt({
+    manualSetupHref = "#manual-setup",
+    variant = "docs",
+  }: AgentSetupPromptProps) {
+    const [copied, setCopied] = useState(false);
+    const timer = useRef<number | undefined>(undefined);
+
+    useEffect(() => () => clearTimeout(timer.current), []);
+
+    const docs = variant === "docs";
+    const copyPrompt = async () => {
+      try {
+        await navigator.clipboard.writeText(AGENT_SETUP_PROMPT);
+        setCopied(true);
+        clearTimeout(timer.current);
+        timer.current = window.setTimeout(() => setCopied(false), 1800);
+      } catch {}
+    };
+
+    return (
+      <div
+        className={
+          docs
+            ? "vocs:my-6 vocs:flex vocs:flex-col vocs:gap-3"
+            : "flex flex-col gap-3"
+        }
+      >
+        <p
+          className={
+            docs
+              ? "vocs:m-0 vocs:text-heading"
+              : "font-sans text-sm leading-[1.2] text-offwhite"
+          }
+        >
+          Paste this into Codex, Claude Code, Amp, or another coding agent:
+        </p>
+        {docs ? (
+          <button
+            aria-label={
+              copied ? "Copied — paste into your agent" : "Copy prompt"
+            }
+            className="vocs:flex vocs:w-full vocs:flex-col vocs:items-start vocs:gap-3 vocs:rounded-lg vocs:border vocs:border-primary vocs:bg-surface vocs:p-4 vocs:text-left vocs:transition-colors vocs:hover:bg-surfaceTint vocs:sm:flex-row vocs:sm:items-center vocs:sm:justify-between"
+            onClick={copyPrompt}
+            type="button"
+          >
+            <code className="vocs:min-w-0 vocs:whitespace-pre-wrap vocs:break-words vocs:font-mono vocs:text-sm vocs:text-heading">
+              {AGENT_SETUP_PROMPT}
+            </code>
+            <span
+              aria-live="polite"
+              className="vocs:inline-flex vocs:shrink-0 vocs:items-center vocs:gap-2 vocs:rounded-md vocs:border vocs:border-primary vocs:px-3 vocs:py-2 vocs:text-sm vocs:font-medium vocs:text-secondary"
+            >
+              {copied ? "Copied — paste into your agent" : "Copy prompt"}
+              <Icon className="shrink-0" name="copy" />
+            </span>
+          </button>
+        ) : (
+          <div className="flex w-full items-start gap-3 border border-border bg-[#101010] p-3">
+            <code className="min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-sm leading-[1.4] text-offwhite">
+              {AGENT_SETUP_PROMPT}
+            </code>
+            <button
+              aria-label={copied ? "Copied to clipboard" : "Copy prompt"}
+              className={
+                copied
+                  ? "ml-auto inline-flex shrink-0 border border-term-green p-1.5 text-term-green"
+                  : "ml-auto inline-flex shrink-0 border border-border p-1.5 text-secondary transition-colors hover:border-[rgba(235,235,235,0.4)] hover:text-offwhite"
+              }
+              onClick={copyPrompt}
+              title={copied ? "Copied" : "Copy prompt"}
+              type="button"
+            >
+              <Icon name="copy" size={14} />
+            </button>
+          </div>
+        )}
+        <p
+          className={
+            docs
+              ? "vocs:m-0 vocs:text-secondary"
+              : "font-sans text-sm leading-[1.2] text-secondary"
+          }
+        >
+          Your agent installs Tempo, pauses when browser and passkey login is
+          required, and verifies your wallet.{" "}
+          <a
+            className={
+              docs
+                ? "vocs:underline"
+                : "underline transition-colors hover:text-offwhite"
+            }
+            href={manualSetupHref}
+          >
+            Manual setup
+          </a>
+        </p>
+      </div>
+    );
+  },
+  () => [
+    {
+      children: [
+        {
+          type: "text",
+          value:
+            "Paste this into Codex, Claude Code, Amp, or another coding agent:",
+        },
+      ],
+      type: "paragraph",
+    },
+    code(AGENT_SETUP_PROMPT),
+    {
+      children: [
+        {
+          type: "text",
+          value:
+            "Your agent installs Tempo, pauses when browser and passkey login is required, and verifies your wallet.",
+        },
+      ],
+      type: "paragraph",
+    },
+  ],
+);

--- a/src/components/ServicesPage.test.tsx
+++ b/src/components/ServicesPage.test.tsx
@@ -216,14 +216,17 @@ describe("buildTryCommands", () => {
   };
 
   it("includes a JSON request for non-GET endpoints", () => {
-    expect(
-      buildTryCommands(service, {
-        method: "POST",
-        path: "/responses",
-      }),
-    ).toContain(
+    const commands = buildTryCommands(service, {
+      method: "POST",
+      path: "/responses",
+    });
+
+    expect(commands).toContain(
       'https://test.mpp.dev/responses \\\n    -X POST --json \'{"input":"Hello!"}\'',
     );
+    expect(commands).toContain("curl -fsSL https://tempo.xyz/install | bash");
+    expect(commands).toContain("tempo wallet login");
+    expect(commands).toContain("tempo request");
   });
 
   it("omits a request body for GET endpoints", () => {
@@ -232,7 +235,9 @@ describe("buildTryCommands", () => {
       path: "/search",
     });
 
-    expect(commands).toContain("tempo run \\\n    https://test.mpp.dev/search");
+    expect(commands).toContain(
+      "tempo request \\\n    https://test.mpp.dev/search",
+    );
     expect(commands).not.toContain("--json");
     expect(commands).not.toContain("-X GET");
   });

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -8,6 +8,7 @@ import {
   type Service,
   serviceIconUrl,
 } from "../data/registry";
+import { AgentSetupPrompt } from "./AgentSetupPrompt";
 import { Button } from "./marketing/Button";
 import { CopyBadge } from "./marketing/CopyBadge";
 import { cx } from "./marketing/cx";
@@ -80,10 +81,9 @@ export function buildTryCommands(service: Service, endpoint: Endpoint): string {
       ? ""
       : ` \\\n    -X ${endpoint.method} --json '{"input":"Hello!"}'`;
   return [
-    "curl -L https://tempo.xyz/install | bash",
-    "tempo add wallet",
+    "curl -fsSL https://tempo.xyz/install | bash",
     "tempo wallet login",
-    `tempo run \\\n    ${endpointUrl(service, endpoint)}${requestArguments}`,
+    `tempo request \\\n    ${endpointUrl(service, endpoint)}${requestArguments}`,
   ].join("\n");
 }
 
@@ -284,34 +284,6 @@ function ShortcutCard({
         name="arrow-right"
       />
     </a>
-  );
-}
-
-function CopyIconButton({ label, text }: { label: string; text: string }) {
-  const [copied, setCopied] = useState(false);
-  const timer = useRef<number | undefined>(undefined);
-
-  useEffect(() => () => clearTimeout(timer.current), []);
-
-  return (
-    <button
-      aria-label={copied ? "Copied" : label}
-      className={cx(
-        "shrink-0 text-secondary transition-colors hover:text-offwhite",
-        copied && "text-term-green",
-      )}
-      onClick={async () => {
-        try {
-          await navigator.clipboard.writeText(text);
-          setCopied(true);
-          clearTimeout(timer.current);
-          timer.current = window.setTimeout(() => setCopied(false), 1200);
-        } catch {}
-      }}
-      type="button"
-    >
-      <Icon name="copy" />
-    </button>
   );
 }
 
@@ -834,52 +806,10 @@ export function ServicesPage() {
               </summary>
 
               <div className="hidden space-y-5 group-open:block">
-                <div className="flex flex-col gap-2">
-                  <p className="font-mono text-sm uppercase leading-4 tracking-[-0.14px] text-offwhite">
-                    Install Tempo tools
-                  </p>
-                  <p className="font-sans text-sm leading-[1.2] text-secondary">
-                    Install the CLI. You&apos;ll be asked to sign in or create a
-                    passkey-based wallet in your browser.
-                  </p>
-                </div>
-                <div className="flex items-start gap-2 bg-[#101010] p-2.5">
-                  <pre className="flex-1 overflow-x-auto whitespace-pre-wrap font-mono text-sm leading-[1.4]">
-                    <span className="text-secondary">$</span>{" "}
-                    <span className="text-term-green">curl</span>{" "}
-                    <span className="text-secondary">-L</span>{" "}
-                    <span className="text-offwhite">
-                      https://tempo.xyz/install
-                    </span>{" "}
-                    <span className="text-term-green">| bash</span>
-                  </pre>
-                  <CopyIconButton
-                    label="Copy command"
-                    text="curl -L https://tempo.xyz/install | bash"
-                  />
-                </div>
-
-                <div className="flex flex-col gap-2">
-                  <p className="font-mono text-sm uppercase leading-4 tracking-[-0.14px] text-offwhite">
-                    Prompt your agent
-                  </p>
-                  <p className="font-sans text-sm leading-[1.2] text-secondary">
-                    Tell Claude, Codex, or another coding agent to use an MPP
-                    service.
-                  </p>
-                </div>
-                <div className="flex items-start gap-2 bg-[#101010] p-2.5">
-                  <pre className="flex-1 overflow-x-auto whitespace-pre-wrap font-mono text-sm leading-[1.4]">
-                    $ claude &quot;Summarize https://stripe.com/docs using
-                    parallel.ai search via Tempo&quot;
-                  </pre>
-                  <CopyIconButton
-                    label="Copy prompt"
-                    text={
-                      'claude "Summarize https://stripe.com/docs using parallel.ai search via Tempo"'
-                    }
-                  />
-                </div>
+                <AgentSetupPrompt
+                  manualSetupHref="/quickstart/agent#manual-setup"
+                  variant="marketing"
+                />
 
                 <p className="font-sans text-sm leading-[1.2] text-secondary">
                   Point your agent to{" "}

--- a/src/components/markdown.test.ts
+++ b/src/components/markdown.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { AgentSetupPrompt } from "./AgentSetupPrompt";
 import { AsciiLogo } from "./AsciiLogo";
 import { staticCards } from "./cards";
 import { EcosystemDiagram } from "./EcosystemDiagram";
@@ -21,6 +22,7 @@ import { TerminalPoem } from "./TerminalPoem";
 type MarkdownComponent = { toMarkdown: () => unknown };
 
 const components = {
+  AgentSetupPrompt,
   AsciiLogo,
   ClientPrompt,
   EcosystemDiagram,

--- a/src/pages/quickstart/agent.mdx
+++ b/src/pages/quickstart/agent.mdx
@@ -3,34 +3,19 @@ description: "Connect your coding agent to MPP-enabled services. Set up a wallet
 imageDescription: "Connect your agent to paid APIs"
 ---
 
-import { Badge, Card, Cards, Tab, Tabs } from 'vocs'
+import { Card, Cards, Tab, Tabs } from 'vocs'
+import { AgentSetupPrompt } from '../../components/AgentSetupPrompt'
 
 # Use with agents [Connect your agent to MPP-enabled services]
 
-Agents can automatically interact with MPP-enabled services, paying for API calls without human intervention. Learn more about [agentic payments](/use-cases/agentic-payments) or get started below.
+After setup, agents can automatically interact with MPP-enabled services and pay for API calls. Learn more about [agentic payments](/use-cases/agentic-payments) or get started below.
 
-| Tool | Best for | Setup |
-|------|----------|-------|
-| [Tempo Wallet](#tempo-wallet) | MPP services with spend controls and service discovery | `tempo wallet login` |
-| [Privy Agent CLI](#privy-agent-cli) | Multi-chain agent wallets with browser-based funding | `privy-agent-wallets login` |
-| [AgentCash](#agentcash) | Discover and use 300+ premium APIs via MPP | `npx agentcash onboard` |
-| [`mppx` CLI](#mppx) | Development and debugging | `mppx account create` |
+<AgentSetupPrompt />
 
-## Tempo Wallet <Badge variant="info" data-toc-exclude>Recommended</Badge>
+## Manual setup
 
-The [Tempo Wallet](https://wallet.tempo.xyz) is a managed MPP client with built in spend controls and service discovery. Agents can use `tempo wallet` to discovery and pay for MPP-enabled services on demand.
+Set up [Tempo Wallet](https://wallet.tempo.xyz) yourself if you don't want your coding agent to handle installation.
 
-<Tabs>
-<Tab title="Agent">
-
-Paste this into your agent to set up Tempo Wallet:
-
-```
-Read https://tempo.xyz/SKILL.md and set up tempo
-```
-
-</Tab>
-<Tab title="Human">
 ::::steps
 
 ### Install the CLI
@@ -66,10 +51,18 @@ $ tempo request -X POST \
 ```
 
 ::::
-</Tab>
-</Tabs>
 
-## Privy Agent CLI
+## Other MPP clients and integrations
+
+Tempo Wallet is the recommended way to use MPP services with a coding agent. These alternatives support other wallets and development workflows.
+
+| Tool | Best for |
+|------|----------|
+| [Privy Agent CLI](#privy-agent-cli) | Multi-chain agent wallets with browser-based funding |
+| [AgentCash](#agentcash) | Discover and use 300+ premium APIs via MPP |
+| [`mppx` CLI](#mppx) | Development and debugging |
+
+### Privy Agent CLI
 
 [Privy Agent CLI](https://docs.privy.io/recipes/agent-integrations/agent-cli) gives agents a CLI-first way to create, fund, and manage wallets with no integration code. It pairs with the [Agent Sandbox](https://agents.privy.io/) where users track agent spending, manage funds, and revoke access.
 
@@ -124,7 +117,7 @@ $ privy-agent-wallets rpc --json '{"method": "eth_sendTransaction", "params": {"
 </Tab>
 </Tabs>
 
-## AgentCash
+### AgentCash
 
 [AgentCash](https://agentcash.dev) gives agents instant access to 300+ premium APIs for data enrichment, social data, image generation, web scraping, email, and much more, all through one USDC.e balance.
 
@@ -173,7 +166,7 @@ $ claude mcp add agentcash --scope user -- npx -y agentcash@latest
 </Tab>
 </Tabs>
 
-## mppx
+### mppx
 
 The [`mppx`](/sdk/typescript/cli) CLI is a lightweight MPP client bundled with the `mppx` package. It is designed for simple use cases and debugging during development.
 


### PR DESCRIPTION
## Motivation

Make the recommended Tempo agent setup action impossible to miss and remove outdated setup paths that derail users.

## Summary

- Added a reusable prompt copy component for docs and marketing surfaces.
- Moved the Tempo skill prompt to the top of the agent quickstart and grouped alternatives below manual setup.
- Updated service try commands to the current Tempo CLI syntax.
- Simplified the services sidebar to the canonical prompt with a compact right-aligned copy action.
- Added regression coverage for prompt ordering, copy behavior, and retired commands.

## Key design considerations

- The quickstart keeps an explicit copy action and confirmation, while the services sidebar uses a compact icon-only control.
- Manual setup remains an adjacent fallback; alternative clients stay accessible but secondary.
- The canonical prompt is shared so docs and marketing surfaces cannot drift.