### PR TITLE
Add EvidInvest — SEC-filing-grounded equity research (first-party)

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1185,6 +1185,76 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── EvidInvest ─────────────────────────────────────────────────────────
+  {
+    id: "evidinvest",
+    name: "EvidInvest",
+    url: "https://mcp.evidinvest.com",
+    serviceUrl: "https://mcp.evidinvest.com",
+    description:
+      "SEC-filing-grounded equity research: cited filing search, fair-value and DCF valuation, company snapshots, and supply-chain maps.",
+
+    categories: ["data", "search"],
+    integration: "first-party",
+    tags: [
+      "finance",
+      "sec-filings",
+      "valuation",
+      "stocks",
+      "dcf",
+      "equity-research",
+    ],
+    docs: {
+      homepage: "https://evidinvest.com/developers",
+      llmsTxt: "https://mcp.evidinvest.com/llms.txt",
+      apiReference: "https://mcp.evidinvest.com/v1/openapi.json",
+    },
+    provider: {
+      name: "EvidInvest (EBD Sweden AB)",
+      url: "https://evidinvest.com",
+    },
+    realm: "mcp.evidinvest.com",
+    intent: "charge",
+    payments: [STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /v1/quote",
+        desc: "Free price quote for any paid task (no auth)",
+        docs: false,
+      },
+      {
+        route: "POST /v1/paid/filing_search",
+        desc: "Cited SEC filing passages with accession numbers",
+        dynamic: true,
+        amountHint: "$2.25 – $2.53 by model tier",
+      },
+      {
+        route: "POST /v1/paid/company_snapshot",
+        desc: "Company overview with key financial metrics",
+        dynamic: true,
+        amountHint: "$2.38 – $2.89 by model tier",
+      },
+      {
+        route: "POST /v1/paid/valuation",
+        desc: "Fair-value range: DCF, reverse DCF, multiples, peers",
+        dynamic: true,
+        amountHint: "$4.29 – $8.32 by model tier",
+      },
+      {
+        route: "POST /v1/paid/supply_chain",
+        desc: "Supply-chain map from filings, with evidence quotes",
+        dynamic: true,
+        amountHint: "$3.52 – $6.11 by model tier",
+      },
+      {
+        route: "POST /v1/paid/thesis_check",
+        desc: "Company products, customers, suppliers and risks from filings",
+        dynamic: true,
+        amountHint: "$6.64 – $15.17 by model tier",
+      },
+    ],
+  },
+
   // ── fal.ai ─────────────────────────────────────────────────────────────
   {
     id: "fal",


### PR DESCRIPTION
## Motivation

EvidInvest is an equity-research service for AI agents where every figure traces to an SEC filing. The paid tasks are **agent runs**: deterministic engines gather filed data (fundamentals, DCF/reverse-DCF, filing search with accession numbers, supply-chain graphs), then an LLM at the buyer's chosen tier writes the analysis. Distinct from generic market-data APIs in the directory: the product is cited, filing-grounded evaluation, not quotes or raw data.

- **Service name:** EvidInvest
- **Live service URL:** https://mcp.evidinvest.com
- **Provider URL:** https://evidinvest.com
- **OpenAPI or API reference URL:** https://mcp.evidinvest.com/v1/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service — verify: `curl -i -X POST https://mcp.evidinvest.com/v1/paid/valuation -H 'Content-Type: application/json' -d '{"symbol":"NVDA","model":"sonnet"}'` returns a 402 challenge (realm `mcp.evidinvest.com`, method `stripe`, amount matching `GET /v1/quote`).
- [x] Public documentation and icon URLs are stable and accessible (llms.txt, OpenAPI, homepage; no icon supplied).
- [x] `pnpm generate:discovery` succeeds (142 services).
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds (381 files); `vitest run` 9410 passed.

## Key design considerations

- **Integration:** first-party — served directly from mcp.evidinvest.com, no proxy.
- **Payment methods and intents:** Stripe MPP (card + Link via SPT), intent `charge`, dynamic per-request pricing with a free unauthenticated quote endpoint (`GET /v1/quote`).
- **Provider relationship:** I own and operate the service (EvidInvest / EBD Sweden AB, org 559332-0384).
- **Directory fit:** production service (also sells via API keys and MCP); no existing listing covers filing-cited equity valuation. Prices are dynamic by model tier, so endpoints use `amountHint` ranges per the schema.