### PR TITLE
Add a9n9 Deep Research to the services directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -310,6 +310,46 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── a9n9 Deep Research ─────────────────────────────────────────────────
+  {
+    id: "a9n9-deep-research",
+    name: "a9n9 Deep Research",
+    url: "https://agent.a9n9.net",
+    serviceUrl: "https://agent.a9n9.net",
+    description:
+      "Objective-driven deep research for agents: quote-first fixed pricing, a real cloud browser over a planned list of public sources, and a cited cross-source report. Free daily quick search over news and arXiv.",
+    icon: "https://agent.a9n9.net/favicon.svg",
+    categories: ["ai", "search", "web"],
+    integration: "third-party",
+    tags: ["research", "deep-research", "browser", "reports", "citations", "mcp"],
+    status: "active",
+    docs: {
+      homepage: "https://agent.a9n9.net",
+      llmsTxt: "https://agent.a9n9.net/llms.txt",
+      apiReference: "https://agent.a9n9.net/openapi.json",
+    },
+    provider: { name: "a9n9", url: "https://a9n9.net" },
+    realm: "agent.a9n9.net",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/research/browserbase",
+        desc: "Quote, pay, and run objective-driven deep research in a cloud browser",
+        dynamic: true,
+        amountHint: "$0.28 – $0.40 by tier (quick / standard / deep)",
+        unitType: "request",
+      },
+      {
+        route: "POST /v1/search",
+        desc: "Free daily-limited quick search over global news or arXiv papers",
+      },
+      {
+        route: "GET /v1/research/status/:trackerCode",
+        desc: "Free progress polling and final report retrieval",
+      },
+    ],
+  },
   // ── agentfax ───────────────────────────────────────────────────────────
   {
     id: "agentfax",


### PR DESCRIPTION
Adds **a9n9 Deep Research** (https://agent.a9n9.net) — an objective-driven deep-research service for agents, paid per request over MPP on Tempo mainnet.

**What it does:** an agent sends an objective (plus optional targetUrl focus hint) and gets a fixed quote bound to the request hash with a planned list of public source URLs; after payment a real cloud Chromium session visits each planned page and AI synthesis returns a cited cross-source report. Free daily quick search (news/arXiv) is included. Native MCP tools at `https://agent.a9n9.net/mcp` alongside REST.

**Verification:**
- `npx mppx validate https://agent.a9n9.net` — passes (15/15)
- Discovery: https://agent.a9n9.net/openapi.json · https://agent.a9n9.net/llms.txt · `/.well-known/a9n9-agent.json`
- Listed on MPPScan with live mainnet transaction history
- Runtime 402 challenges: `method=tempo`, `intent=charge`, USDC.e, realm `agent.a9n9.net`
- Payment recipient: `0x2D6424143693eB6ADc36C318468811D01B25DEFf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)