### PR TITLE
test: add Tempo localnet integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [lint, typecheck, test, mcp-services, build]
+    needs: [lint, typecheck, test, tempo-integration, mcp-services, build]
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -70,6 +70,24 @@ jobs:
       - run: pnpm test
       - name: Verify generated Markdown
         run: pnpm check:markdown
+
+  tempo-integration:
+    name: Tempo integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: docker compose up -d --wait tempo
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test:integration
+        env:
+          TEMPO_RPC_URL: http://127.0.0.1:18545
 
   mcp-services:
     name: MPP Discovery Service MCP Worker

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ pnpm run check:sdk-drift # Validate SDK reference pages against mppx exports
 pnpm run preview  # Preview production build
 ```
 
+Run the real Tempo charge integration test against the bootstrapped localnet:
+
+```bash
+docker compose up -d --wait tempo
+pnpm test:integration
+docker compose down
+```
+
+Set `TEMPO_LOCALNET_IMAGE` to pin a release tag or image digest. Set
+`TEMPO_RPC_URL` to run the same test against an existing localnet.
+
 ### Publish a blog post
 
 1. Copy [`templates/blog-post.mdx`](templates/blog-post.mdx) to `src/pages/blog/<slug>.mdx`.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,7 @@
+services:
+  tempo:
+    image: ${TEMPO_LOCALNET_IMAGE:-ghcr.io/tempoxyz/tempo-localnet@sha256:86f199f161be85d3610d990e5bc2653ece29de3ee9c91e8c8e768cf2b8c05c3b}
+    command: ["--block-time", "1ms"]
+    ports:
+      - "127.0.0.1:18545:8545"
+    stop_grace_period: 10s

--- a/integration/tempo-charge.test.ts
+++ b/integration/tempo-charge.test.ts
@@ -1,0 +1,108 @@
+import { Receipt } from "mppx";
+import { Mppx as ClientMppx, tempo as clientTempo } from "mppx/client";
+import { Mppx as ServerMppx, tempo as serverTempo } from "mppx/server";
+import {
+  type Address,
+  createClient,
+  defineChain,
+  type Hash,
+  http,
+  parseUnits,
+} from "viem";
+import { mnemonicToAccount } from "viem/accounts";
+import { readContract, waitForTransactionReceipt } from "viem/actions";
+import { beforeAll, describe, expect, test } from "vitest";
+
+const rpcUrl = process.env.TEMPO_RPC_URL ?? "http://127.0.0.1:18545";
+const pathUsd = "0x20c0000000000000000000000000000000000000";
+const mnemonic = "test test test test test test test test test test test junk";
+const payer = mnemonicToAccount(mnemonic, { accountIndex: 1 });
+const recipient = mnemonicToAccount(mnemonic, { accountIndex: 2 });
+
+const chain = defineChain({
+  id: 1337,
+  name: "Tempo Localnet",
+  nativeCurrency: { decimals: 18, name: "USD", symbol: "USD" },
+  rpcUrls: { default: { http: [rpcUrl] } },
+});
+const transport = http(rpcUrl, { retryCount: 0, timeout: 30_000 });
+const payerClient = createClient({ account: payer, chain, transport });
+const publicClient = createClient({ chain, transport });
+
+const balanceOfAbi = [
+  {
+    inputs: [{ name: "account", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+beforeAll(async () => {
+  const hashes = (await publicClient.request({
+    method: "tempo_fundAddress",
+    params: [payer.address],
+  } as never)) as Hash[];
+
+  for (const hash of hashes) {
+    await waitForTransactionReceipt(publicClient, { hash, timeout: 30_000 });
+  }
+});
+
+describe("Tempo charge integration", () => {
+  test("settles a paid request and returns an MPP Receipt", async () => {
+    const amount = parseUnits("0.01", 6);
+    const recipientBefore = await balanceOf(recipient.address);
+    const payment = ServerMppx.create({
+      methods: [
+        serverTempo.charge({
+          chainId: chain.id,
+          currency: pathUsd,
+          getClient: () => publicClient,
+          recipient: recipient.address,
+        }),
+      ],
+      realm: "local.mpp.dev",
+      secretKey: "local-integration-secret-key-32-bytes",
+    });
+    const paid = payment.charge({ amount: "0.01" });
+
+    const appFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const result = await paid(new Request(input, init));
+      if (result.status === 402) return result.challenge;
+      return result.withReceipt(Response.json({ paid: true }));
+    };
+    const client = ClientMppx.create({
+      fetch: appFetch,
+      methods: [
+        clientTempo.charge({
+          account: payer,
+          expectedChainId: chain.id,
+          getClient: () => payerClient,
+          mode: "push",
+        }),
+      ],
+      polyfill: false,
+    });
+
+    const response = await client.fetch("https://local.mpp.dev/paid");
+
+    expect(response.status).toBe(200);
+    expect(await response.clone().json()).toEqual({ paid: true });
+    expect(Receipt.fromResponse(response)).toMatchObject({
+      method: "tempo",
+      status: "success",
+    });
+    expect(await balanceOf(recipient.address)).toBe(recipientBefore + amount);
+  });
+});
+
+function balanceOf(address: Address) {
+  return readContract(publicClient, {
+    abi: balanceOfAbi,
+    address: pathUsd,
+    args: [address],
+    functionName: "balanceOf",
+  });
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "sync:vocs": "node scripts/copy-vocs-theme.ts && pnpm check",
     "test": "vitest run",
     "test:e2e": "VITE_SKIP_ANIMATION=true VITE_DEMO_LIVE=false vitest run --config vitest.config.e2e.ts",
+    "test:integration": "tsc -p tsconfig.integration.json && vitest run --config vitest.config.integration.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/src/pages/_api/api/payment-link/photo-stripe.ts
+++ b/src/pages/_api/api/payment-link/photo-stripe.ts
@@ -4,6 +4,7 @@ export async function GET(request: Request) {
   const result = await stripeMppx.charge({
     amount: "1",
     currency: "usd",
+    decimals: 2,
     description: "A random unique image",
   })(request);
 

--- a/tsconfig.integration.json
+++ b/tsconfig.integration.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["integration", "vitest.config.integration.ts"],
+  "exclude": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -325,7 +325,12 @@ export default defineConfig(({ mode }) => {
       external: ["typescript"],
     },
     test: {
-      exclude: [...configDefaults.exclude, "e2e/**", "workers/**"],
+      exclude: [
+        ...configDefaults.exclude,
+        "e2e/**",
+        "integration/**",
+        "workers/**",
+      ],
     },
   };
 });

--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    fileParallelism: false,
+    hookTimeout: 150_000,
+    include: ["integration/**/*.test.ts"],
+    testTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
## Motivation

The documentation site needs one real-chain check that its documented MPP charge flow works against deterministic Tempo state.

## Summary

- add a digest-pinned Tempo localnet service for local and CI integration tests
- exercise the complete charge flow through settlement and Receipt validation
- keep integration coverage isolated from the fast default test suite

## Key design considerations

- keep browser E2E tests mocked and run the on-chain flow in a dedicated job
- allow local image and RPC overrides while pinning CI to a reproducible image