### PR TITLE
feat: improve search indexing and metadata

### DIFF
--- a/scripts/sitemap.test.ts
+++ b/scripts/sitemap.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { assertSitemapXml, pruneSitemapXml } from "./sitemap";
+
+const entry = (location: string) => `
+  <url>
+    <loc>${location}</loc>
+    <lastmod>2026-08-24</lastmod>
+  </url>`;
+
+describe("pruneSitemapXml", () => {
+  it("removes duplicate and 404 routes", () => {
+    const sitemap = `<urlset>${entry("https://mpp.dev/")}${entry(
+      "https://mpp.dev/blog",
+    )}${entry("https://mpp.dev/")}${entry(
+      "https://mpp.dev/blog/",
+    )}${entry("https://mpp.dev/404")}</urlset>`;
+
+    const result = pruneSitemapXml(sitemap);
+
+    expect(result.match(/<loc>https:\/\/mpp\.dev\/<\/loc>/g)).toHaveLength(1);
+    expect(result.match(/<loc>https:\/\/mpp\.dev\/blog<\/loc>/g)).toHaveLength(
+      1,
+    );
+    expect(result).not.toContain("https://mpp.dev/blog/");
+    expect(result).not.toContain("https://mpp.dev/404");
+  });
+
+  it("keeps the first complete entry for each location", () => {
+    const sitemap = `<urlset>${entry("https://mpp.dev/overview")}${entry(
+      "https://mpp.dev/overview",
+    )}</urlset>`;
+
+    expect(pruneSitemapXml(sitemap)).toBe(
+      `<urlset>${entry("https://mpp.dev/overview")}</urlset>`,
+    );
+  });
+
+  it("rejects duplicate and 404 routes before publication", () => {
+    expect(() =>
+      assertSitemapXml(
+        `<urlset>${entry("https://mpp.dev/blog")}${entry(
+          "https://mpp.dev/blog/",
+        )}</urlset>`,
+      ),
+    ).toThrow("Duplicate sitemap locations");
+    expect(() =>
+      assertSitemapXml(`<urlset>${entry("https://mpp.dev/404")}</urlset>`),
+    ).toThrow("Sitemap must not contain /404");
+  });
+
+  it("accepts the pruned sitemap", () => {
+    const sitemap = `<urlset>${entry("https://mpp.dev/")}${entry(
+      "https://mpp.dev/blog",
+    )}${entry("https://mpp.dev/blog/")}</urlset>`;
+
+    expect(() => assertSitemapXml(pruneSitemapXml(sitemap))).not.toThrow();
+  });
+});

--- a/scripts/sitemap.ts
+++ b/scripts/sitemap.ts
@@ -1,0 +1,42 @@
+const URL_ENTRY = /\s*<url>[\s\S]*?<\/url>/g;
+const LOC = /<loc>([^<]+)<\/loc>/;
+
+function normalizeLocation(location: string): string {
+  const url = new URL(location);
+  url.hash = "";
+  if (url.pathname !== "/") url.pathname = url.pathname.replace(/\/+$/, "");
+  return url.toString();
+}
+
+export function pruneSitemapXml(sitemap: string): string {
+  const seen = new Set<string>();
+
+  return sitemap.replace(URL_ENTRY, (entry) => {
+    const location = entry.match(LOC)?.[1];
+    if (!location) return entry;
+
+    const normalized = normalizeLocation(location);
+    if (new URL(normalized).pathname === "/404" || seen.has(normalized)) {
+      return "";
+    }
+
+    seen.add(normalized);
+    return entry;
+  });
+}
+
+export function assertSitemapXml(sitemap: string): void {
+  const locations = Array.from(sitemap.matchAll(new RegExp(LOC, "g"))).map(
+    (match) => normalizeLocation(match[1]),
+  );
+  const duplicates = locations.filter(
+    (location, index) => locations.indexOf(location) !== index,
+  );
+
+  if (duplicates.length > 0) {
+    throw new Error(`Duplicate sitemap locations: ${[...new Set(duplicates)]}`);
+  }
+  if (locations.some((location) => new URL(location).pathname === "/404")) {
+    throw new Error("Sitemap must not contain /404");
+  }
+}

--- a/src/components/BlogIndexPage.tsx
+++ b/src/components/BlogIndexPage.tsx
@@ -29,13 +29,13 @@ export function BlogIndexPage() {
           <div className="flex flex-col gap-[60px] border-t border-border pt-6 xl:flex-row xl:gap-0">
             <div className="xl:w-1/2">
               <h1 className="font-sans !text-[32px] font-normal !leading-[1.1] !tracking-[-0.32px] text-offwhite">
-                See Updates
+                MPP protocol updates
               </h1>
             </div>
             <div className="flex flex-col gap-14 xl:w-1/2">
               <div className="flex flex-col">
                 {blogPosts.slice(0, shown).map((post) => (
-                  <BlogRow key={post.to} post={post} />
+                  <BlogRow headingLevel="h2" key={post.to} post={post} />
                 ))}
               </div>
               <div className="flex items-center justify-between">

--- a/src/components/FaqStructuredData.test.tsx
+++ b/src/components/FaqStructuredData.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment happy-dom
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { FAQ_ENTRIES, FaqStructuredData } from "./FaqStructuredData";
+
+afterEach(cleanup);
+
+describe("FaqStructuredData", () => {
+  it("matches every visible FAQ heading", () => {
+    const source = readFileSync(resolve("src/pages/faq.mdx"), "utf8");
+    const questions = Array.from(source.matchAll(/^## (.+)$/gm), (match) =>
+      match[1].replaceAll("`", ""),
+    );
+
+    expect(FAQ_ENTRIES.map(({ question }) => question)).toEqual(questions);
+  });
+
+  it("renders valid FAQPage JSON-LD", () => {
+    const { container } = render(<FaqStructuredData />);
+    const script = container.querySelector(
+      'script[type="application/ld+json"]',
+    );
+    const data = JSON.parse(script?.textContent ?? "") as {
+      "@type": string;
+      mainEntity: unknown[];
+    };
+
+    expect(data["@type"]).toBe("FAQPage");
+    expect(data.mainEntity).toHaveLength(FAQ_ENTRIES.length);
+  });
+});

--- a/src/components/FaqStructuredData.tsx
+++ b/src/components/FaqStructuredData.tsx
@@ -1,0 +1,99 @@
+import { withMarkdown } from "./markdown";
+import { StructuredData } from "./StructuredData";
+
+export const FAQ_ENTRIES = [
+  {
+    answer:
+      "No. MPP is payment-method agnostic. Production implementations support Tempo stablecoin payments, card payments through Card or Stripe, and Lightning payments. Anyone can add a custom payment method.",
+    question: "Is MPP only for stablecoins?",
+  },
+  {
+    answer:
+      "No. Card and Stripe methods let you pay with cards, and Lightning lets you pay with Bitcoin. Stablecoin payments require a wallet, but SDKs and wallet CLIs can handle key management.",
+    question: "Do I need a stablecoin wallet?",
+  },
+  {
+    answer:
+      "MPP and x402 both use HTTP 402. MPP uses standard HTTP authentication semantics and supports payment rails including stablecoins, cards, and Lightning. x402 focuses on on-chain payment mechanisms. MPP also defines core Challenge binding, Receipts, and payment intents.",
+    question: "How is MPP different from x402?",
+  },
+  {
+    answer:
+      "Yes. The x402 exact flow maps onto MPP's charge intent. mppx can run x402-compatible EVM charges inline so one endpoint serves both MPP and x402 clients.",
+    question: "Is MPP compatible with x402?",
+  },
+  {
+    answer:
+      "MPP works with any payment rail and does not require Tempo. Tempo is well suited to high-throughput, low-value machine payments because it provides deterministic finality, predictable costs, payment lanes, and native stablecoin support.",
+    question: "Why build MPP on Tempo?",
+  },
+  {
+    answer:
+      "Sessions enable streaming, pay-as-you-go payments. A client funds a channel reserve, sends signed off-chain vouchers for requests, and the server periodically settles the accumulated value on-chain.",
+    question: "What are sessions?",
+  },
+  {
+    answer:
+      "Each service sets its own price. The MPP protocol is free and open, with no licensing fees. Session payments can support lower per-request prices because individual interactions use signed vouchers and only net settlement reaches the payment network.",
+    question: "How much does it cost?",
+  },
+  {
+    answer:
+      "MPP requires TLS 1.2 or later and binds Challenge IDs to prevent replay. Unpaid requests do not perform protected side effects. Each payment method also applies the security model of its underlying payment rail.",
+    question: "Is it safe?",
+  },
+  {
+    answer:
+      "Store MPP_SECRET_KEY in a secrets manager, keep it server-side, never log it, and rotate it immediately if exposed. During rotation, verify with current and previous keys so in-flight Challenges continue to work.",
+    question: "How do I handle MPP_SECRET_KEY?",
+  },
+  {
+    answer:
+      "The service returns an RFC 9457 Problem Details response. The client can retry with another payment method or surface the error. Failed requests do not deduct money.",
+    question: "What happens if a payment fails?",
+  },
+  {
+    answer:
+      "Yes. The MPP SDKs include server middleware and primitives for accepting payments from APIs built with frameworks including Hono, Express, Next.js, and Elysia.",
+    question: "Can I accept MPP payments for my own service?",
+  },
+  {
+    answer:
+      "The core Payment HTTP Authentication Scheme is submitted to the IETF standards track. Payment method and intent specifications are separate documents that can evolve independently.",
+    question: "Is MPP an IETF standard?",
+  },
+  {
+    answer:
+      "Yes. MPP includes an MCP transport binding that maps the Challenge-Credential-Receipt flow onto the Model Context Protocol so MCP servers can charge for tool calls.",
+    question: "Can I use MPP outside of HTTP?",
+  },
+  {
+    answer:
+      "MPP is co-authored by Tempo and Stripe. Its core specification is developed openly and can be extended by any payment network or provider.",
+    question: "Who is building MPP?",
+  },
+] as const;
+
+function FaqStructuredDataComponent() {
+  return (
+    <StructuredData
+      data={{
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: FAQ_ENTRIES.map(({ answer, question }) => ({
+          "@type": "Question",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: answer,
+          },
+          name: question,
+        })),
+      }}
+    />
+  );
+}
+
+export const FaqStructuredData = withMarkdown(
+  FaqStructuredDataComponent,
+  () => [],
+);

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -116,6 +116,9 @@ export function LandingPage() {
               <Button className="w-full sm:w-auto" href="/quickstart/server">
                 Add payments to your API
               </Button>
+              <Button className="w-full sm:w-auto" href="/mpp-vs-x402">
+                Compare MPP vs x402
+              </Button>
             </div>
           </div>
 
@@ -209,7 +212,7 @@ export function LandingPage() {
             <div className="flex flex-col gap-14 xl:w-1/2">
               <div className="flex flex-col">
                 {blogPosts.slice(0, 5).map((post) => (
-                  <BlogRow key={post.to} post={post} />
+                  <BlogRow headingLevel="h3" key={post.to} post={post} />
                 ))}
               </div>
               <Button className="self-start" href="/blog">

--- a/src/components/ServicesPage.test.tsx
+++ b/src/components/ServicesPage.test.tsx
@@ -5,6 +5,7 @@ import {
   buildTryCommands,
   CATEGORY_LABELS,
   formatPrice,
+  orderServices,
   PAGE_SIZE,
   providerUrl,
 } from "./ServicesPage";
@@ -202,6 +203,33 @@ describe("providerUrl", () => {
     expect(providerUrl({ url: "https://api.example.com" })).toBe(
       "https://api.example.com",
     );
+  });
+});
+
+describe("orderServices", () => {
+  const makeService = (id: string, name = id): Service => ({
+    endpoints: [],
+    id,
+    methods: {},
+    name,
+    url: `https://${id}.example.com`,
+  });
+
+  it("pins featured services and removes temporary name labels", () => {
+    const services = [
+      makeService("later"),
+      makeService("openai", "OpenAI (New)"),
+      makeService("anthropic"),
+    ];
+
+    expect(
+      orderServices(services).map(({ id, name }) => ({ id, name })),
+    ).toEqual([
+      { id: "openai", name: "OpenAI" },
+      { id: "anthropic", name: "anthropic" },
+      { id: "later", name: "later" },
+    ]);
+    expect(services[1].name).toBe("OpenAI (New)");
   });
 });
 

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -43,6 +43,20 @@ export const PINNED_IDS: string[] = [
   "stripe-climate",
 ];
 
+export function orderServices(services: readonly Service[]): Service[] {
+  const pinned = new Map(PINNED_IDS.map((id, index) => [id, index] as const));
+  return services
+    .map((service) => ({
+      ...service,
+      name: service.name.replace(/ \(New\)$/i, ""),
+    }))
+    .toSorted(
+      (a, b) =>
+        (pinned.get(a.id) ?? PINNED_IDS.length) -
+        (pinned.get(b.id) ?? PINNED_IDS.length),
+    );
+}
+
 export function allCategories(service: Service): Category[] {
   return service.categories ?? [];
 }
@@ -126,9 +140,9 @@ function ServiceTableRow({ service }: { service: Service }) {
               src={serviceIconUrl(service)}
             />
             <div className="flex min-w-0 flex-col gap-1">
-              <p className="truncate font-sans text-lg font-normal leading-[1.1] text-offwhite">
+              <h2 className="truncate font-sans text-lg font-normal leading-[1.1] text-offwhite">
                 {service.name}
-              </p>
+              </h2>
               <p className="font-mono text-sm capitalize leading-[1.2] tracking-[0.24px] text-secondary">
                 {categoryLabel(service)}
               </p>
@@ -589,8 +603,14 @@ const topShortcuts = [
   ...shortcuts.filter((shortcut) => shortcut.title !== "Discovery"),
 ];
 
-export function ServicesPage() {
-  const [services, setServices] = useState<Service[]>([]);
+export function ServicesPage({
+  initialServices = [],
+}: {
+  initialServices?: readonly Service[];
+}) {
+  const [services, setServices] = useState<Service[]>(() =>
+    orderServices(initialServices),
+  );
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState<Category | "">("");
   const [page, setPage] = useState(0);
@@ -600,18 +620,7 @@ export function ServicesPage() {
 
   useEffect(() => {
     fetchServices()
-      .then((data) => {
-        const pinned = new Map(
-          PINNED_IDS.map((id, index) => [id, index] as const),
-        );
-        setServices(
-          data.toSorted(
-            (a, b) =>
-              (pinned.get(a.id) ?? PINNED_IDS.length) -
-              (pinned.get(b.id) ?? PINNED_IDS.length),
-          ),
-        );
-      })
+      .then((data) => setServices(orderServices(data)))
       .catch(() => {});
   }, []);
   const categories = useMemo(
@@ -649,13 +658,19 @@ export function ServicesPage() {
       <Header active="services" />
       <main className="mx-auto w-full max-w-[1728px]">
         <section className="flex h-[300px] flex-col items-start justify-end gap-6 px-4 py-12 md:px-12">
-          <LineLogo
-            className="h-auto w-[619px] max-w-full"
-            label="Services"
-            name="services"
-          />
+          <h1>
+            <span className="sr-only">MPP services directory</span>
+            <span aria-hidden="true">
+              <LineLogo
+                className="h-auto w-[619px] max-w-full"
+                label="Services"
+                name="services"
+              />
+            </span>
+          </h1>
           <p className="font-mono text-sm uppercase leading-4 tracking-[-0.14px] text-offwhite">
-            Use MPP-enabled services with your agent.
+            Discover APIs and tools that accept machine-to-machine payments
+            through MPP.
           </p>
         </section>
 
@@ -751,7 +766,7 @@ export function ServicesPage() {
                     role="button"
                     tabIndex={0}
                   >
-                    <ServiceCard service={service} />
+                    <ServiceCard headingLevel="h2" service={service} />
                   </div>
                 ))}
               </div>

--- a/src/components/StructuredData.test.tsx
+++ b/src/components/StructuredData.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { StructuredData } from "./StructuredData";
+
+afterEach(cleanup);
+
+describe("StructuredData", () => {
+  it("serializes JSON-LD without executable closing tags", () => {
+    const value = "</script><script>alert('xss')</script>";
+    const { container } = render(<StructuredData data={{ value }} />);
+    const script = container.querySelector(
+      'script[type="application/ld+json"]',
+    );
+    const serialized = script?.textContent ?? "";
+
+    expect(serialized).not.toContain("</script>");
+    expect(JSON.parse(serialized)).toEqual({ value });
+  });
+});

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -1,0 +1,13 @@
+type JsonLd = Record<string, unknown> | readonly Record<string, unknown>[];
+
+export function StructuredData({ data }: { data: JsonLd }) {
+  return (
+    <script
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON is serialized locally and escapes HTML opening characters.
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replaceAll("<", "\\u003c"),
+      }}
+      type="application/ld+json"
+    />
+  );
+}

--- a/src/components/markdown.test.ts
+++ b/src/components/markdown.test.ts
@@ -3,6 +3,7 @@ import { AgentSetupPrompt } from "./AgentSetupPrompt";
 import { AsciiLogo } from "./AsciiLogo";
 import { staticCards } from "./cards";
 import { EcosystemDiagram } from "./EcosystemDiagram";
+import { FaqStructuredData } from "./FaqStructuredData";
 import { LandingPage } from "./LandingPage";
 import { NotFoundPage } from "./NotFoundPage";
 import { PaymentFlowDiagram } from "./PaymentFlowDiagram";
@@ -26,6 +27,7 @@ const components = {
   AsciiLogo,
   ClientPrompt,
   EcosystemDiagram,
+  FaqStructuredData,
   LandingPage,
   NotFoundPage,
   PaymentFlowDiagram,

--- a/src/components/marketing/BlogRow.tsx
+++ b/src/components/marketing/BlogRow.tsx
@@ -3,16 +3,22 @@ import type { BlogPost } from "../../lib/blog";
 import { formatBlogPostDate } from "../../lib/blog";
 import { Icon } from "./Icon";
 
-export function BlogRow({ post }: { post: BlogPost }) {
+export function BlogRow({
+  headingLevel: Heading = "h2",
+  post,
+}: {
+  headingLevel?: "h2" | "h3";
+  post: BlogPost;
+}) {
   return (
     <Link
       className="group flex items-start gap-4 border-b border-border px-4 py-5 text-offwhite no-underline transition-colors hover:bg-white/[0.02] md:py-6"
       to={post.to}
     >
       <div className="flex min-w-0 flex-1 flex-col gap-1 md:w-[200px] md:flex-none">
-        <p className="font-sans text-xl font-normal leading-[1.1] tracking-normal !text-offwhite">
+        <Heading className="font-sans text-xl font-normal leading-[1.1] tracking-normal !text-offwhite">
           {post.title}
-        </p>
+        </Heading>
         <time className="mt-px font-mono text-sm uppercase leading-4 tracking-normal !text-white/60 transition-colors group-hover:!text-offwhite">
           {formatBlogPostDate(post.date)}
         </time>

--- a/src/components/marketing/ServiceCard.tsx
+++ b/src/components/marketing/ServiceCard.tsx
@@ -3,8 +3,10 @@ import { serviceIconUrl } from "../../data/registry";
 import { CopyBadge } from "./CopyBadge";
 
 export function ServiceCard({
+  headingLevel: Heading = "h3",
   service,
 }: {
+  headingLevel?: "h2" | "h3";
   service: FeaturedService | Service;
 }) {
   const category = service.categories?.[0] ?? "service";
@@ -19,9 +21,9 @@ export function ServiceCard({
             src={serviceIconUrl(service)}
           />
           <div className="flex min-w-0 flex-1 flex-col gap-1">
-            <p className="font-sans text-xl font-normal leading-[1.1] text-offwhite">
+            <Heading className="font-sans text-xl font-normal leading-[1.1] text-offwhite">
               {service.name}
-            </p>
+            </Heading>
             <p className="font-mono text-sm uppercase leading-4 tracking-[-0.14px] text-secondary">
               {category}
             </p>

--- a/src/pages/blog/index.mdx
+++ b/src/pages/blog/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: minimal
-title: "Blog"
+title: "MPP Blog: HTTP 402 payment protocol updates"
 showAskAi: false
 showFeedback: false
 showSearch: false

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -9,7 +9,7 @@ export default function BlogRoute() {
         description="Updates from the MPP team on protocol development, integrations, and the future of machine payments."
         imageDescription="Updates on the Machine Payments Protocol"
         path="/blog"
-        title="Blog"
+        title="MPP Blog: HTTP 402 payment protocol updates"
       />
       <BlogIndexPage />
       <Footer />

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -3,6 +3,10 @@ description: "Answers to common questions about MPP—payment methods, settlemen
 imageDescription: "Answers to common MPP questions"
 ---
 
+import { FaqStructuredData } from '../components/FaqStructuredData'
+
+<FaqStructuredData />
+
 # Frequently asked questions [Common questions about the Machine Payments Protocol]
 
 ## Is MPP only for stablecoins?

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -15,24 +15,24 @@ import { PromptBlock } from '../../components/PromptBlock'
 <SigningAccountTabs />
 
 
-MPP runs x402-compatible EVM charges inline with native MPP flows. Both protocols use HTTP `402` to gate API access behind payment, and x402's "exact" charge flow maps directly onto MPP's `charge` intent. Adding MPP gives you standard `WWW-Authenticate` / `Authorization` headers, multi-method support (stablecoins, cards, Lightning), sessions for streaming payments, and an [IETF standards track](https://paymentauth.org) foundation—while the same route can still serve x402 clients.
+MPP runs x402-compatible EVM charges inline with native MPP flows. Both protocols use HTTP `402` to gate API access behind payment, and x402's "exact" charge flow maps directly onto MPP's `charge` intent. Adding MPP gives you standard `WWW-Authenticate` / `Authorization` headers and one interface for stablecoins, cards, Lightning, and payment intents—while the same route can still serve x402 clients. See [MPP vs x402](/mpp-vs-x402) for the full comparison.
 
-## What MPP adds
+## Where MPP differs
 
-MPP builds on the same `402` pattern that x402 established, and extends it with standardized headers and new capabilities.
+MPP and x402 apply the same `402` pattern through different protocol models. MPP uses HTTP authentication and separates payment intents from payment methods. x402 registers on-chain payment schemes and optional extensions.
 
 | | x402 | MPP |
 |---|---|---|
 | **Challenge** | `PAYMENT-REQUIRED` header | `WWW-Authenticate: Payment` header |
 | **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` header |
 | **Receipt** | `PAYMENT-RESPONSE` header | `Payment-Receipt` header |
-| **Payment methods** | Stablecoins only | Stablecoins, cards, digital wallets, and many other methods |
-| **Sessions** | No | Yes—off-chain vouchers for sub-cent streaming |
+| **Payment rails** | Registered blockchain network mechanisms | Stablecoins, cards, Lightning, and custom methods |
+| **Usage-based billing** | `upto` and EVM `batch-settlement` schemes | Payment-method intents, including `session` |
 | **Error format** | Custom | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
-| **Idempotency** | No | Built-in Challenge binding |
+| **Idempotency** | Optional Payment Identifier extension | Challenge identity plus standard `Idempotency-Key` guidance |
 
 :::info
-MPP is compatible with x402. The x402 "exact" charge flow maps directly onto MPP's `charge` intent. MPP extends beyond x402 with idempotency, Receipts, request binding, multiple payment methods, and efficient payment sessions.
+MPP is compatible with x402. The x402 "exact" charge flow maps directly onto MPP's `charge` intent. MPP adds a payment-method-agnostic HTTP authentication layer while preserving access for existing x402 clients.
 :::
 
 ## Key concepts

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,46 @@
 import { LandingPage } from "../components/LandingPage";
 import { MarketingHead } from "../components/MarketingHead";
 import { Footer } from "../components/marketing/Footer";
+import { StructuredData } from "../components/StructuredData";
+
+const homepageStructuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@id": "https://mpp.dev/#organization",
+      "@type": "Organization",
+      logo: "https://mpp.dev/marketing/mpp-logo.svg",
+      name: "MPP",
+      sameAs: ["https://github.com/tempoxyz/mpp", "https://x.com/mpp"],
+      url: "https://mpp.dev/",
+    },
+    {
+      "@id": "https://mpp.dev/#website",
+      "@type": "WebSite",
+      description:
+        "The open standard for machine-to-machine payments over HTTP 402.",
+      name: "MPP — Machine Payments Protocol",
+      publisher: { "@id": "https://mpp.dev/#organization" },
+      url: "https://mpp.dev/",
+    },
+    {
+      "@id": "https://mpp.dev/sdk/typescript/#software",
+      "@type": ["SoftwareApplication", "SoftwareSourceCode"],
+      applicationCategory: "DeveloperApplication",
+      codeRepository: "https://github.com/wevm/mppx",
+      description:
+        "TypeScript SDK for clients and servers that use the Machine Payments Protocol.",
+      name: "mppx",
+      offers: {
+        "@type": "Offer",
+        price: 0,
+        priceCurrency: "USD",
+      },
+      operatingSystem: "Any",
+      url: "https://mpp.dev/sdk/typescript/",
+    },
+  ],
+} as const;
 
 export default function HomePage() {
   return (
@@ -11,6 +51,7 @@ export default function HomePage() {
         path="/"
         title="Machine Payments Protocol"
       />
+      <StructuredData data={homepageStructuredData} />
       <LandingPage />
       <Footer />
     </>

--- a/src/pages/mpp-vs-x402.mdx
+++ b/src/pages/mpp-vs-x402.mdx
@@ -1,44 +1,42 @@
 ---
 description: "Compare MPP vs x402 for HTTP 402 payments. Learn the protocol differences, supported payment methods, session support, and when to choose each approach."
 imageDescription: "MPP vs x402 comparison"
+title: "MPP vs x402: Agentic payment protocols compared"
 ---
 
 import { Card, Cards } from 'vocs'
 
 # MPP vs x402 [How the two HTTP 402 payment protocols compare]
 
-MPP and x402 both use HTTP `402 Payment Required` to charge for API requests. They solve the same core problem, but they operate at different levels of scope.
+MPP and x402 both use HTTP `402 Payment Required` to charge for API requests. x402 focuses on on-chain payment mechanisms. MPP defines a payment-method-agnostic HTTP authentication framework for stablecoins, cards, Lightning, and other payment rails.
 
-x402 focuses on on-chain stablecoin payments. MPP uses the same `402` pattern, but broadens it to support stablecoins, cards, Lightning, and session-based billing for high-frequency usage.
+You can run both protocols on the same endpoint with `mppx`, so adopting MPP doesn't require you to exclude x402 clients.
 
 ## Quick answer
 
-Choose **MPP** by default. It is the stronger choice for real APIs, real agent workflows, and real payment volume.
+Choose **MPP** by default when you need multiple payment rails, standard HTTP authentication semantics, or a protocol-level model for one-time and session payments.
 
-Choose **x402** only if you explicitly want a narrow on-chain paywall for one-off requests.
+Choose **x402** when your service exclusively needs on-chain payments and its registered schemes match your billing model.
 
 ## Side-by-side comparison
 
 | | x402 | MPP |
 |---|---|---|
-| **Core model** | Stablecoin payment attached to a request | General payment protocol for machine-to-machine payments |
+| **Core model** | On-chain payment schemes attached to requests | Payment authentication framework for machine-to-machine payments |
 | **HTTP status** | `402 Payment Required` | `402 Payment Required` |
 | **Challenge header** | `PAYMENT-REQUIRED` | `WWW-Authenticate: Payment` |
 | **Credential header** | `PAYMENT-SIGNATURE` | `Authorization: Payment` |
 | **Receipt header** | `PAYMENT-RESPONSE` | `Payment-Receipt` |
-| **Payment methods** | Blockchain-based methods | Stablecoins, cards, Lightning, wallets, and custom methods |
-| **Sessions / streaming** | No native session flow | Yes—session intent for pay-as-you-go billing |
-| **Request binding** | Narrower | First-class Challenge binding and request digest support |
-| **Error format** | Implementation-specific | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
-| **Standards path** | Project-specific | Built around the [Payment HTTP Authentication Scheme](https://paymentauth.org) |
+| **Payment rails** | Registered blockchain network mechanisms | Stablecoins, cards, Lightning, and custom methods |
+| **Usage-based billing** | `upto` and EVM `batch-settlement` schemes | Payment-method intents, including `session` |
+| **Request binding** | Depends on the scheme and extensions | Core Challenge binding and request digest support |
+| **Idempotency** | Optional Payment Identifier extension | Challenge identity plus standard `Idempotency-Key` guidance |
+| **Error model** | Protocol-specific responses | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
+| **Standards path** | x402 Foundation specification | [Payment HTTP Authentication Scheme](https://paymentauth.org) submitted to the IETF |
 
 ## The biggest difference
 
-The most important distinction is payment scope.
-
-MPP is the better choice for almost every serious implementation.
-
-x402 fits the narrower case where you only want an on-chain flow for one-time payments.
+The most important distinction is scope. x402 registers payment schemes for blockchain networks. MPP standardizes how any payment method negotiates a payment through HTTP authentication.
 
 MPP supports the broader model most teams actually need. An MPP Challenge can describe:
 
@@ -47,11 +45,11 @@ MPP supports the broader model most teams actually need. An MPP Challenge can de
 - expiration and idempotency constraints
 - request binding so the payment is tied to the exact request
 
-That makes MPP the right choice for production APIs, coding agents, and services that want broader payment support.
+That makes MPP the recommended choice for APIs and agents that need to evolve beyond one payment rail. It also lets HTTP infrastructure handle payment Credentials through the same authentication fields it already understands.
 
 ## Payment methods
 
-x402 focuses on on-chain payments. That's useful if your users already have wallets and you're optimizing around an on-chain payment flow.
+x402 focuses on on-chain payments across registered networks and schemes. That's useful when your clients already have compatible wallets and your service wants blockchain settlement.
 
 MPP keeps the same stablecoin path, but it also supports non-stablecoin methods. A single endpoint can advertise:
 
@@ -60,17 +58,15 @@ MPP keeps the same stablecoin path, but it also supports non-stablecoin methods.
 - [Lightning payments](/payment-methods/lightning)
 - [custom payment methods](/payment-methods/custom)
 
-This matters if you want to serve both agents and human-operated apps, or if you don't want your API monetization strategy tied to a single settlement rail.
+This matters if you want to serve agents and human-operated apps, or if you don't want your API monetization strategy tied to blockchain settlement.
 
 ## Sessions and micropayments
 
-This is where the gap gets large.
+x402 supports fixed-price `exact`, usage-based `upto`, and EVM `batch-settlement` schemes. Batch settlement funds a channel and uses off-chain vouchers for repeated requests. See the [x402 payment schemes](https://docs.x402.org/getting-started/quickstart-for-sellers#payment-schemes-exact-upto-and-batch-settlement).
 
-x402 works well for one-off purchases. It does not define a native session model for repeated low-value requests. If you charge on every request, every request carries payment overhead.
+MPP defines session billing as a payment intent within the same Challenge–Credential–Receipt framework used by other payment methods. A client funds a session, sends signed off-chain vouchers per request, and lets the server settle the net result later. That makes [micropayments](/use-cases/micropayments), streaming APIs, and token-metered usage practical without changing the HTTP authentication model.
 
-MPP adds a session intent for pay-as-you-go billing. A client can fund a session once, send signed off-chain vouchers per request, and let the server settle the net result later. That makes [micropayments](/use-cases/micropayments), streaming APIs, and token-metered usage practical.
-
-For low-volume one-off stablecoin payments, x402 can work. For search, inference, feeds, MCP tools, or any high-frequency tool call pattern, use MPP.
+Use MPP when you want one client and server interface across session and one-time payments or across different payment rails. Use x402 batch settlement when its supported EVM networks and on-chain model match your deployment.
 
 ## Compatibility
 
@@ -88,14 +84,14 @@ Choose **MPP** if:
 - you want multiple payment methods on one endpoint
 - you need sessions, streaming, or micropayments
 - you want standard `WWW-Authenticate` / `Authorization` semantics
-- you want a cleaner path from developer tool to production payment system
+- you want one HTTP authentication model across payment rails and intents
 
-Choose **x402** only if:
+Choose **x402** if:
 
-- you only need stablecoin payments
-- you want an on-chain payment flow
-- your API charges once per request
-- you want the narrowest possible protocol surface
+- you exclusively want on-chain payments
+- your clients use x402-compatible wallets and schemes
+- `exact`, `upto`, or EVM `batch-settlement` matches your billing model
+- you want to use the x402 facilitator and extension ecosystem directly
 
 ## Next steps
 

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -1,16 +1,17 @@
 ---
 description: "MPP standardizes HTTP 402 for machine-to-machine payments. Learn how agents, apps, and services exchange payments in the same HTTP request."
 imageDescription: "The open protocol for machine-to-machine payments"
+title: "What is MPP? Machine-to-machine HTTP 402 payments"
 ---
 
-import { Cards } from 'vocs'
+import { Card, Cards } from 'vocs'
 import { SpecCard } from '../components/SpecCard'
 import { TerminalPing } from '../components/TerminalPing'
 import { TypeScriptSdkCard, PythonSdkCard, RustSdkCard, GoSdkCard, QuickstartCard, ProtocolConceptsCard } from '../components/cards'
 import { PaymentFlowDiagram } from '../components/PaymentFlowDiagram'
 
 
-# Machine Payments Protocol [The open protocol for machine-to-machine payments]
+# What is MPP? [Machine-to-machine payments over HTTP 402]
 
 The Machine Payments Protocol (MPP) lets any client—agents, apps, or humans—pay for any service in the same HTTP request. Developers use MPP to let their agents pay for services. Service operators use MPP to accept payments for their APIs.
 
@@ -74,6 +75,7 @@ MPP comes with a suite of official SDKs maintained by [Tempo Labs](https://tempo
 ## Next steps
 
 <Cards>
+  <Card title="MPP vs x402" description="Compare HTTP 402 payment protocols" to="/mpp-vs-x402" />
   <QuickstartCard />
   <ProtocolConceptsCard />
   <SpecCard to="https://paymentauth.org" />

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -12,6 +12,8 @@ The Machine Payments Protocol (MPP) is a protocol for machine-to-machine payment
 
 These docs provide a developer-friendly overview. For the full specification, see the full [IETF Specification](https://paymentauth.org).
 
+If you're evaluating HTTP payment protocols, compare [MPP vs x402](/mpp-vs-x402).
+
 ## Flow
 
 <PaymentFlowDiagram />

--- a/src/pages/services.mdx
+++ b/src/pages/services.mdx
@@ -1,7 +1,7 @@
 ---
 description: "Browse live MPP-enabled services that accept machine-to-machine payments. Discover APIs you can pay for with stablecoins, cards, or Bitcoin."
 layout: minimal
-title: "Services"
+title: "MPP services: APIs that accept MPP payments"
 showAskAi: false
 showOutline: false
 showSearch: false

--- a/src/pages/services.tsx
+++ b/src/pages/services.tsx
@@ -1,18 +1,44 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { MarketingHead } from "../components/MarketingHead";
 import { Footer } from "../components/marketing/Footer";
 import { ServicesAgentDiscovery } from "../components/ServicesAgentDiscovery";
 import { ServicesPage } from "../components/ServicesPage";
+import type { Service } from "../data/registry";
 
-export default function ServicesRoute() {
+async function loadServices(): Promise<Service[]> {
+  const catalog = JSON.parse(
+    await readFile(
+      resolve(process.cwd(), "public/services/catalog.json"),
+      "utf8",
+    ),
+  ) as { services: Service[] };
+  return catalog.services.map((service) => ({
+    categories: service.categories,
+    description: service.description,
+    docs: service.docs,
+    endpoints: [],
+    id: service.id,
+    methods: {},
+    name: service.name,
+    provider: service.provider,
+    serviceUrl: service.serviceUrl,
+    url: service.url,
+  }));
+}
+
+export default async function ServicesRoute() {
+  const services = await loadServices();
+
   return (
     <>
       <MarketingHead
         description="Browse live MPP-enabled services that accept machine-to-machine payments. Discover APIs you can pay for with stablecoins, cards, or Bitcoin."
         imageDescription="Browse live APIs that accept machine payments"
         path="/services"
-        title="Services"
+        title="MPP services: APIs that accept MPP payments"
       />
-      <ServicesPage />
+      <ServicesPage initialServices={services} />
       <ServicesAgentDiscovery />
       <Footer />
     </>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import { defineConfig, loadEnv } from "vite";
 import mkcert from "vite-plugin-mkcert";
 import { configDefaults } from "vitest/config";
 import { vocs } from "vocs/vite";
+import { assertSitemapXml, pruneSitemapXml } from "./scripts/sitemap.js";
 import { blogContent } from "./scripts/vite-blog.js";
 
 const commitSha = child_process
@@ -131,10 +132,8 @@ function pruneSitemap(): Plugin {
       });
       if (!current) return;
 
-      const next = current.replace(
-        /\s*<url>\s*<loc>[^<]*\/404<\/loc>\s*<lastmod>[^<]+<\/lastmod>\s*<\/url>/,
-        "",
-      );
+      const next = pruneSitemapXml(current);
+      assertSitemapXml(next);
 
       if (next !== current) await fs.writeFile(sitemapPath, next, "utf8");
     },


### PR DESCRIPTION
## Motivation

Improve crawlability, search intent differentiation, and protocol positioning across the marketing and documentation pages.

## Summary

- add distinct titles and semantic heading hierarchies for overview, services, and blog pages
- pre-render crawlable service summaries while retaining client-side catalog behavior
- add homepage and FAQ JSON-LD
- deduplicate sitemap URLs and reject invalid generated sitemaps
- update and internally link the MPP vs x402 comparison

## Key design considerations

- retain paired TSX and MDX marketing routes for designed pages and semantic Markdown output
- keep structured data aligned with visible page content and model `mppx` separately from the protocol
- seed service summaries without embedding the full endpoint catalog in initial HTML