### PR TITLE
docs: add service submission guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/service.md
+++ b/.github/PULL_REQUEST_TEMPLATE/service.md
@@ -1,0 +1,25 @@
+## Motivation
+
+<!-- Describe what the service does, who it serves, and what makes it useful or distinct. -->
+
+- **Service name:**
+- **Live service URL:**
+- **Provider URL:**
+- **OpenAPI or API reference URL:**
+
+## Summary
+
+- [ ] The service is live and accepts MPP payments.
+- [ ] This PR adds or updates its entry in `schemas/services.ts`.
+- [ ] Listed endpoints, prices, and payment methods match the live service.
+- [ ] Public documentation and icon URLs are stable and accessible.
+- [ ] `pnpm generate:discovery` succeeds.
+- [ ] `pnpm check:types` passes.
+- [ ] `pnpm build` succeeds.
+
+## Key design considerations
+
+- **Integration:** <!-- first-party or third-party -->
+- **Payment methods and intents:**
+- **Provider relationship:** <!-- State whether you own or operate the service. If not, explain the integration. -->
+- **Directory fit:** <!-- Explain why this is production-ready and not a duplicate of an existing listing. -->

--- a/.github/workflows/service-pr-guide.yml
+++ b/.github/workflows/service-pr-guide.yml
@@ -21,23 +21,9 @@ jobs:
             const body = [
               'Thanks for submitting a service to the MPP directory!',
               '',
-              'If you want your service included in the curated `mpp.dev/services` list, complete this checklist before review:',
+              'Complete the [service pull request template](https://github.com/tempoxyz/mpp/blob/main/.github/PULL_REQUEST_TEMPLATE/service.md) in your PR description before review. It contains the current submission requirements and review criteria.',
               '',
-              '### Required',
-              '- [ ] Your service is **live and accepting payments** via MPP (not a placeholder or coming-soon)',
-              '- [ ] You\'ve added your entry to `schemas/services.ts` following the [service submission guide](https://mpp.dev/services#list-your-service)',
-              '- [ ] Registry generation succeeds: `pnpm generate:discovery`',
-              '- [ ] Types pass: `pnpm check:types`',
-              '- [ ] Build succeeds: `pnpm build`',
-              '',
-              '### Recommended',
-              '- [ ] Register your service on [MPPScan](https://www.mppscan.com/register) (by Merit Systems) — it follows the standard MPP discovery format and makes your service discoverable by agents immediately, no PR required',
-              '',
-              '### Review criteria',
-              'We prioritize services that are **high quality and novel**. We may not approve services that duplicate existing functionality or aren\'t yet production-ready.',
-              '',
-              '---',
-              '[Service submission guide](https://mpp.dev/services#list-your-service) · [Service PR template](https://github.com/tempoxyz/mpp/compare?expand=1&template=service.md) · [MPPScan](https://www.mppscan.com/register) · [Protocol docs](https://mpp.dev/protocol/)',
+              '[Service submission guide](https://mpp.dev/services#list-your-service)',
             ].join('\n');
 
             await github.rest.issues.createComment({

--- a/.github/workflows/service-pr-guide.yml
+++ b/.github/workflows/service-pr-guide.yml
@@ -25,7 +25,8 @@ jobs:
               '',
               '### Required',
               '- [ ] Your service is **live and accepting payments** via MPP (not a placeholder or coming-soon)',
-              '- [ ] You\'ve added your entry to `schemas/services.ts` following the [contributing guide](https://github.com/tempoxyz/mpp?tab=readme-ov-file#contributing-to-the-service-directory)',
+              '- [ ] You\'ve added your entry to `schemas/services.ts` following the [service submission guide](https://mpp.dev/services#list-your-service)',
+              '- [ ] Registry generation succeeds: `pnpm generate:discovery`',
               '- [ ] Types pass: `pnpm check:types`',
               '- [ ] Build succeeds: `pnpm build`',
               '',
@@ -36,7 +37,7 @@ jobs:
               'We prioritize services that are **high quality and novel**. We may not approve services that duplicate existing functionality or aren\'t yet production-ready.',
               '',
               '---',
-              '[Contributing guide](https://github.com/tempoxyz/mpp?tab=readme-ov-file#contributing-to-the-service-directory) · [MPPScan](https://www.mppscan.com/register) · [Protocol docs](https://mpp.dev/protocol/)',
+              '[Service submission guide](https://mpp.dev/services#list-your-service) · [Service PR template](https://github.com/tempoxyz/mpp/compare?expand=1&template=service.md) · [MPPScan](https://www.mppscan.com/register) · [Protocol docs](https://mpp.dev/protocol/)',
             ].join('\n');
 
             await github.rest.issues.createComment({

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Post frontmatter is the source of truth. The build validates it, orders the blog
 
 The service directory at [mpp.dev/services](https://mpp.dev/services) is curated for live, production-ready MPP services.
 
+Read the [service submission guide](https://mpp.dev/services#list-your-service), then use the [service pull request template](https://github.com/tempoxyz/mpp/compare?expand=1&template=service.md) when you open your PR.
+
 ### Submit a pull request to this repo
 
 If you want your service included in the curated `mpp.dev/services` list, open a PR and complete this checklist:
@@ -62,6 +64,7 @@ If you want your service included in the curated `mpp.dev/services` list, open a
 
 - [ ] Your service is **live and accepting payments** via MPP (not a placeholder or coming-soon)
 - [ ] You've added your entry to `schemas/services.ts`
+- [ ] Registry generation succeeds: `pnpm generate:discovery`
 - [ ] Types pass: `pnpm check:types`
 - [ ] Build succeeds: `pnpm build`
 
@@ -79,26 +82,27 @@ We prioritize services that are **high quality and novel**. We may not approve s
 
 ```ts
 {
-  id: "my-service",
-  name: "My Service",
-  url: "https://example.com",
-  serviceUrl: "https://api.example.com",
-  description: "What your service does.",
   categories: ["ai"],
-  integration: "first-party",
-  tags: ["llm", "chat"],
+  description: "What your service does.",
   docs: {
+    apiReference: "https://api.example.com/openapi.json",
     homepage: "https://docs.example.com",
     llmsTxt: "https://docs.example.com/llms.txt",
   },
-  provider: { name: "Example Inc.", url: "https://example.com" },
-  realm: MPP_REALM,
-  intent: "charge",
-  payment: TEMPO_PAYMENT,
   endpoints: [
-    { route: "POST /v1/completions", desc: "Generate completions", amount: "5000" },
-    { route: "GET /v1/models", desc: "List models" },
+    { amount: "5000", desc: "Generate completions", route: "POST /v1/completions" },
+    { desc: "List models", route: "GET /v1/models" },
   ],
+  id: "my-service",
+  integration: "first-party",
+  intent: "charge",
+  name: "My Service",
+  payments: [TEMPO_PAYMENT],
+  provider: { name: "Example Inc.", url: "https://example.com" },
+  realm: "api.example.com",
+  serviceUrl: "https://api.example.com",
+  tags: ["chat", "llm"],
+  url: "https://example.com",
 }
 ```
 

--- a/src/components/ServicesAgentDiscovery.test.tsx
+++ b/src/components/ServicesAgentDiscovery.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ServicesAgentDiscovery } from "./ServicesAgentDiscovery";
+
+afterEach(cleanup);
+
+describe("ServicesAgentDiscovery", () => {
+  it("links service owners to the submission template", () => {
+    render(<ServicesAgentDiscovery />);
+
+    expect(screen.getByRole("heading", { name: "List your service" }).id).toBe(
+      "list-your-service",
+    );
+    expect(
+      screen
+        .getByRole("link", { name: "Open a pull request" })
+        .getAttribute("href"),
+    ).toBe(
+      "https://github.com/tempoxyz/mpp/compare?expand=1&template=service.md",
+    );
+  });
+});

--- a/src/components/ServicesAgentDiscovery.tsx
+++ b/src/components/ServicesAgentDiscovery.tsx
@@ -69,6 +69,40 @@ export function ServicesAgentDiscovery() {
         </a>
         .
       </p>
+      <h2 data-v="" id="list-your-service">
+        List your service
+      </h2>
+      <p data-v="">
+        The curated directory accepts live, production-ready MPP services. To
+        submit yours:
+      </p>
+      <ol data-v="">
+        <li data-v="">
+          Make sure your service is live and accepts MPP payments.
+        </li>
+        <li data-v="">
+          Gather its public URL, documentation, endpoints, payment methods, and
+          pricing.
+        </li>
+        <li data-v="">
+          <a
+            data-v=""
+            href="https://github.com/tempoxyz/mpp/compare?expand=1&amp;template=service.md"
+          >
+            Open a pull request
+          </a>
+          .
+        </li>
+      </ol>
+      <p data-v="">
+        We prioritize high-quality, novel services and may decline duplicate or
+        incomplete listings. For immediate discovery outside the curated
+        directory, you can also{" "}
+        <a data-v="" href="https://www.mppscan.com/register">
+          register on MPPScan
+        </a>
+        .
+      </p>
     </div>
   );
 }

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -573,6 +573,11 @@ const shortcuts = [
     subtext: "Services which directly integrate with MPP.",
     title: "First-party services",
   },
+  {
+    href: "#list-your-service",
+    subtext: "Submit a live MPP API to the curated directory.",
+    title: "List your service",
+  },
 ];
 
 const topShortcuts = [

--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -26,7 +26,7 @@ Registries aggregate discovery documents from multiple services, making it easy 
 | Registry | Description | How to add |
 |----------|-------------|------------|
 | [MPPScan](https://mppscan.com) | Public registry of MPP-enabled services with search and analytics | [Manually register](https://www.mppscan.com/register) in one click |
-| [MPP Services directory](https://mpp.dev/services) | Curated list of live services on mpp.dev | [Submit a PR](https://github.com/tempoxyz/mpp) to add your service |
+| [MPP Services directory](https://mpp.dev/services) | Curated list of live services on mpp.dev | [Follow the submission guide](/services#list-your-service) |
 
 Agents can query the curated services directory over MCP at
 `https://mpp.dev/mcp/services`. The server is read-only and exposes tools to

--- a/src/pages/services.mdx
+++ b/src/pages/services.mdx
@@ -33,4 +33,14 @@ For MCP client setup, Inspector smoke tests, agent prompts, and recommended
 tool-call recipes, see
 [Discover MPP services on Tempo docs](https://docs.tempo.xyz/guide/machine-payments/discover-services).
 
+## List your service
+
+The curated directory accepts live, production-ready MPP services. To submit yours:
+
+1. Make sure your service is live and accepts MPP payments.
+2. Gather its public URL, documentation, endpoints, payment methods, and pricing.
+3. [Open a pull request](https://github.com/tempoxyz/mpp/compare?expand=1&template=service.md).
+
+We prioritize high-quality, novel services and may decline duplicate or incomplete listings. For immediate discovery outside the curated directory, you can also [register on MPPScan](https://www.mppscan.com/register).
+
 </div>


### PR DESCRIPTION
## Motivation

Make the curated service directory submission path easier for service owners to find and follow.

## Summary

- Add a high-level submission flow and shortcut to the Services page
- Add a service-specific pull request template
- Point registry documentation and PR automation to the submission guide
- Update the README service example for the current registry schema

## Key design considerations

- Keep the public flow focused on service readiness and listing information
- Keep technical contribution checks in the pull request template and contributor guidance
- Place the submission shortcut last in the Services page shortcut list