### PR TITLE
Add Minibase API — URL to LLM-ready Markdown, pay-per-page

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1475,6 +1475,40 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Minibase ────────────────────────────────────────────────────────────
+  {
+    id: "minibase",
+    name: "Minibase API",
+    url: "https://api.minibase.md",
+    serviceUrl: "https://api.minibase.md",
+    description:
+      "Convert any URL to clean, LLM-ready Markdown — real-browser fetching, clutter stripped, 300+ site adapters (YouTube transcripts, X threads, Instagram, TikTok). Pay per page, no account.",
+
+    icon: "https://www.minibase.md/favicon-192.png",
+    categories: ["web", "data"],
+    integration: "first-party",
+    tags: ["markdown", "scraping", "rag", "url-to-markdown", "transcripts"],
+    status: "active",
+    docs: {
+      homepage: "https://www.minibase.md/api",
+      llmsTxt: "https://www.minibase.md/llms.txt",
+      apiReference: "https://api.minibase.md/openapi.json",
+    },
+    provider: { name: "Minibase", url: "https://www.minibase.md" },
+    realm: "api.minibase.md",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/convert",
+        desc: "Convert a URL to clean Markdown (plain $0.01; with an AI formatting template $0.05)",
+        dynamic: true,
+        amountHint: "$0.01 per page, $0.05 with an AI template",
+        unitType: "page",
+      },
+    ],
+  },
+
   // ── molty.cash ──────────────────────────────────────────────────────────
   {
     id: "moltycash",


### PR DESCRIPTION
## Motivation

Minibase API converts any URL into clean, LLM-ready Markdown: real-browser fetching, clutter stripped, 300+ site adapters (YouTube transcripts, X threads, Instagram, TikTok). Built for agents doing RAG/research that need one page *now* without an account — first MPP payments settled on Tempo mainnet on 2026-08-19.

- **Service name:** Minibase API
- **Live service URL:** https://api.minibase.md
- **Provider URL:** https://www.minibase.md
- **OpenAPI or API reference URL:** https://api.minibase.md/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [x] `pnpm generate:discovery` succeeds.
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds.

## Key design considerations

- **Integration:** first-party — direct endpoint, no proxy (realm `api.minibase.md`, challenges signed per mppx/Stripe recipe).
- **Payment methods and intents:** `tempo/charge`, USDC.e. Priced per request from the body: $0.01 plain markdown, $0.05 when an AI formatting `template` is requested — listed as `dynamic` with an `amountHint`; the runtime 402 is authoritative and the discovery document at `/openapi.json` is generated from the same middleware that signs the challenges.
- **Provider relationship:** I own and operate the service (solo developer).
- **Directory fit:** production-ready (live paid traffic settling through Stripe on Tempo since 2026-08-19). Closest neighbour in the directory is Firecrawl (scraping/crawling suites); Minibase is the single-purpose page→Markdown primitive with per-platform extraction (video transcripts, threads) at one cent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)