### PR TITLE
docs: fix audited MPP documentation

### DIFF
--- a/.github/actions/sdk-drift-check/check-sdk-drift.test.ts
+++ b/.github/actions/sdk-drift-check/check-sdk-drift.test.ts
@@ -158,6 +158,20 @@ describe("parseLink", () => {
       });
     });
 
+    it("maps client Mppx instance methods as docs-only", () => {
+      const result = parseLink(
+        "/sdk/typescript/client/Mppx.preparePayment",
+        prefix,
+      );
+      expect(result).toEqual<SidebarReference>({
+        link: "/sdk/typescript/client/Mppx.preparePayment",
+        area: "client",
+        namespace: "Mppx",
+        member: "preparePayment",
+        docsOnly: true,
+      });
+    });
+
     it("maps Html docs to the html entrypoint", () => {
       const result = parseLink("/sdk/typescript/Html.init", prefix);
       expect(result).toEqual<SidebarReference>({

--- a/.github/actions/sdk-drift-check/check-sdk-drift.ts
+++ b/.github/actions/sdk-drift-check/check-sdk-drift.ts
@@ -291,6 +291,16 @@ export function parseLink(
     };
   }
 
+  if (area === "client" && symbolPart === "Mppx.preparePayment") {
+    return {
+      link,
+      area,
+      namespace: "Mppx",
+      member: "preparePayment",
+      docsOnly: true,
+    };
+  }
+
   if (area === "server" && symbolPart === "Ws.serve") {
     return {
       link,

--- a/src/pages/guides/monetize-mcp-server.mdx
+++ b/src/pages/guides/monetize-mcp-server.mdx
@@ -181,8 +181,9 @@ Three lines turn a free tool into a paid one:
 ### Test with the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create and fund a testnet account
+$ npx mppx account create --network testnet
+$ npx mppx account fund --network testnet
 
 # Start the server and call the tool
 $ echo '{"method":"tools/call","params":{"name":"search","arguments":{"query":"hello"}}}' | node server.ts

--- a/src/pages/guides/multiple-payment-methods.mdx
+++ b/src/pages/guides/multiple-payment-methods.mdx
@@ -161,8 +161,9 @@ The `mppx` CLI uses Tempo by default. Each payment method has its own client SDK
 # Validate the paid route
 $ npx mppx validate http://localhost:3000
 
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create and fund a testnet account
+$ npx mppx account create --network testnet
+$ npx mppx account fund --network testnet
 
 # Make a paid request (pays with Tempo)
 $ npx mppx http://localhost:3000

--- a/src/pages/guides/one-time-payments.mdx
+++ b/src/pages/guides/one-time-payments.mdx
@@ -132,8 +132,9 @@ export const GET =
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create and fund a testnet account
+$ npx mppx account create --network testnet
+$ npx mppx account fund --network testnet
 
 # Make a paid request
 $ npx mppx http://localhost:3000/api/photo 
@@ -245,8 +246,9 @@ app.get(
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create and fund a testnet account
+$ npx mppx account create --network testnet
+$ npx mppx account fund --network testnet
 
 # Make a paid request
 $ npx mppx http://localhost:3000/api/photo 
@@ -355,8 +357,9 @@ export default {
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create and fund a testnet account
+$ npx mppx account create --network testnet
+$ npx mppx account fund --network testnet
 
 # Make a paid request
 $ npx mppx http://localhost:8787 
@@ -468,8 +471,9 @@ app.get(
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create and fund a testnet account
+$ npx mppx account create --network testnet
+$ npx mppx account fund --network testnet
 
 # Make a paid request
 $ npx mppx http://localhost:3000/api/photo 
@@ -583,8 +587,9 @@ Bun.serve({
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create and fund a testnet account
+$ npx mppx account create --network testnet
+$ npx mppx account fund --network testnet
 
 # Make a paid request
 $ npx mppx http://localhost:3000

--- a/src/pages/guides/pay-as-you-go.mdx
+++ b/src/pages/guides/pay-as-you-go.mdx
@@ -160,8 +160,8 @@ export const GET =
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Make a paid request
 $ npx mppx http://localhost:3000/api/sessions/photo 
@@ -290,8 +290,8 @@ app.get(
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Make a paid request
 $ npx mppx http://localhost:3000/api/sessions/photo 
@@ -414,8 +414,8 @@ export default {
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Make a paid request
 $ npx mppx http://localhost:8787 
@@ -544,8 +544,8 @@ app.get(
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Make a paid request
 $ npx mppx http://localhost:3000/api/sessions/photo 
@@ -673,8 +673,8 @@ Bun.serve({
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Make a paid request
 $ npx mppx http://localhost:3000

--- a/src/pages/guides/proxy-existing-service.mdx
+++ b/src/pages/guides/proxy-existing-service.mdx
@@ -163,8 +163,8 @@ export default { fetch: proxy.fetch }
 # Validate the paid route
 $ npx mppx validate http://localhost:3000
 
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Free route — no payment required
 $ npx mppx http://localhost:3000/weather/v1/status

--- a/src/pages/guides/streamed-payments.mdx
+++ b/src/pages/guides/streamed-payments.mdx
@@ -149,8 +149,8 @@ export const GET = mppx.session({ amount: "0.001", unitType: "word" })(
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Stream a paid poem
 $ npx mppx http://localhost:3000/api/sessions/poem
@@ -266,8 +266,8 @@ app.get(
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Stream a paid poem
 $ npx mppx http://localhost:3000/api/sessions/poem
@@ -380,8 +380,8 @@ export default {
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Stream a paid poem
 $ npx mppx http://localhost:8787
@@ -497,8 +497,8 @@ app.get(
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Stream a paid poem
 $ npx mppx http://localhost:3000/api/sessions/poem
@@ -616,8 +616,8 @@ Bun.serve({
 ### Test via the `mppx` CLI
 
 ```bash [terminal]
-# Create account funded with testnet tokens
-$ npx mppx account create
+# Create a mainnet account, then fund it with pathUSD
+$ npx mppx account create --network mainnet
 
 # Stream a paid poem
 $ npx mppx http://localhost:3000

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -357,12 +357,17 @@ Set `testnet: true` in `tempo.charge()` while testing so `npx mppx validate` and
 You can also test each step individually:
 
 ```bash [terminal]
-# Create an account funded with testnet tokens
-$ npx mppx account create
+# Create and fund a testnet account
+$ npx mppx account create --network testnet
+$ npx mppx account fund --network testnet
 
 # Make a paid request
 $ npx mppx <your-server>/resource
 ```
+
+:::tip
+Use `curl -i <your-server>/resource` to inspect the server's `402` Challenge without paying. To validate the returned header, run `npx mppx sign --challenge '<WWW-Authenticate value>' --dry-run`.
+:::
 
 ## Next steps
 

--- a/src/pages/sdk/typescript/client/Fetch.from.mdx
+++ b/src/pages/sdk/typescript/client/Fetch.from.mdx
@@ -157,3 +157,16 @@ Array of payment methods to use for `402` responses.
 - **Type:** `(challenge, helpers) => Promise<string | undefined>`
 
 Called after a `402` Challenge is selected and before the wrapper retries the request. Return a Credential string to override the default Credential flow.
+
+### orderChallenges (optional)
+
+- **Type:** `(challenges: readonly Challenge[]) => readonly Challenge[]`
+
+Filters or reorders supported Challenges before Credential creation.
+
+### transport (optional)
+
+- **Type:** `Transport.AnyTransport`
+- **Default:** `Transport.http()`
+
+Transport used to extract Challenges and attach Credentials.

--- a/src/pages/sdk/typescript/client/Fetch.polyfill.mdx
+++ b/src/pages/sdk/typescript/client/Fetch.polyfill.mdx
@@ -150,3 +150,16 @@ Array of payment methods to use for `402` responses.
 - **Type:** `(challenge, helpers) => Promise<string | undefined>`
 
 Called after a `402` Challenge is selected and before the wrapper retries the request.
+
+### orderChallenges (optional)
+
+- **Type:** `(challenges: readonly Challenge[]) => readonly Challenge[]`
+
+Filters or reorders supported Challenges before Credential creation.
+
+### transport (optional)
+
+- **Type:** `Transport.AnyTransport`
+- **Default:** `Transport.http()`
+
+Transport used to extract Challenges and attach Credentials.

--- a/src/pages/sdk/typescript/client/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/client/Mppx.create.mdx
@@ -710,6 +710,12 @@ const mppx = Mppx.create({
 </Tab>
 </Tabs>
 
+### orderChallenges (optional)
+
+- **Type:** `(challenges: readonly Challenge[]) => readonly Challenge[]`
+
+Filters or reorders supported Challenges before Credential creation. It applies to automatic fetch handling and manual `createCredential` calls unless you pass a request-local override.
+
 ### paymentPreferences (optional)
 
 - **Type:** `AcceptPayment.Config<methods>`
@@ -925,6 +931,12 @@ Request-local Challenge filter or sort order for `preparePayment` and `createCre
 - **Type:** `RequestInit`
 
 Original request passed to Challenge extraction. Include this for transports that inspect both request and response, including MCP-over-HTTP.
+
+### createCredential.orderChallenges (optional)
+
+- **Type:** `(challenges: readonly Challenge[]) => readonly Challenge[]`
+
+Request-local Challenge filter or ordering override for `mppx.createCredential(response, context, options)`.
 
 ### transport (optional)
 

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -459,17 +459,17 @@ The `mppx` package install automatically includes a [CLI tool](/sdk/typescript/c
 
 ### Create an account
 
-Create a Tempo account to sign payments. The account is auto-funded on testnet and key is stored in your system keychain.
+Create a Tempo mainnet account to sign payments. The key is stored in your system keychain. Fund the account with pathUSD before making a paid request.
 
 :::code-group
 ```bash [npm]
-$ npx mppx account create
+$ npx mppx account create --network mainnet
 ```
 ```bash [pnpm]
-$ pnpm mppx account create
+$ pnpm mppx account create --network mainnet
 ```
 ```bash [bun]
-$ bunx mppx account create
+$ bunx mppx account create --network mainnet
 ```
 :::
 

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -207,6 +207,12 @@ type ReturnType = (request: Request) => Promise<
 
 These parameters configure the `tempo.charge()` constructor.
 
+### account (optional)
+
+- **Type:** `Account | Address`
+
+Account or address that receives payments. Use `recipient` when you only need to provide the address.
+
 ### canOffer (optional)
 
 - **Type:** `Method.CanOfferFn`
@@ -269,6 +275,12 @@ const mppx = Mppx.create({
 
 Function that returns a viem client for the given chain ID. Overrides the default RPC configuration.
 
+### html (optional)
+
+- **Type:** `boolean | Html.Config`
+
+Renders a payment page when the request accepts `text/html`. Pass an object to customize the page.
+
 ### machineTokenEnabled (optional)
 
 - **Type:** `boolean`
@@ -317,11 +329,23 @@ For non-zero charges, `mppx` falls back to an in-memory store when you omit this
 
 Use `Store.memory()` for local development, tests, or a single long-lived server process. For multi-instance deployments, use `Store.redis()`, `Store.upstash()`, or `Store.cloudflare()`. All built-in factories return `AtomicStore`—for custom backends, provide an `update` function alongside `get`, `put`, and `delete`.
 
+### storeKeyPrefix (optional)
+
+- **Type:** `string`
+
+Prefix prepended to replay-protection keys. Use distinct prefixes when multiple applications share one store.
+
 ### testnet (optional)
 
 - **Type:** `boolean`
 
 Testnet mode. Defaults the chain ID to `42431` (Tempo testnet).
+
+### validateSender (optional)
+
+- **Type:** `(parameters: { expectedSender: Address; sender: Address; source?: { address: Address; chainId: number } }) => boolean | Promise<boolean>`
+
+Allows a verified TIP-20 transfer sender to differ from the Credential source. Core verification still checks the amount, currency, memo, recipient, replay state, and transaction success.
 
 ### waitForConfirmation (optional)
 

--- a/src/pages/sdk/typescript/server/Method.tempo.renewSubscription.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.renewSubscription.mdx
@@ -68,6 +68,12 @@ type ReturnType = Promise<
 
 ## Parameters
 
+### feePayerPolicy (optional)
+
+- **Type:** `Partial<FeePayer.Policy>`
+
+Overrides the fee-sponsor limits used for the renewal transaction.
+
 ### getClient (optional)
 
 - **Type:** `(parameters: { chainId?: number }) => MaybePromise<Client>`

--- a/src/pages/sdk/typescript/server/Method.tempo.subscription.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.subscription.mdx
@@ -171,6 +171,12 @@ Returns the access key to include in the Challenge. Omit this for the recommende
 
 Account used as the default `recipient` and local transaction signer.
 
+### activate (optional)
+
+- **Type:** `(parameters: ActivationParameters) => Promise<ActivationResult>`
+
+Custom activation hook. It must verify that the access key matches the resolved subscription and return the activated subscription with its Receipt.
+
 ### activationTimeoutMs (optional)
 
 - **Type:** `number`
@@ -221,6 +227,12 @@ Human-readable subscription description.
 
 Application-defined identifier for reconciliation.
 
+### feePayerPolicy (optional)
+
+- **Type:** `Partial<FeePayer.Policy>`
+
+Overrides the fee-sponsor limits used for subscription activation and renewal transactions.
+
 ### getClient (optional)
 
 - **Type:** `(parameters: { chainId?: number }) => MaybePromise<Client>`
@@ -247,9 +259,9 @@ Number of period units per billing period.
 
 ### periodUnit (optional)
 
-- **Type:** `'day' | 'week'`
+- **Type:** `'day' | 'dev_second' | 'week'`
 
-Billing period unit.
+Billing period unit. Use `dev_second` only for development and tests.
 
 ### recipient (optional)
 
@@ -288,6 +300,12 @@ Maps a request to a subscription lookup key. With `requireCredential`, use `sour
 - **Default:** `Store.memory()`
 
 Atomic store for access keys, activation locks, renewal locks, and subscription records. Use [`Subscription.fromStore`](/payment-methods/tempo/subscription#cancellation) from `mppx/tempo` when you need to update subscription records directly, such as marking `canceledAt`.
+
+### storeKeyPrefix (optional)
+
+- **Type:** `string`
+
+Prefix prepended to all subscription store keys. Use distinct prefixes when multiple applications share one store.
 
 ### subscriptionExpires (optional)
 

--- a/src/pages/tools/wallet.mdx
+++ b/src/pages/tools/wallet.mdx
@@ -362,7 +362,7 @@ $ mppx https://mpp.dev/api/ping/paid
 
 **Key features:**
 
-- **Zero config**—create an account and start making paid requests immediately
+- **Built-in account management**—create a local account, fund it, and use it for paid requests
 - **Custom payment methods**—load additional client methods or CLI plugins from `mppx.config.ts`, `mppx.config.mjs`, or `mppx.config.js`
 - **Local keychain**—private keys stored in the OS keychain, configurable via `MPPX_PRIVATE_KEY` env var
 - **Development-first**—designed for testing and debugging MPP integrations


### PR DESCRIPTION
## Motivation

Correct documentation drift found across account funding flows, CLI debugging guidance, and TypeScript API references.

## Summary

- clarify mainnet and testnet account creation and funding commands
- replace the removed inspect flag with supported Challenge inspection commands
- document omitted Fetch, Mppx, and Tempo method parameters
- recognize documented Mppx instance methods in the SDK drift checker

## Key design considerations

- keep default server examples on Tempo mainnet and use explicit network flags for testnet examples
- validate instance-method pages by page existence because module runtime exports do not expose returned-object methods