### PR TITLE
fix: correct Stripe charge amount in photo stripe endpoint

### DIFF
--- a/src/pages/_api/api/payment-link/photo-stripe.ts
+++ b/src/pages/_api/api/payment-link/photo-stripe.ts
@@ -2,9 +2,8 @@ import { stripeMppx } from "../../../../mppx-payment-link-stripe.server";
 
 export async function GET(request: Request) {
   const result = await stripeMppx.charge({
-    amount: "100",
+    amount: "1",
     currency: "usd",
-    decimals: 0,
     description: "A random unique image",
   })(request);
 


### PR DESCRIPTION
Fixes #908

The Stripe photo endpoint was using `amount: "100"` with `decimals: 0`, charging $1.00 (100 cents) while displaying "$0.01" a 100× mismatch.

Fix: use `amount: "1"` (1 cent = $0.01) to match the label and mirror the non-Stripe `photo.ts` endpoint. Also removes non standard `decimals: 0` to align with `STRIPE_PAYMENT`'s standard `decimals: 2`.