### PR TITLE
ci(dependabot): approve and merge updates via github-sts

### DIFF
--- a/.github/sts/dependabot.sts.yaml
+++ b/.github/sts/dependabot.sts.yaml
@@ -1,0 +1,18 @@
+# Allow the Dependabot auto-merge workflow (pull_request_target, which runs
+# the workflow as it exists on main) to mint a short-lived token that
+# approves and squash-merges Dependabot's patch/minor update PRs through the
+# shared tempoxyz/mpp-tools dependabot reusable workflow. Replaces the
+# built-in GITHUB_TOKEN so the org can turn off "Allow GitHub Actions to
+# create and approve pull requests".
+#
+# The claim checks narrow the grant: the run must have been triggered by
+# dependabot[bot] (a human pushing to the PR branch becomes the actor and is
+# denied) and must mint through the shared reusable workflow.
+subject: repo:tempoxyz@211589300/mpp@1144842521:ref:refs/heads/main
+claim_pattern:
+  actor: dependabot\[bot\]
+  actor_id: "49699333"
+  job_workflow_ref: tempoxyz/mpp-tools/\.github/workflows/dependabot\.yml@.+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -9,8 +9,15 @@ permissions: {}
 jobs:
   merge:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    # The called workflow approves and merges with a short-lived GitHub App
+    # token minted via the github-sts action against this repo's
+    # .github/sts/dependabot.sts.yaml policy; the built-in GITHUB_TOKEN is
+    # not allowed to approve pull requests and only needs read scopes.
+    # id-token lets the called job request the OIDC token the STS exchange
+    # verifies.
     permissions:
       checks: read
-      contents: write
-      pull-requests: write
-    uses: tempoxyz/mpp-tools/.github/workflows/dependabot.yml@1d20c6f032568c0aea39c0e7e57e4ba350516281
+      contents: read
+      pull-requests: read
+      id-token: write
+    uses: tempoxyz/mpp-tools/.github/workflows/dependabot.yml@77de41d7ae6e215290f31ac1f0782f545ee07e5d


### PR DESCRIPTION
## Motivation

We are disabling the org-level **"Allow GitHub Actions to create and approve pull requests"** setting, after which the built-in `GITHUB_TOKEN` can no longer open or approve pull requests. This repo's Dependabot auto-merge calls the shared [`tempoxyz/mpp-tools` dependabot reusable workflow](https://github.com/tempoxyz/mpp-tools/blob/main/.github/workflows/dependabot.yml), and at runtime its approve/merge steps ran on **this repo's** built-in token.

Follow-up to tempoxyz/mpp-tools#195, which migrated the reusable workflow to mint a short-lived GitHub App token via the `tempoxyz/gh-actions/actions/github-sts` action, scoped by a trust policy in the repository the workflow runs against.

## Changes

- Bump the reusable-workflow pin to `77de41d7` — the migrated revision, current `mpp-tools` main.
- Grant the calling job `checks: read`, `contents: read`, `pull-requests: read`, `id-token: write` in place of the old write scopes; the approve and merge now happen with the STS-minted token.
- Add `.github/sts/dependabot.sts.yaml`, narrowed so only runs triggered by `dependabot[bot]` that mint through the shared reusable workflow are granted `contents: write` + `pull_requests: write`.

## Things to verify before flipping the org setting (same as tempoxyz/mpp-tools#195)

1. **Dependabot-triggered runs and OIDC**: Dependabot-actor runs are permission-restricted; confirm such a run can obtain an OIDC token with `id-token: write` before relying on the new path.
2. **Verified-human review requirements**: the STS App's approval posts fine but will not satisfy a ruleset that requires verified-human reviews — confirm what auto-merge is meant to satisfy here.
3. Requires the Tempo GitHub STS App to be installed on this repository.
