### PR TITLE
docs: refocus x402 guide on existing services

### DIFF
--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -25,12 +25,6 @@ Both protocols use HTTP `402` to gate API access behind payment. x402 exact char
 | **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
 | **Idempotency** | No | Built-in Challenge binding |
 
-MPP uses three protocol objects throughout a payment flow:
-
-- **Challenge**—the server's `402` response describing the required payment
-- **Credential**—the client's signed payment authorization
-- **Receipt**—the server's confirmation that the payment settled
-
 ## Server
 
 Choose the server setup that matches the protocols your endpoint needs to expose:

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -134,6 +134,10 @@ app.get('/api/data', (req, res) => {
 
 The wrapper delegates x402 Credentials, lifecycle hooks, verification, and settlement to the official x402 adapter. For a compatible `exact` requirement, it also returns an MPP Challenge and settles MPP Credentials through the same x402 resource server.
 
+:::note
+The x402 compatibility wrapper converts atomic payment requirements to display units automatically, so keep your existing x402 route configuration unchanged. When configuring `mppx.evm.charge` directly, convert atomic amounts first—for six-decimal USDC, `10000` becomes `0.01`.
+:::
+
 ### Run x402 inline with `mppx`
 
 For a new service, configure `mppx` directly when one route must serve native MPP and x402 clients.

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -9,21 +9,23 @@ import { OneTimePaymentsCard, PaymentMethodsCard, ServerQuickstartCard } from '.
 
 # Use MPP with x402 [Connect existing x402 services and clients]
 
-MPP and x402 are complementary protocols and x402 clients and servers can easily support MPP with just a few lines of code.
+MPP and x402 are complementary protocols. You can add MPP to an x402 client or server with a few lines of code while preserving x402 support.
 
 ## Protocol comparison
 
-Both protocols use HTTP `402` to gate API access behind payment. x402 exact charges map to MPP's `charge` intent, while MPP adds standard HTTP authentication, more payment methods, and efficient payment methods like Sessions.
+Both protocols use HTTP `402` to gate API access behind payment. MPP uses HTTP authentication and separates payment intents from payment methods. x402 registers on-chain payment schemes and optional extensions. An x402 exact charge maps to MPP's `charge` intent.
 
 | | x402 | MPP |
 |---|---|---|
 | **Challenge** | `PAYMENT-REQUIRED` header | `WWW-Authenticate: Payment` header |
 | **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` header |
 | **Receipt** | `PAYMENT-RESPONSE` header | `Payment-Receipt` header |
-| **Payment methods** | Stablecoins | Stablecoins, cards, digital wallets, and other methods |
-| **Sessions** | No | Yes—off-chain vouchers for sub-cent streaming |
+| **Payment rails** | Registered blockchain network mechanisms | Stablecoins, cards, Lightning, and custom methods |
+| **Usage-based billing** | `upto` and EVM `batch-settlement` schemes | Payment-method intents, including `session` |
 | **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
-| **Idempotency** | No | Built-in Challenge binding |
+| **Idempotency** | Optional Payment Identifier extension | Challenge identity plus standard `Idempotency-Key` guidance |
+
+See [MPP vs x402](/mpp-vs-x402) for a full comparison.
 
 ## Server
 

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -13,17 +13,19 @@ MPP and x402 are complementary protocols. You can add MPP to an x402 client or s
 
 ## Protocol comparison
 
-Both protocols use HTTP `402` to gate API access behind payment. MPP uses HTTP authentication and separates payment intents from payment methods. x402 registers on-chain payment schemes and optional extensions. An x402 exact charge maps to MPP's `charge` intent.
+Both protocols use HTTP `402` to gate API access behind payment. MPP uses HTTP authentication and separates payment intents from payment methods. x402 registers on-chain payment schemes and optional extensions.
 
 | | x402 | MPP |
 |---|---|---|
 | **Challenge** | `PAYMENT-REQUIRED` header | `WWW-Authenticate: Payment` header |
 | **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` header |
 | **Receipt** | `PAYMENT-RESPONSE` header | `Payment-Receipt` header |
+| **Flow used here** | x402 v2 EIP-3009 `exact` | EVM `charge` |
 | **Payment rails** | Registered blockchain network mechanisms | Stablecoins, cards, Lightning, and custom methods |
-| **Usage-based billing** | `upto` and EVM `batch-settlement` schemes | Payment-method intents, including `session` |
 | **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
 | **Idempotency** | Optional Payment Identifier extension | Challenge identity plus standard `Idempotency-Key` guidance |
+
+The `mppx` compatibility adapter maps extension-free x402 v2 EIP-3009 `exact` requirements to MPP `charge` Challenges. Other x402 schemes, including `upto` and `batch-settlement`, continue through the official x402 middleware but don't produce an equivalent MPP Challenge.
 
 See [MPP vs x402](/mpp-vs-x402) for a full comparison.
 
@@ -31,12 +33,12 @@ See [MPP vs x402](/mpp-vs-x402) for a full comparison.
 
 Choose the server setup that matches the protocols your endpoint needs to expose:
 
-1. **Add `mppx` to an x402 server**—start with your existing x402 route and move its payment configuration into `mppx`.
+1. **Add MPP to an x402 server**—keep your existing x402 route table and resource server, then wrap them with `mppx`.
 2. **Start with `mppx`**—create a new route that serves native MPP and x402 clients.
 
-### Add `mppx` to an x402 server
+### Add MPP to an x402 server
 
-Install `mppx`, then move your existing asset, facilitator, price, and recipient into the equivalent `mppx` configuration.
+Install `mppx`. Keep your existing x402 SDK packages and configuration.
 
 :::code-group
 
@@ -57,7 +59,7 @@ $ bun add mppx viem
 Start with your existing x402 SDK route:
 
 ```ts [server.ts]
-import { HTTPFacilitatorClient } from '@x402/core/server'
+import { HTTPFacilitatorClient, type RoutesConfig } from '@x402/core/server'
 import { ExactEvmScheme } from '@x402/evm/exact/server'
 import { paymentMiddleware, x402ResourceServer } from '@x402/express'
 import express from 'express'
@@ -66,69 +68,75 @@ const app = express()
 const facilitator = new HTTPFacilitatorClient({
   url: 'https://x402.org/facilitator',
 })
-
-app.use(
-  paymentMiddleware(
-    {
-      'GET /api/data': {
-        accepts: [
-          {
-            network: 'eip155:84532',
-            payTo: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-            price: '$0.01',
-            scheme: 'exact',
-          },
-        ],
-        description: 'Premium data access',
-        mimeType: 'application/json',
-      },
-    },
-    new x402ResourceServer(facilitator).register(
-      'eip155:84532',
-      new ExactEvmScheme(),
-    ),
-  ),
+const resourceServer = new x402ResourceServer(facilitator).register(
+  'eip155:84532',
+  new ExactEvmScheme(),
 )
+const routes = {
+  'GET /api/data': {
+    accepts: [
+      {
+        network: 'eip155:84532',
+        payTo: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+        price: '$0.01',
+        scheme: 'exact',
+      },
+    ],
+    description: 'Premium data access',
+    mimeType: 'application/json',
+  },
+} satisfies RoutesConfig
+
+app.use(paymentMiddleware(routes, resourceServer))
 
 app.get('/api/data', (req, res) => {
   res.json({ data: 'premium content' })
 })
 ```
 
-Move the payment configuration into `mppx` and keep the route handler unchanged:
+Replace the x402 middleware import with the MPP compatibility wrapper. Keep the route table, resource server, facilitator, and handler unchanged:
 
 ```ts [server.ts]
-import { Mppx, evm } from 'mppx/express'
+import { HTTPFacilitatorClient, type RoutesConfig } from '@x402/core/server'
+import { ExactEvmScheme } from '@x402/evm/exact/server'
+import { x402ResourceServer } from '@x402/express'
 import express from 'express'
+import { mpp } from 'mppx/x402/express'
 
 const app = express()
-
-const mppx = Mppx.create({
-  methods: [
-    evm.charge({
-      currency: evm.assets.baseSepolia.USDC,
-      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-      x402: {
-        facilitator: 'https://x402.org/facilitator',
-      },
-    }),
-  ],
-  secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
+const facilitator = new HTTPFacilitatorClient({
+  url: 'https://x402.org/facilitator',
 })
-
-app.get(
-  '/api/data',
-  mppx.evm.charge({
-    amount: '0.01',
-    description: 'Premium data access',
-  }),
-  (req, res) => {
-    res.json({ data: 'premium content' })
-  },
+const resourceServer = new x402ResourceServer(facilitator).register(
+  'eip155:84532',
+  new ExactEvmScheme(),
 )
+const routes = {
+  'GET /api/data': {
+    accepts: [
+      {
+        network: 'eip155:84532',
+        payTo: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+        price: '$0.01',
+        scheme: 'exact',
+      },
+    ],
+    description: 'Premium data access',
+    mimeType: 'application/json',
+  },
+} satisfies RoutesConfig
+
+const secretKey = process.env.MPP_SECRET_KEY
+if (!secretKey) throw new Error('Set MPP_SECRET_KEY to at least 32 random bytes.')
+
+app.use(mpp(routes, resourceServer, { secretKey }))
+
+app.get('/api/data', (req, res) => {
+  res.json({ data: 'premium content' })
+})
 ```
 
-`mppx` replaces the x402 payment middleware, but the route still accepts standard x402 v2 exact clients. It also returns native MPP Challenges and accepts native MPP Credentials.
+The wrapper delegates x402 Credentials, lifecycle hooks, verification, and settlement to the official x402 adapter. For a compatible `exact` requirement, it also returns an MPP Challenge and settles MPP Credentials through the same x402 resource server.
 
 ### Run x402 inline with `mppx`
 
@@ -175,6 +183,19 @@ The handler stays unchanged. `mppx`:
 This flow also supports body-bearing and route-scoped endpoints. Standard x402 clients don't need the optional `mppx` route-binding extension.
 
 ### Advanced server options
+
+#### Use another x402 adapter
+
+The compatibility wrappers cover the official x402 adapters for each supported environment:
+
+| Environment | Import |
+|---|---|
+| Express | `mppx/x402/express` |
+| Hono | `mppx/x402/hono` |
+| MCP | `mppx/x402/mcp` |
+| Next.js | `mppx/x402/next` |
+
+Each wrapper keeps the official adapter's route or tool configuration, hooks, verification, and settlement.
 
 #### Add another payment method
 
@@ -233,7 +254,7 @@ const method = evm.charge({
 
 The default compares the echoed resource URL and payment requirements, and verifies any body digest against the request. Required binding also cryptographically binds MPP scope, opaque values, and metadata, but excludes standard clients that don't implement the extension.
 
-#### Use Hono middleware
+#### Use native Hono middleware
 
 Import the Hono adapter to apply the same inline flow as route middleware.
 

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -13,7 +13,7 @@ MPP and x402 are complementary protocols. You can add MPP to an x402 client or s
 
 ## Protocol comparison
 
-Both protocols use HTTP `402` to gate API access behind payment. MPP uses HTTP authentication and separates payment intents from payment methods. x402 registers on-chain payment schemes and optional extensions.
+See [MPP vs x402](/mpp-vs-x402) for a full comparison.
 
 | | x402 | MPP |
 |---|---|---|
@@ -24,10 +24,6 @@ Both protocols use HTTP `402` to gate API access behind payment. MPP uses HTTP a
 | **Payment rails** | Registered blockchain network mechanisms | Stablecoins, cards, Lightning, and custom methods |
 | **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
 | **Idempotency** | Optional Payment Identifier extension | Challenge identity plus standard `Idempotency-Key` guidance |
-
-The `mppx` compatibility adapter maps extension-free x402 v2 EIP-3009 `exact` requirements to MPP `charge` Challenges. Other x402 schemes, including `upto` and `batch-settlement`, continue through the official x402 middleware but don't produce an equivalent MPP Challenge.
-
-See [MPP vs x402](/mpp-vs-x402) for a full comparison.
 
 ## Server
 
@@ -101,7 +97,7 @@ import { HTTPFacilitatorClient, type RoutesConfig } from '@x402/core/server'
 import { ExactEvmScheme } from '@x402/evm/exact/server'
 import { x402ResourceServer } from '@x402/express'
 import express from 'express'
-import { mpp } from 'mppx/x402/express'
+import { mpp } from 'mppx/x402/express' // [!code hl]
 
 const app = express()
 const facilitator = new HTTPFacilitatorClient({
@@ -129,7 +125,7 @@ const routes = {
 const secretKey = process.env.MPP_SECRET_KEY
 if (!secretKey) throw new Error('Set MPP_SECRET_KEY to at least 32 random bytes.')
 
-app.use(mpp(routes, resourceServer, { secretKey }))
+app.use(mpp(routes, resourceServer, { secretKey })) // [!code hl]
 
 app.get('/api/data', (req, res) => {
   res.json({ data: 'premium content' })
@@ -153,9 +149,11 @@ const mppx = Mppx.create({
     evm.charge({
       currency: evm.assets.baseSepolia.USDC,
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      // [!code hl:start]
       x402: {
         facilitator: 'https://x402.org/facilitator',
       },
+      // [!code hl:end]
     }),
   ],
   secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
@@ -199,7 +197,7 @@ Each wrapper keeps the official adapter's route or tool configuration, hooks, ve
 
 #### Add another payment method
 
-Register another method beside `evm.charge`, then use the intent shorthand to advertise every compatible charge method. This example adds pathUSD payments on Tempo while preserving x402 support on Base Sepolia.
+Register another method beside `evm.charge`, then use `mppx.charge()` to advertise every compatible charge method. This example adds pathUSD payments on Tempo while preserving x402 support on Base Sepolia.
 
 ```ts [server.ts]
 import { Mppx, evm, tempo } from 'mppx/express'
@@ -245,10 +243,12 @@ import { evm } from 'mppx/server'
 const method = evm.charge({
   currency: evm.assets.baseSepolia.USDC,
   recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  // [!code hl:start]
   x402: {
     facilitator: 'https://x402.org/facilitator',
     routeBinding: 'required',
   },
+  // [!code hl:end]
 })
 ```
 
@@ -324,7 +324,7 @@ const account = privateKeyToAccount(
   '0x0123456789012345678901234567890123456789012345678901234567890123',
 )
 
-const fetch = Fetch.from({
+const fetch = Fetch.from({ // [!code hl]
   acceptPaymentPolicy: {
     origins: ['https://api.example.com'],
   },
@@ -345,9 +345,7 @@ console.log(response.status)
 
 The same client now reads native MPP and x402 Challenges, then retries with the matching Credential header. It validates the resource, EIP-3009 token metadata, network, currency, and amount before signing an x402 offer.
 
-### Advanced client options
-
-#### Control the x402 retry
+### Control the x402 retry
 
 Use `Mppx.create` when you need to inspect a selected x402 Challenge before signing. `preparePayment` selects the offer, and `setCredential` attaches the Credential as `PAYMENT-SIGNATURE`.
 

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -7,13 +7,13 @@ import { SigningAccountTabs } from '../../components/SigningAccountTabs'
 import { Cards } from 'vocs'
 import { OneTimePaymentsCard, PaymentMethodsCard, ServerQuickstartCard } from '../../components/cards'
 
-# Use MPP with x402 [Connect existing services and clients]
+# Use MPP with x402 [Connect existing x402 services and clients]
 
-Keep your existing x402 server when you only need `mppx` clients to pay it. Use `mppx` on the server when the same endpoint must speak both native MPP and x402.
+MPP and x402 are complementary protocols and x402 clients and servers can easily support MPP with just a few lines of code.
 
-## Compare MPP and x402
+## Protocol comparison
 
-Both protocols use HTTP `402` to gate API access behind payment. x402 exact charges map to MPP's `charge` intent, while MPP adds standard HTTP authentication, more payment methods, and Sessions.
+Both protocols use HTTP `402` to gate API access behind payment. x402 exact charges map to MPP's `charge` intent, while MPP adds standard HTTP authentication, more payment methods, and efficient payment methods like Sessions.
 
 | | x402 | MPP |
 |---|---|---|
@@ -35,12 +35,30 @@ MPP uses three protocol objects throughout a payment flow:
 
 Choose the server setup that matches the protocols your endpoint needs to expose:
 
-1. **Keep the x402 SDK**—recommended for an existing x402 service that only needs to accept `mppx` clients.
-2. **Use `mppx`**—serve native MPP and x402 clients from the same route.
+1. **Add `mppx` to an x402 server**—start with your existing x402 route and move its payment configuration into `mppx`.
+2. **Start with `mppx`**—create a new route that serves native MPP and x402 clients.
 
-### Keep your existing x402 service
+### Add `mppx` to an x402 server
 
-The `mppx` client supports standard x402 v2 exact Challenges, including those from the official [x402 SDK](https://docs.x402.org/getting-started/quickstart-for-sellers). You don't need to change an existing x402 server for `mppx` clients to pay it.
+Install `mppx`, then move your existing asset, facilitator, price, and recipient into the equivalent `mppx` configuration.
+
+:::code-group
+
+```bash [npm]
+$ npm install mppx viem
+```
+
+```bash [pnpm]
+$ pnpm add mppx viem
+```
+
+```bash [bun]
+$ bun add mppx viem
+```
+
+:::
+
+Start with your existing x402 SDK route:
 
 ```ts [server.ts]
 import { HTTPFacilitatorClient } from '@x402/core/server'
@@ -81,31 +99,44 @@ app.get('/api/data', (req, res) => {
 })
 ```
 
-This option keeps the x402 wire format: `PAYMENT-REQUIRED`, `PAYMENT-SIGNATURE`, and `PAYMENT-RESPONSE`. The [client setup](#build-a-client-for-mpp-and-x402) detects those headers and pays the route.
+Move the payment configuration into `mppx` and keep the route handler unchanged:
 
-:::info
-Use the next option when the server must also return `WWW-Authenticate: Payment`, accept `Authorization: Payment`, or offer MPP-only methods such as Sessions.
-:::
+```ts [server.ts]
+import { Mppx, evm } from 'mppx/express'
+import express from 'express'
+
+const app = express()
+
+const mppx = Mppx.create({
+  methods: [
+    evm.charge({
+      currency: evm.assets.baseSepolia.USDC,
+      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      x402: {
+        facilitator: 'https://x402.org/facilitator',
+      },
+    }),
+  ],
+  secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
+})
+
+app.get(
+  '/api/data',
+  mppx.evm.charge({
+    amount: '0.01',
+    description: 'Premium data access',
+  }),
+  (req, res) => {
+    res.json({ data: 'premium content' })
+  },
+)
+```
+
+`mppx` replaces the x402 payment middleware, but the route still accepts standard x402 v2 exact clients. It also returns native MPP Challenges and accepts native MPP Credentials.
 
 ### Run x402 inline with `mppx`
 
-Replace the payment middleware with `mppx` when one route must serve native MPP and x402 clients. Keep the same EVM asset, facilitator, pricing, recipient, and application logic.
-
-:::code-group
-
-```bash [npm]
-$ npm install mppx viem
-```
-
-```bash [pnpm]
-$ pnpm add mppx viem
-```
-
-```bash [bun]
-$ bun add mppx viem
-```
-
-:::
+For a new service, configure `mppx` directly when one route must serve native MPP and x402 clients.
 
 ```ts [server.ts]
 import { Mppx, evm } from 'mppx/express'
@@ -244,7 +275,29 @@ Use one `mppx` client for native MPP endpoints and standard or route-bound x402 
 
 <SigningAccountTabs />
 
-Register `evm.charge` for x402 exact Challenges. Add other MPP methods when the client also calls endpoints that offer them. `Fetch.from` reads either Challenge format and retries with the matching Credential header.
+Start with an existing x402 fetch client:
+
+```ts [client.ts]
+import { x402Client } from '@x402/core/client'
+import { ExactEvmScheme } from '@x402/evm/exact/client'
+import { wrapFetchWithPayment } from '@x402/fetch'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount(
+  '0x0123456789012345678901234567890123456789012345678901234567890123',
+)
+
+const client = new x402Client()
+client.register('eip155:*', new ExactEvmScheme(account))
+
+const fetchWithPayment = wrapFetchWithPayment(fetch, client)
+const response = await fetchWithPayment('https://api.example.com/paid')
+
+console.log(response.status)
+// @log: 200
+```
+
+Replace the x402 wrapper with `Fetch.from`, register the same EVM account and asset policy, then add the MPP methods you want to support:
 
 ```ts twoslash [client.ts]
 import { Fetch, evm, tempo } from 'mppx/client'
@@ -273,7 +326,7 @@ console.log(response.status)
 // @log: 200
 ```
 
-The client validates the resource, EIP-3009 token metadata, network, currency, and amount before signing an x402 offer. It skips unsupported offers and fails without signing when none match your policy.
+The same client now reads native MPP and x402 Challenges, then retries with the matching Credential header. It validates the resource, EIP-3009 token metadata, network, currency, and amount before signing an x402 offer.
 
 ### Advanced client options
 

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -1,21 +1,75 @@
 ---
-description: "Add MPP to an existing x402 service without breaking current clients, routes, or pricing."
-imageDescription: "Add MPP without breaking your x402 service"
+description: "Keep your x402 server or use mppx to serve native MPP and x402 clients from the same endpoint."
+imageDescription: "Add MPP support to your x402 service"
 ---
 
 import { SigningAccountTabs } from '../../components/SigningAccountTabs'
 import { Cards } from 'vocs'
 import { OneTimePaymentsCard, PaymentMethodsCard, ServerQuickstartCard } from '../../components/cards'
 
-# Add MPP to an x402 service [Keep your existing x402 clients working]
+# Use MPP with x402 [Connect existing services and clients]
 
-Move an existing x402 exact charge into `mppx` to serve MPP and x402 clients from the same route. You can keep the same EVM asset, facilitator, pricing, and application logic.
+Keep your existing x402 server when you only need `mppx` clients to pay it. Use `mppx` on the server when the same endpoint must speak both native MPP and x402.
 
-## Run x402 inline with `mppx`
+## Server
 
-::::steps
+Choose the server setup that matches the protocols your endpoint needs to expose:
 
-### Install `mppx`
+1. **Keep the x402 SDK**—recommended for an existing x402 service that only needs to accept `mppx` clients.
+2. **Use `mppx`**—serve native MPP and x402 clients from the same route.
+
+### Keep your existing x402 service
+
+The `mppx` client supports standard x402 v2 exact Challenges, including those from the official [x402 SDK](https://docs.x402.org/getting-started/quickstart-for-sellers). You don't need to change an existing x402 server for `mppx` clients to pay it.
+
+```ts [server.ts]
+import { HTTPFacilitatorClient } from '@x402/core/server'
+import { ExactEvmScheme } from '@x402/evm/exact/server'
+import { paymentMiddleware, x402ResourceServer } from '@x402/express'
+import express from 'express'
+
+const app = express()
+const facilitator = new HTTPFacilitatorClient({
+  url: 'https://x402.org/facilitator',
+})
+
+app.use(
+  paymentMiddleware(
+    {
+      'GET /api/data': {
+        accepts: [
+          {
+            network: 'eip155:84532',
+            payTo: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            price: '$0.01',
+            scheme: 'exact',
+          },
+        ],
+        description: 'Premium data access',
+        mimeType: 'application/json',
+      },
+    },
+    new x402ResourceServer(facilitator).register(
+      'eip155:84532',
+      new ExactEvmScheme(),
+    ),
+  ),
+)
+
+app.get('/api/data', (req, res) => {
+  res.json({ data: 'premium content' })
+})
+```
+
+This option keeps the x402 wire format: `PAYMENT-REQUIRED`, `PAYMENT-SIGNATURE`, and `PAYMENT-RESPONSE`. The [client setup](#build-a-client-for-mpp-and-x402) detects those headers and pays the route.
+
+:::info
+Use the next option when the server must also return `WWW-Authenticate: Payment`, accept `Authorization: Payment`, or offer MPP-only methods such as Sessions.
+:::
+
+### Run x402 inline with `mppx`
+
+Replace the payment middleware with `mppx` when one route must serve native MPP and x402 clients. Keep the same EVM asset, facilitator, pricing, recipient, and application logic.
 
 :::code-group
 
@@ -33,19 +87,14 @@ $ bun add mppx viem
 
 :::
 
-### Move the x402 charge into `mppx`
-
-Replace your x402 payment middleware with `evm.charge`. Configure the same asset, facilitator, recipient, and route price that your service already uses.
-
 ```ts [server.ts]
-import express from 'express'
 import { Mppx, evm } from 'mppx/express'
+import express from 'express'
 
 const app = express()
 
 const mppx = Mppx.create({
   methods: [
-    // [!code hl:start]
     evm.charge({
       currency: evm.assets.baseSepolia.USDC,
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -53,82 +102,40 @@ const mppx = Mppx.create({
         facilitator: 'https://x402.org/facilitator',
       },
     }),
-    // [!code hl:end]
   ],
   secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
 })
 
 app.get(
   '/api/data',
-  // [!code hl:start]
   mppx.evm.charge({
     amount: '0.01',
     description: 'Premium data access',
   }),
-  // [!code hl:end]
   (req, res) => {
     res.json({ data: 'premium content' })
   },
 )
 ```
 
-The handler stays unchanged. `mppx` now:
+The handler stays unchanged. `mppx`:
 
-- Returns both MPP and x402 Challenges on `402` responses
-- Accepts MPP `Authorization` and x402 `PAYMENT-SIGNATURE` Credentials
-- Calls your facilitator to verify and settle x402 payments
+- Returns MPP and x402 Challenges on `402` responses
+- Accepts MPP and x402 Credentials
+- Calls the configured facilitator to verify and settle x402 payments
 - Returns the Receipt header that matches the client's protocol
 
 This flow also supports body-bearing and route-scoped endpoints. Standard x402 clients don't need the optional `mppx` route-binding extension.
 
-### Test the route
+### Advanced server options
 
-Use the `mppx` CLI to call the service with a funded account:
-
-```bash [test.sh]
-$ npx mppx account create
-$ npx mppx http://localhost:3000/api/data
-```
-
-::::
-
-## What you gain
-
-- **Existing client compatibility.** Keep serving standard x402 exact clients while adding native MPP clients.
-- **Standard HTTP authentication.** Add `WWW-Authenticate`, `Authorization`, and `Payment-Receipt` alongside x402 headers.
-- **More payment methods.** Add stablecoins, cards, Lightning, and other methods to the same endpoint.
-- **Sessions.** Meter repeated or streaming requests with off-chain vouchers instead of one transaction per request.
-- **Production primitives.** Use built-in idempotency, expiration, request binding, Receipts, and RFC 9457 errors.
-
-## Advanced options
-
-### Compare MPP and x402
-
-Both protocols use HTTP `402` to gate API access behind payment. x402 exact charges map to MPP's `charge` intent, while MPP adds standard HTTP authentication, more payment methods, and Sessions.
-
-| | x402 | MPP |
-|---|---|---|
-| **Challenge** | `PAYMENT-REQUIRED` header | `WWW-Authenticate: Payment` header |
-| **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` header |
-| **Receipt** | `PAYMENT-RESPONSE` header | `Payment-Receipt` header |
-| **Payment methods** | Stablecoins | Stablecoins, cards, digital wallets, and other methods |
-| **Sessions** | No | Yes—off-chain vouchers for sub-cent streaming |
-| **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
-| **Idempotency** | No | Built-in Challenge binding |
-
-MPP uses three protocol objects throughout a payment flow:
-
-- **Challenge**—the server's `402` response describing the required payment
-- **Credential**—the client's signed payment authorization
-- **Receipt**—the server's confirmation that the payment settled
-
-### Add another payment method
+#### Add another payment method
 
 Register another method beside `evm.charge`, then use the intent shorthand to advertise every compatible charge method. This example adds pathUSD payments on Tempo while preserving x402 support on Base Sepolia.
 
 ```ts [server.ts]
-import express from 'express'
 import { Mppx, evm, tempo } from 'mppx/express'
+import express from 'express'
 
 const app = express()
 
@@ -141,12 +148,10 @@ const mppx = Mppx.create({
         facilitator: 'https://x402.org/facilitator',
       },
     }),
-    // [!code hl:start]
     tempo.charge({
       currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     }),
-    // [!code hl:end]
   ],
   secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
 })
@@ -160,9 +165,9 @@ app.get(
 )
 ```
 
-The route advertises both methods and verifies the Credential the client selects. See [Payment methods](/payment-methods) to add cards, Lightning, or another payment rail.
+See [Payment methods](/payment-methods) to add cards, Lightning, or another payment rail.
 
-### Require route-bound x402 Credentials
+#### Require route-bound x402 Credentials
 
 Keep the default `routeBinding: 'resource'` for compatibility with standard x402 clients. Set `routeBinding: 'required'` when every x402 Credential for a scoped route must include the `mppx` extension and a route-bound nonce.
 
@@ -181,7 +186,7 @@ const method = evm.charge({
 
 The default compares the echoed resource URL and payment requirements, and verifies any body digest against the request. Required binding also cryptographically binds MPP scope, opaque values, and metadata, but excludes standard clients that don't implement the extension.
 
-### Use Hono middleware
+#### Use Hono middleware
 
 Import the Hono adapter to apply the same inline flow as route middleware.
 
@@ -211,11 +216,15 @@ app.get(
 )
 ```
 
+## Client
+
+Use one `mppx` client for native MPP endpoints and standard or route-bound x402 exact endpoints.
+
 ### Build a client for MPP and x402
 
 <SigningAccountTabs />
 
-Register `evm.charge` to pay standard and route-bound x402 exact Challenges. Add other MPP methods when the client also calls endpoints that offer them. `Fetch.from` reads either Challenge format and retries with the matching Credential header.
+Register `evm.charge` for x402 exact Challenges. Add other MPP methods when the client also calls endpoints that offer them. `Fetch.from` reads either Challenge format and retries with the matching Credential header.
 
 ```ts twoslash [client.ts]
 import { Fetch, evm, tempo } from 'mppx/client'
@@ -246,7 +255,9 @@ console.log(response.status)
 
 The client validates the resource, EIP-3009 token metadata, network, currency, and amount before signing an x402 offer. It skips unsupported offers and fails without signing when none match your policy.
 
-### Control the x402 retry
+### Advanced client options
+
+#### Control the x402 retry
 
 Use `Mppx.create` when you need to inspect a selected x402 Challenge before signing. `preparePayment` selects the offer, and `setCredential` attaches the Credential as `PAYMENT-SIGNATURE`.
 
@@ -290,7 +301,29 @@ console.log(response.status)
 // @log: 200
 ```
 
-### Next steps
+## Advanced concepts
+
+### Compare MPP and x402
+
+Both protocols use HTTP `402` to gate API access behind payment. x402 exact charges map to MPP's `charge` intent, while MPP adds standard HTTP authentication, more payment methods, and Sessions.
+
+| | x402 | MPP |
+|---|---|---|
+| **Challenge** | `PAYMENT-REQUIRED` header | `WWW-Authenticate: Payment` header |
+| **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` header |
+| **Receipt** | `PAYMENT-RESPONSE` header | `Payment-Receipt` header |
+| **Payment methods** | Stablecoins | Stablecoins, cards, digital wallets, and other methods |
+| **Sessions** | No | Yes—off-chain vouchers for sub-cent streaming |
+| **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
+| **Idempotency** | No | Built-in Challenge binding |
+
+MPP uses three protocol objects throughout a payment flow:
+
+- **Challenge**—the server's `402` response describing the required payment
+- **Credential**—the client's signed payment authorization
+- **Receipt**—the server's confirmation that the payment settled
+
+## Next steps
 
 <Cards>
   <OneTimePaymentsCard />

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -1,64 +1,47 @@
 ---
-description: "Use MPP with x402 to support exact stablecoin flows, multi-method payments, sessions, and IETF standardization."
-imageDescription: "Use MPP with existing x402 flows"
+description: "Add MPP to an existing x402 service without breaking current clients, routes, or pricing."
+imageDescription: "Add MPP without breaking your x402 service"
 ---
 
 import { SigningAccountTabs } from '../../components/SigningAccountTabs'
 import { Cards } from 'vocs'
 import { OneTimePaymentsCard, PaymentMethodsCard, ServerQuickstartCard } from '../../components/cards'
-import { PromptBlock } from '../../components/PromptBlock'
 
-# Use MPP with x402 [Run both payment flows together]
+# Add MPP to an x402 service [Keep your existing x402 clients working]
 
-## Choose a signing account
-
-<SigningAccountTabs />
-
-
-MPP runs x402-compatible EVM charges inline with native MPP flows. Both protocols use HTTP `402` to gate API access behind payment, and x402's "exact" charge flow maps directly onto MPP's `charge` intent. Adding MPP gives you standard `WWW-Authenticate` / `Authorization` headers and one interface for stablecoins, cards, Lightning, and payment intents—while the same route can still serve x402 clients. See [MPP vs x402](/mpp-vs-x402) for the full comparison.
-
-## Where MPP differs
-
-MPP and x402 apply the same `402` pattern through different protocol models. MPP uses HTTP authentication and separates payment intents from payment methods. x402 registers on-chain payment schemes and optional extensions.
-
-| | x402 | MPP |
-|---|---|---|
-| **Challenge** | `PAYMENT-REQUIRED` header | `WWW-Authenticate: Payment` header |
-| **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` header |
-| **Receipt** | `PAYMENT-RESPONSE` header | `Payment-Receipt` header |
-| **Payment rails** | Registered blockchain network mechanisms | Stablecoins, cards, Lightning, and custom methods |
-| **Usage-based billing** | `upto` and EVM `batch-settlement` schemes | Payment-method intents, including `session` |
-| **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
-| **Idempotency** | Optional Payment Identifier extension | Challenge identity plus standard `Idempotency-Key` guidance |
-
-:::info
-MPP is compatible with x402. The x402 "exact" charge flow maps directly onto MPP's `charge` intent. MPP adds a payment-method-agnostic HTTP authentication layer while preserving access for existing x402 clients.
-:::
-
-## Key concepts
-
-MPP uses three protocol objects in every payment flow—the same lifecycle x402 uses, with standardized names:
-
-- **Challenge** — The server's `402` response advertising what payment is required. Sent in the `WWW-Authenticate: Payment` header. Equivalent to x402's `PAYMENT-REQUIRED`.
-- **Credential** — The client's signed payment authorization. Sent in the `Authorization: Payment` header. Equivalent to x402's `PAYMENT-SIGNATURE`.
-- **Receipt** — The server's confirmation that payment settled. Sent in the `Payment-Receipt` header. Equivalent to x402's `PAYMENT-RESPONSE`.
+Move an existing x402 exact charge into `mppx` to serve MPP and x402 clients from the same route. You can keep the same EVM asset, facilitator, pricing, and application logic.
 
 ## Run x402 inline with `mppx`
 
-Use `evm.charge` when you want one MPP route to serve native MPP charge Challenges and x402 exact Challenges.
+::::steps
 
-:::info
-When x402 options are enabled, `mppx` emits both `WWW-Authenticate` and `PAYMENT-REQUIRED` Challenges, accepts either `Authorization` or `PAYMENT-SIGNATURE` Credentials, and returns the matching Receipt header.
+### Install `mppx`
+
+:::code-group
+
+```bash [npm]
+$ npm install mppx viem
+```
+
+```bash [pnpm]
+$ pnpm add mppx viem
+```
+
+```bash [bun]
+$ bun add mppx viem
+```
+
 :::
 
-This also applies to body-bearing and route-scoped endpoints such as `POST` routes behind [`Proxy`](/sdk/typescript/proxy). By default, a standard x402 client can pay these routes without the optional `mppx` extension. The server compares the echoed resource URL and payment requirements, and still verifies any body digest against the request.
+### Move the x402 charge into `mppx`
 
-### Run an inline x402 endpoint
+Replace your x402 payment middleware with `evm.charge`. Configure the same asset, facilitator, recipient, and route price that your service already uses.
 
-Configure `evm.charge` with a known x402 asset and a facilitator. The route stays an MPP flow, but also behaves as an x402-compatible server for existing clients.
+```ts [server.ts]
+import express from 'express'
+import { Mppx, evm } from 'mppx/express'
 
-```ts twoslash [server.ts]
-import { evm, Mppx } from 'mppx/server'
+const app = express()
 
 const mppx = Mppx.create({
   methods: [
@@ -75,23 +58,113 @@ const mppx = Mppx.create({
   secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
 })
 
-export async function GET(request: Request) {
+app.get(
+  '/api/data',
   // [!code hl:start]
-  const result = await mppx.evm.charge({
+  mppx.evm.charge({
     amount: '0.01',
     description: 'Premium data access',
-  })(request)
+  }),
   // [!code hl:end]
-
-  if (result.status === 402) return result.challenge
-
-  return result.withReceipt(Response.json({ ok: true }))
-}
+  (req, res) => {
+    res.json({ data: 'premium content' })
+  },
+)
 ```
+
+The handler stays unchanged. `mppx` now:
+
+- Returns both MPP and x402 Challenges on `402` responses
+- Accepts MPP `Authorization` and x402 `PAYMENT-SIGNATURE` Credentials
+- Calls your facilitator to verify and settle x402 payments
+- Returns the Receipt header that matches the client's protocol
+
+This flow also supports body-bearing and route-scoped endpoints. Standard x402 clients don't need the optional `mppx` route-binding extension.
+
+### Test the route
+
+Use the `mppx` CLI to call the service with a funded account:
+
+```bash [test.sh]
+$ npx mppx account create
+$ npx mppx http://localhost:3000/api/data
+```
+
+::::
+
+## What you gain
+
+- **Existing client compatibility.** Keep serving standard x402 exact clients while adding native MPP clients.
+- **Standard HTTP authentication.** Add `WWW-Authenticate`, `Authorization`, and `Payment-Receipt` alongside x402 headers.
+- **More payment methods.** Add stablecoins, cards, Lightning, and other methods to the same endpoint.
+- **Sessions.** Meter repeated or streaming requests with off-chain vouchers instead of one transaction per request.
+- **Production primitives.** Use built-in idempotency, expiration, request binding, Receipts, and RFC 9457 errors.
+
+## Advanced options
+
+### Compare MPP and x402
+
+Both protocols use HTTP `402` to gate API access behind payment. x402 exact charges map to MPP's `charge` intent, while MPP adds standard HTTP authentication, more payment methods, and Sessions.
+
+| | x402 | MPP |
+|---|---|---|
+| **Challenge** | `PAYMENT-REQUIRED` header | `WWW-Authenticate: Payment` header |
+| **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` header |
+| **Receipt** | `PAYMENT-RESPONSE` header | `Payment-Receipt` header |
+| **Payment methods** | Stablecoins | Stablecoins, cards, digital wallets, and other methods |
+| **Sessions** | No | Yes—off-chain vouchers for sub-cent streaming |
+| **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
+| **Idempotency** | No | Built-in Challenge binding |
+
+MPP uses three protocol objects throughout a payment flow:
+
+- **Challenge**—the server's `402` response describing the required payment
+- **Credential**—the client's signed payment authorization
+- **Receipt**—the server's confirmation that the payment settled
+
+### Add another payment method
+
+Register another method beside `evm.charge`, then use the intent shorthand to advertise every compatible charge method. This example adds pathUSD payments on Tempo while preserving x402 support on Base Sepolia.
+
+```ts [server.ts]
+import express from 'express'
+import { Mppx, evm, tempo } from 'mppx/express'
+
+const app = express()
+
+const mppx = Mppx.create({
+  methods: [
+    evm.charge({
+      currency: evm.assets.baseSepolia.USDC,
+      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      x402: {
+        facilitator: 'https://x402.org/facilitator',
+      },
+    }),
+    // [!code hl:start]
+    tempo.charge({
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    }),
+    // [!code hl:end]
+  ],
+  secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
+})
+
+app.get(
+  '/api/data',
+  mppx.charge({ amount: '0.01', description: 'Premium data access' }),
+  (req, res) => {
+    res.json({ data: 'premium content' })
+  },
+)
+```
+
+The route advertises both methods and verifies the Credential the client selects. See [Payment methods](/payment-methods) to add cards, Lightning, or another payment rail.
 
 ### Require route-bound x402 Credentials
 
-Keep the default `routeBinding: 'resource'` for compatibility with standard x402 clients. Set `routeBinding: 'required'` when every x402 Credential for a scoped route must include the `mppx` extension and route-bound nonce.
+Keep the default `routeBinding: 'resource'` for compatibility with standard x402 clients. Set `routeBinding: 'required'` when every x402 Credential for a scoped route must include the `mppx` extension and a route-bound nonce.
 
 ```ts twoslash [server.ts]
 import { evm } from 'mppx/server'
@@ -106,62 +179,20 @@ const method = evm.charge({
 })
 ```
 
-`resource` and the accepted payment requirements aren't part of the EIP-3009 signature. The default prevents accidental cross-route reuse, but it doesn't cryptographically bind scope, opaque values, or metadata for clients without the extension. Required binding only accepts extension-aware clients on scoped routes, including the `mppx` client.
-
-### Compose x402 with another MPP method
-
-Use `mppx.compose` when one endpoint should support inline x402 EVM charges and another MPP method. The same route verifies either wire format.
-
-```ts twoslash [server.ts]
-import { evm, Mppx, tempo } from 'mppx/server'
-
-const mppx = Mppx.create({
-  methods: [
-    // [!code hl:start]
-    evm.charge({
-      currency: evm.assets.baseSepolia.USDC,
-      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-      x402: {
-        facilitator: 'https://x402.org/facilitator',
-      },
-    }),
-    // [!code hl:end]
-    tempo.charge({
-      currency: '0x20c0000000000000000000000000000000000000',
-      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-      testnet: true,
-    }),
-  ],
-  secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
-})
-
-// [!code hl:start]
-const paid = mppx.compose(
-  [mppx.evm.charge, { amount: '0.01', description: 'Premium data access' }],
-  [mppx.tempo.charge, { amount: '0.01', description: 'Premium data access' }],
-)
-// [!code hl:end]
-
-export async function GET(request: Request) {
-  const result = await paid(request)
-
-  if (result.status === 402) return result.challenge
-
-  return result.withReceipt(Response.json({ ok: true }))
-}
-```
+The default compares the echoed resource URL and payment requirements, and verifies any body digest against the request. Required binding also cryptographically binds MPP scope, opaque values, and metadata, but excludes standard clients that don't implement the extension.
 
 ### Use Hono middleware
 
+Import the Hono adapter to apply the same inline flow as route middleware.
+
 ```ts twoslash [server.ts]
 import { Hono } from 'hono'
-import { evm, Mppx } from 'mppx/hono'
+import { Mppx, evm } from 'mppx/hono'
 
 const app = new Hono()
 
 const mppx = Mppx.create({
   methods: [
-    // [!code hl:start]
     evm.charge({
       currency: evm.assets.baseSepolia.USDC,
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
@@ -169,50 +200,22 @@ const mppx = Mppx.create({
         facilitator: 'https://x402.org/facilitator',
       },
     }),
-    // [!code hl:end]
   ],
   secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
 })
 
-// [!code hl:start]
-app.get('/paid', mppx.evm.charge({ amount: '0.01' }), (c) =>
-  c.json({ ok: true }),
+app.get(
+  '/api/data',
+  mppx.evm.charge({ amount: '0.01', description: 'Premium data access' }),
+  (c) => c.json({ data: 'premium content' }),
 )
-// [!code hl:end]
 ```
-
-### Call with the mppx client
-
-`evm.charge` on the client signs native MPP EVM charge Challenges, route-bound x402 exact Challenges from `mppx` servers, and standard x402 v2 EIP-3009 Challenges, including Challenges from official Coinbase x402 resource servers. Standard providers don't need to include the optional `mppx` route-binding extension.
-
-```ts twoslash [client.ts]
-import { Fetch, evm } from 'mppx/client'
-import { privateKeyToAccount } from 'viem/accounts'
-
-const fetch = Fetch.from({
-  methods: [
-    // [!code hl:start]
-    evm.charge({
-      account: privateKeyToAccount(
-        '0x0123456789012345678901234567890123456789012345678901234567890123',
-      ),
-      currencies: [evm.assets.baseSepolia.USDC],
-      maxAmount: '1.00',
-    }),
-    // [!code hl:end]
-  ],
-})
-
-const response = await fetch('https://api.example.com/paid')
-console.log(response.status)
-// @log: 200
-```
-
-For x402, `mppx` requires resource information and EIP-3009 token name and version metadata. It applies your network, currency, and amount policies before signing. Unsupported or rejected offers are skipped so a later compatible offer can be selected; if none remain, the request fails without signing or retrying.
 
 ### Build a client for MPP and x402
 
-Register `evm.charge` for standard and route-bound x402 exact Challenges, plus the MPP methods you want to support. The HTTP client reads both `WWW-Authenticate` and `PAYMENT-REQUIRED`, then retries with either `Authorization` or `PAYMENT-SIGNATURE`.
+<SigningAccountTabs />
+
+Register `evm.charge` to pay standard and route-bound x402 exact Challenges. Add other MPP methods when the client also calls endpoints that offer them. `Fetch.from` reads either Challenge format and retries with the matching Credential header.
 
 ```ts twoslash [client.ts]
 import { Fetch, evm, tempo } from 'mppx/client'
@@ -241,11 +244,11 @@ console.log(response.status)
 // @log: 200
 ```
 
-Use this pattern for coding agents, CLIs, SDKs, and application clients that need to call both native MPP APIs and x402 exact APIs.
+The client validates the resource, EIP-3009 token metadata, network, currency, and amount before signing an x402 offer. It skips unsupported offers and fails without signing when none match your policy.
 
-### Send x402 headers manually
+### Control the x402 retry
 
-Use `Mppx.create` when you need explicit control over the first request and retry. `preparePayment` lets you inspect the selected x402 Challenge before signing, and `setCredential` attaches the resulting Credential as `PAYMENT-SIGNATURE`.
+Use `Mppx.create` when you need to inspect a selected x402 Challenge before signing. `preparePayment` selects the offer, and `setCredential` attaches the Credential as `PAYMENT-SIGNATURE`.
 
 ```ts twoslash [client.ts]
 import { Mppx, evm } from 'mppx/client'
@@ -267,7 +270,10 @@ const mppx = Mppx.create({
 })
 
 const request: RequestInit = {}
-const challengeResponse = await mppx.rawFetch('https://api.example.com/paid', request)
+const challengeResponse = await mppx.rawFetch(
+  'https://api.example.com/paid',
+  request,
+)
 if (challengeResponse.status !== 402) throw new Error('Expected payment Challenge')
 
 const payment = await mppx.preparePayment(challengeResponse, { request })
@@ -275,180 +281,16 @@ console.log(payment.challenge.request.amount)
 
 const credential = await payment.createCredential()
 const paidRequest = payment.setCredential(request, credential)
-const response = await mppx.rawFetch('https://api.example.com/paid', paidRequest)
+const response = await mppx.rawFetch(
+  'https://api.example.com/paid',
+  paidRequest,
+)
 
 console.log(response.status)
 // @log: 200
 ```
 
-:::tip
-Because MPP uses the standard `WWW-Authenticate` scheme, it works with HTTP intermediaries (proxies, CDNs, API gateways) that understand [RFC 7235](https://www.rfc-editor.org/rfc/rfc7235) authentication.
-:::
-
-## Prompt mode
-
-Paste this into your coding agent to add MPP in one prompt:
-
-<PromptBlock>
-{`Use https://mpp.dev/guides/use-mpp-with-x402.md#run-x402-inline-with-mppx as reference.
-Run my existing x402 EVM charges inline with MPP flows. Use the Tempo
-payment method with USDC.e as an additional option. Keep the same pricing
-and route structure. Point out areas where I could benefit from adding sessions.`}
-</PromptBlock>
-
-## Advanced: Update an existing x402 route
-
-::::steps
-
-### Install `mppx`
-
-:::code-group
-```bash [npm]
-$ npm install mppx viem
-```
-```bash [pnpm]
-$ pnpm add mppx viem
-```
-```bash [bun]
-$ bun add mppx viem
-```
-:::
-
-### Move the x402 charge into `mppx`
-
-Here's a typical x402 route moved into an MPP flow. Your business logic stays the same, and the route still accepts x402 exact Credentials.
-
-```ts [server.ts]
-import express from 'express'
-import { evm, Mppx, tempo } from 'mppx/express' // [!code hl]
-
-const app = express()
-
-// [!code hl:start]
-const mppx = Mppx.create({
-  methods: [
-    evm.charge({
-      currency: evm.assets.baseSepolia.USDC,
-      recipient: '0xYourAddress',
-      x402: {
-        facilitator: 'https://facilitator.x402.org',
-      },
-    }),
-    tempo.charge({
-      currency: '0x20c0000000000000000000000000000000000000',
-      recipient: '0xYourAddress',
-    }),
-  ],
-  secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
-})
-// [!code hl:end]
-
-app.get(
-  '/api/data',
-  mppx.charge({ amount: '0.01', description: 'Premium data access' }), // [!code hl]
-  (req, res) => {
-    res.json({ data: 'premium content' })
-  },
-)
-```
-
-Key differences:
-
-- **Inline x402.** `evm.charge` serves x402 exact Challenges from the same MPP route.
-- **Per-route pricing.** The route declares pricing where it verifies payment.
-- **Amount in dollars, not atomic units.** `'0.01'` instead of `'10000'`.
-- **No header parsing.** The SDK handles `WWW-Authenticate`, `Authorization`, and `Payment-Receipt` headers automatically.
-
-### Simplify verification and settlement
-
-x402 servers typically call a facilitator service for `POST /verify` and `POST /settle`. In an MPP flow, configure the facilitator once on `evm.charge`; `mppx` calls it while it verifies the route payment.
-
-```ts [server.ts]
-import { createFacilitator } from '@x402/server'
-import { evm, Mppx } from 'mppx/server'
-
-// x402 — external facilitator
-const facilitator = createFacilitator('https://facilitator.x402.org')
-
-// MPP — inline with the route payment
-const mppx = Mppx.create({
-  methods: [
-    evm.charge({
-      currency: evm.assets.baseSepolia.USDC,
-      recipient: '0xYourAddress',
-      x402: {
-        facilitator: 'https://facilitator.x402.org',
-      },
-    }),
-  ],
-})
-```
-
-### Add more payment methods
-
-This is where MPP goes beyond x402. You can accept stablecoins, cards, and Lightning on the same endpoint by registering additional methods. The `402` response advertises all of them, and the client picks one.
-
-```ts [server.ts]
-import express from 'express'
-import Stripe from 'stripe'
-import { Mppx, tempo, stripe } from 'mppx/express'
-
-const app = express()
-const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
-
-const mppx = Mppx.create({
-  methods: [
-    tempo.charge({
-      currency: '0x20c0000000000000000000000000000000000000',
-      recipient: '0xYourAddress',
-      testnet: true,
-    }),
-    // [!code hl:start]
-    stripe.spt({
-      client: stripeClient,
-      currency: 'usd',
-      decimals: 2,
-      networkId: 'internal',
-      paymentMethodTypes: ['card'],
-    }),
-    // [!code hl:end]
-  ],
-  secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
-})
-
-app.get(
-  '/api/data',
-  mppx.charge({ amount: '0.01', description: 'Premium data access' }),
-  (req, res) => {
-    res.json({ data: 'premium content' })
-  },
-)
-```
-
-No changes to the route handler—`mppx.charge` advertises both methods and verifies whichever Credential the client presents.
-
-### Test via the `mppx` CLI
-
-```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
-
-# Make a paid request
-$ npx mppx http://localhost:3000/api/data
-```
-
-::::
-
-## What you gain
-
-- **Inline x402 compatibility.** Keep x402 exact clients working while the same route serves native MPP clients.
-- **Multi-method payments.** Accept stablecoins, cards, and Lightning on the same endpoint—new rails are additive.
-- **Sessions.** Stream sub-cent payments with off-chain vouchers instead of one on-chain transaction per request.
-- **IETF standards track.** MPP's [Payment HTTP Authentication Scheme](https://paymentauth.org) follows the IETF standards process—building on a standard that browsers, proxies, and CDNs already understand.
-- **Production primitives.** Idempotency, expiration, request-body binding, and RFC 9457 error responses are built into the protocol.
-- **Permissionless extensibility.** Anyone can author and publish a new payment method without approval from a foundation.
-
-## Next steps
+### Next steps
 
 <Cards>
   <OneTimePaymentsCard />

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -11,6 +11,26 @@ import { OneTimePaymentsCard, PaymentMethodsCard, ServerQuickstartCard } from '.
 
 Keep your existing x402 server when you only need `mppx` clients to pay it. Use `mppx` on the server when the same endpoint must speak both native MPP and x402.
 
+## Compare MPP and x402
+
+Both protocols use HTTP `402` to gate API access behind payment. x402 exact charges map to MPP's `charge` intent, while MPP adds standard HTTP authentication, more payment methods, and Sessions.
+
+| | x402 | MPP |
+|---|---|---|
+| **Challenge** | `PAYMENT-REQUIRED` header | `WWW-Authenticate: Payment` header |
+| **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` header |
+| **Receipt** | `PAYMENT-RESPONSE` header | `Payment-Receipt` header |
+| **Payment methods** | Stablecoins | Stablecoins, cards, digital wallets, and other methods |
+| **Sessions** | No | Yes—off-chain vouchers for sub-cent streaming |
+| **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
+| **Idempotency** | No | Built-in Challenge binding |
+
+MPP uses three protocol objects throughout a payment flow:
+
+- **Challenge**—the server's `402` response describing the required payment
+- **Credential**—the client's signed payment authorization
+- **Receipt**—the server's confirmation that the payment settled
+
 ## Server
 
 Choose the server setup that matches the protocols your endpoint needs to expose:
@@ -300,28 +320,6 @@ const response = await mppx.rawFetch(
 console.log(response.status)
 // @log: 200
 ```
-
-## Advanced concepts
-
-### Compare MPP and x402
-
-Both protocols use HTTP `402` to gate API access behind payment. x402 exact charges map to MPP's `charge` intent, while MPP adds standard HTTP authentication, more payment methods, and Sessions.
-
-| | x402 | MPP |
-|---|---|---|
-| **Challenge** | `PAYMENT-REQUIRED` header | `WWW-Authenticate: Payment` header |
-| **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` header |
-| **Receipt** | `PAYMENT-RESPONSE` header | `Payment-Receipt` header |
-| **Payment methods** | Stablecoins | Stablecoins, cards, digital wallets, and other methods |
-| **Sessions** | No | Yes—off-chain vouchers for sub-cent streaming |
-| **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
-| **Idempotency** | No | Built-in Challenge binding |
-
-MPP uses three protocol objects throughout a payment flow:
-
-- **Challenge**—the server's `402` response describing the required payment
-- **Credential**—the client's signed payment authorization
-- **Receipt**—the server's confirmation that the payment settled
 
 ## Next steps
 

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -27,7 +27,7 @@ See [MPP vs x402](/mpp-vs-x402) for a full comparison.
 
 ## Server
 
-Choose the server setup that matches the protocols your endpoint needs to expose:
+Choose the server setup that matches your current integration shape:
 
 1. **Add MPP to an x402 server**—keep your existing x402 route table and resource server, then wrap them with `mppx`.
 2. **Start with `mppx`**—create a new route that serves native MPP and x402 clients.
@@ -97,7 +97,7 @@ import { HTTPFacilitatorClient, type RoutesConfig } from '@x402/core/server'
 import { ExactEvmScheme } from '@x402/evm/exact/server'
 import { x402ResourceServer } from '@x402/express'
 import express from 'express'
-import { mpp } from 'mppx/x402/express' // [!code hl]
+import { mpp } from 'mppx/x402/express' // [!code focus]
 
 const app = express()
 const facilitator = new HTTPFacilitatorClient({
@@ -125,7 +125,7 @@ const routes = {
 const secretKey = process.env.MPP_SECRET_KEY
 if (!secretKey) throw new Error('Set MPP_SECRET_KEY to at least 32 random bytes.')
 
-app.use(mpp(routes, resourceServer, { secretKey })) // [!code hl]
+app.use(mpp(routes, resourceServer, { secretKey })) // [!code focus]
 
 app.get('/api/data', (req, res) => {
   res.json({ data: 'premium content' })
@@ -149,11 +149,11 @@ const mppx = Mppx.create({
     evm.charge({
       currency: evm.assets.baseSepolia.USDC,
       recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-      // [!code hl:start]
+      // [!code focus:start]
       x402: {
         facilitator: 'https://x402.org/facilitator',
       },
-      // [!code hl:end]
+      // [!code focus:end]
     }),
   ],
   secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
@@ -182,57 +182,6 @@ This flow also supports body-bearing and route-scoped endpoints. Standard x402 c
 
 ### Advanced server options
 
-#### Use another x402 adapter
-
-The compatibility wrappers cover the official x402 adapters for each supported environment:
-
-| Environment | Import |
-|---|---|
-| Express | `mppx/x402/express` |
-| Hono | `mppx/x402/hono` |
-| MCP | `mppx/x402/mcp` |
-| Next.js | `mppx/x402/next` |
-
-Each wrapper keeps the official adapter's route or tool configuration, hooks, verification, and settlement.
-
-#### Add another payment method
-
-Register another method beside `evm.charge`, then use `mppx.charge()` to advertise every compatible charge method. This example adds pathUSD payments on Tempo while preserving x402 support on Base Sepolia.
-
-```ts [server.ts]
-import { Mppx, evm, tempo } from 'mppx/express'
-import express from 'express'
-
-const app = express()
-
-const mppx = Mppx.create({
-  methods: [
-    evm.charge({
-      currency: evm.assets.baseSepolia.USDC,
-      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-      x402: {
-        facilitator: 'https://x402.org/facilitator',
-      },
-    }),
-    tempo.charge({
-      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
-      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-    }),
-  ],
-  secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
-})
-
-app.get(
-  '/api/data',
-  mppx.charge({ amount: '0.01', description: 'Premium data access' }),
-  (req, res) => {
-    res.json({ data: 'premium content' })
-  },
-)
-```
-
-See [Payment methods](/payment-methods) to add cards, Lightning, or another payment rail.
-
 #### Require route-bound x402 Credentials
 
 Keep the default `routeBinding: 'resource'` for compatibility with standard x402 clients. Set `routeBinding: 'required'` when every x402 Credential for a scoped route must include the `mppx` extension and a route-bound nonce.
@@ -253,36 +202,6 @@ const method = evm.charge({
 ```
 
 The default compares the echoed resource URL and payment requirements, and verifies any body digest against the request. Required binding also cryptographically binds MPP scope, opaque values, and metadata, but excludes standard clients that don't implement the extension.
-
-#### Use native Hono middleware
-
-Import the Hono adapter to apply the same inline flow as route middleware.
-
-```ts twoslash [server.ts]
-import { Hono } from 'hono'
-import { Mppx, evm } from 'mppx/hono'
-
-const app = new Hono()
-
-const mppx = Mppx.create({
-  methods: [
-    evm.charge({
-      currency: evm.assets.baseSepolia.USDC,
-      recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-      x402: {
-        facilitator: 'https://x402.org/facilitator',
-      },
-    }),
-  ],
-  secretKey: process.env.MPP_SECRET_KEY ?? 'local-dev-secret',
-})
-
-app.get(
-  '/api/data',
-  mppx.evm.charge({ amount: '0.01', description: 'Premium data access' }),
-  (c) => c.json({ data: 'premium content' }),
-)
-```
 
 ## Client
 


### PR DESCRIPTION
## Motivation

Show x402 service operators how to add MPP while retaining their official x402 configuration and payment lifecycle.

## Summary

- Lead with the new `mppx/x402/express` compatibility wrapper for an existing x402 server
- Keep native `mppx` composition as the second server option
- Clarify that MPP compatibility maps extension-free x402 v2 EIP-3009 `exact` requirements to MPP `charge`
- Document compatibility wrappers for Express, Hono, MCP, and Next.js
- Keep client migration and optional server capabilities below the primary setup

## Key design considerations

- Preserve the existing x402 route table, resource server, facilitator, hooks, verification, and settlement
- Leave `upto`, `batch-settlement`, and extension-bearing requirements on the official x402 path
- Separate protocol-level comparison from the compatibility supported by the current `mppx` adapters