### PR TITLE
docs: sync mppx APIs through 4e4810a

### DIFF
--- a/.mppx-docs-sync
+++ b/.mppx-docs-sync
@@ -5,5 +5,5 @@
 # When updating docs from mppx changes, bump this SHA to HEAD of mppx main
 # after incorporating the new features/changes into the docs site.
 
-mppx_version=0.0.0-main-20260821193729
-mppx_sha=d343aae71a6e4961551489f6a05153391a42e941
+mppx_version=https://pkg.pr.new/mppx@4e4810a
+mppx_sha=4e4810a0f33dc0a5a71c4ae70b9b05761be8f60b

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "hono": "^4.12.27",
     "lottie-web": "^5.13.0",
     "mermaid": "^11.15.0",
-    "mppx": "0.0.0-main-20260821193729",
+    "mppx": "https://pkg.pr.new/mppx@4e4810a",
     "nuqs": "2.9.1",
     "react": "^19",
     "react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       mppx:
-        specifier: 0.0.0-main-20260821193729
-        version: 0.0.0-main-20260821193729(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
+        specifier: https://pkg.pr.new/mppx@4e4810a
+        version: https://pkg.pr.new/mppx@4e4810a(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
       nuqs:
         specifier: 2.9.1
         version: 2.9.1(react@19.2.7)
@@ -4099,25 +4099,6 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  mppx@0.0.0-main-20260821193729:
-    resolution: {integrity: sha512-RqNrv7fGuMqsztF8k1RHchSKqRb6pmgbZMbUtwu2mVfmluno586Lv1glwoBS2F6vPubaamjPneCp+4yPfWiqOg==}
-    hasBin: true
-    peerDependencies:
-      '@modelcontextprotocol/sdk': '>=1.25.0'
-      elysia: '>=1'
-      express: '>=5'
-      hono: '>=4.12.25'
-      viem: '>=2.54.0'
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-      elysia:
-        optional: true
-      express:
-        optional: true
-      hono:
-        optional: true
-
   mppx@0.7.0:
     resolution: {integrity: sha512-qOHQjD75wSHSZeXutngPXou8NEMIOw6RhZ/lQbo2JmDQWfOi40pLGpqXgHgwIjw4YcJHClFsI7mFXBK3Nj5WCQ==}
     hasBin: true
@@ -4135,6 +4116,44 @@ packages:
       express:
         optional: true
       hono:
+        optional: true
+
+  mppx@https://pkg.pr.new/mppx@4e4810a:
+    resolution: {tarball: https://pkg.pr.new/mppx@4e4810a}
+    version: 0.8.19
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.25.0'
+      '@x402/core': '>=2.22.0'
+      '@x402/express': '>=2.22.0'
+      '@x402/hono': '>=2.22.0'
+      '@x402/mcp': '>=2.22.0'
+      '@x402/next': '>=2.22.0'
+      elysia: '>=1'
+      express: '>=5'
+      hono: '>=4.12.25'
+      next: '>=16.2.6'
+      viem: '>=2.54.0'
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+      '@x402/core':
+        optional: true
+      '@x402/express':
+        optional: true
+      '@x402/hono':
+        optional: true
+      '@x402/mcp':
+        optional: true
+      '@x402/next':
+        optional: true
+      elysia:
+        optional: true
+      express:
+        optional: true
+      hono:
+        optional: true
+      next:
         optional: true
 
   ms@2.1.3:
@@ -9706,12 +9725,11 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.0.0-main-20260821193729(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
-      '@stripe/stripe-js': 9.13.0
-      eventsource-parser: 3.1.1
+      '@stripe/stripe-js': 9.7.0
+      incur: 0.4.26
       ox: 0.14.33(typescript@6.0.3)(zod@4.4.3)
-      structured-headers: 2.0.3
       viem: 2.54.0(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -9721,11 +9739,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@https://pkg.pr.new/mppx@4e4810a(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
-      '@stripe/stripe-js': 9.7.0
-      incur: 0.4.26
+      '@stripe/stripe-js': 9.13.0
+      eventsource-parser: 3.1.1
       ox: 0.14.33(typescript@6.0.3)(zod@4.4.3)
+      structured-headers: 2.0.3
       viem: 2.54.0(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:

--- a/src/pages.gen.ts
+++ b/src/pages.gen.ts
@@ -135,6 +135,7 @@ type Page =
   | { path: '/sdk/typescript/client/Transport.mcp'; render: 'static' }
   | { path: '/sdk/typescript/core/BodyDigest.compute'; render: 'static' }
   | { path: '/sdk/typescript/core/BodyDigest.verify'; render: 'static' }
+  | { path: '/sdk/typescript/core/Challenge.credentialHeader'; render: 'static' }
   | { path: '/sdk/typescript/core/Challenge.deserialize'; render: 'static' }
   | { path: '/sdk/typescript/core/Challenge.from'; render: 'static' }
   | { path: '/sdk/typescript/core/Challenge.fromHeaders'; render: 'static' }
@@ -192,6 +193,10 @@ type Page =
   | { path: '/sdk/typescript/server/Transport.mcp'; render: 'static' }
   | { path: '/sdk/typescript/server/Transport.mcpSdk'; render: 'static' }
   | { path: '/sdk/typescript/server/Ws.serve'; render: 'static' }
+  | { path: '/sdk/typescript/x402/express'; render: 'static' }
+  | { path: '/sdk/typescript/x402/hono'; render: 'static' }
+  | { path: '/sdk/typescript/x402/mcp'; render: 'static' }
+  | { path: '/sdk/typescript/x402/next'; render: 'static' }
   | { path: '/services'; render: 'static' }
   | { path: '/tools/wallet'; render: 'static' }
   | { path: '/use-cases/agentic-payments'; render: 'static' }

--- a/src/pages/advanced/security.mdx
+++ b/src/pages/advanced/security.mdx
@@ -28,6 +28,7 @@ Do not log:
 
 - `MPP_SECRET_KEY`
 - `Authorization: Payment` headers
+- `Payment-Authorization: Payment` headers
 - `Payment-Receipt` headers
 
 Keep them out of error messages, debugging output, analytics, traces, and support logs. If you need observability, log stable metadata such as request IDs, Challenge IDs, status codes, or payment method names instead.
@@ -38,7 +39,7 @@ Treat reverse proxies, CDNs, API gateways, and observability pipelines as part o
 
 - Send `Cache-Control: no-store` with `402` responses so intermediaries do not cache Challenges.
 - Send `Cache-Control: private` on successful responses that include `Payment-Receipt`.
-- Redact `Authorization: Payment` and `Payment-Receipt` headers in proxy logs, trace exporters, and edge analytics.
+- Redact `Authorization: Payment`, `Payment-Authorization: Payment`, and `Payment-Receipt` headers in proxy logs, trace exporters, and edge analytics.
 - Do not rely on intermediary-specific `402` handling—verify that your deployment forwards `WWW-Authenticate` headers correctly.
 
 ## Bind paid requests to the actual request

--- a/src/pages/guides/use-mpp-with-x402.mdx
+++ b/src/pages/guides/use-mpp-with-x402.mdx
@@ -18,7 +18,7 @@ See [MPP vs x402](/mpp-vs-x402) for a full comparison.
 | | x402 | MPP |
 |---|---|---|
 | **Challenge** | `PAYMENT-REQUIRED` header | `WWW-Authenticate: Payment` header |
-| **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` header |
+| **Credential** | `PAYMENT-SIGNATURE` header | `Authorization: Payment` or an advertised alternate field |
 | **Receipt** | `PAYMENT-RESPONSE` header | `Payment-Receipt` header |
 | **Flow used here** | x402 v2 EIP-3009 `exact` | EVM `charge` |
 | **Payment rails** | Registered blockchain network mechanisms | Stablecoins, cards, Lightning, and custom methods |
@@ -55,9 +55,9 @@ $ bun add mppx viem
 Start with your existing x402 SDK route:
 
 ```ts [server.ts]
-import { HTTPFacilitatorClient, type RoutesConfig } from '@x402/core/server'
+import { HTTPFacilitatorClient, type RoutesConfig, x402ResourceServer } from '@x402/core/server'
 import { ExactEvmScheme } from '@x402/evm/exact/server'
-import { paymentMiddleware, x402ResourceServer } from '@x402/express'
+import { paymentMiddleware } from '@x402/express'
 import express from 'express'
 
 const app = express()
@@ -93,9 +93,8 @@ app.get('/api/data', (req, res) => {
 Replace the x402 middleware import with the MPP compatibility wrapper. Keep the route table, resource server, facilitator, and handler unchanged:
 
 ```ts [server.ts]
-import { HTTPFacilitatorClient, type RoutesConfig } from '@x402/core/server'
+import { HTTPFacilitatorClient, type RoutesConfig, x402ResourceServer } from '@x402/core/server'
 import { ExactEvmScheme } from '@x402/evm/exact/server'
-import { x402ResourceServer } from '@x402/express'
 import express from 'express'
 import { mpp } from 'mppx/x402/express' // [!code focus]
 
@@ -132,11 +131,23 @@ app.get('/api/data', (req, res) => {
 })
 ```
 
-The wrapper delegates x402 Credentials, lifecycle hooks, verification, and settlement to the official x402 adapter. For a compatible `exact` requirement, it also returns an MPP Challenge and settles MPP Credentials through the same x402 resource server.
+The wrapper delegates x402 Credentials, lifecycle hooks, verification, and settlement to the official x402 adapter. For the first compatible extension-free EIP-3009 `exact` requirement, it also advertises native Tempo and source-chain EVM MPP Challenges. The source-chain MPP option verifies and settles through the same x402 resource server. Requirements with x402 extensions remain x402-only so their semantics aren't lost.
 
 :::note
 The x402 compatibility wrapper converts atomic payment requirements to display units automatically, so keep your existing x402 route configuration unchanged. When configuring `mppx.evm.charge` directly, convert atomic amounts first—for six-decimal USDC, `10000` becomes `0.01`.
 :::
+
+#### Use another x402 adapter
+
+The same compatibility layer wraps official Hono, Next.js, and MCP integrations:
+
+| Runtime | Import | Wrapper |
+|---|---|---|
+| Express | `mppx/x402/express` | [`mpp(routes, server, config)`](/sdk/typescript/x402/express) |
+| Hono | `mppx/x402/hono` | [`mpp(routes, server, config)`](/sdk/typescript/x402/hono) |
+| MCP | `mppx/x402/mcp` | [`mpp(server, config)(handler)`](/sdk/typescript/x402/mcp) |
+| Next.js proxy | `mppx/x402/next` | [`mppProxy(routes, server, config)`](/sdk/typescript/x402/next) |
+| Next.js route | `mppx/x402/next` | [`mpp(handler, route, server, config)`](/sdk/typescript/x402/next) |
 
 ### Run x402 inline with `mppx`
 

--- a/src/pages/mpp-vs-x402.mdx
+++ b/src/pages/mpp-vs-x402.mdx
@@ -25,7 +25,7 @@ Choose **x402** when your service exclusively needs on-chain payments and its re
 | **Core model** | On-chain payment schemes attached to requests | Payment authentication framework for machine-to-machine payments |
 | **HTTP status** | `402 Payment Required` | `402 Payment Required` |
 | **Challenge header** | `PAYMENT-REQUIRED` | `WWW-Authenticate: Payment` |
-| **Credential header** | `PAYMENT-SIGNATURE` | `Authorization: Payment` |
+| **Credential header** | `PAYMENT-SIGNATURE` | `Authorization: Payment`, or an advertised alternate field |
 | **Receipt header** | `PAYMENT-RESPONSE` | `Payment-Receipt` |
 | **Payment rails** | Registered blockchain network mechanisms | Stablecoins, cards, Lightning, and custom methods |
 | **Usage-based billing** | `upto` and EVM `batch-settlement` schemes | Payment-method intents, including `session` |

--- a/src/pages/partner-integrations/cloudflare-agents.mdx
+++ b/src/pages/partner-integrations/cloudflare-agents.mdx
@@ -116,7 +116,7 @@ export async function paidPing() {
 
 ## Support MPP and x402 clients
 
-Register an EVM method beside your Tempo method when the agent needs to call APIs that support either native MPP or x402 exact. The same payment-aware fetch reads MPP `WWW-Authenticate` Challenges and x402 `PAYMENT-REQUIRED` Challenges, including standard x402 v2 EIP-3009 offers without the optional `mppx` extension, then retries with the matching `Authorization` or `PAYMENT-SIGNATURE` header.
+Register an EVM method beside your Tempo method when the agent needs to call APIs that support either native MPP or x402 exact. The same payment-aware fetch reads MPP `WWW-Authenticate` Challenges and x402 `PAYMENT-REQUIRED` Challenges, including standard x402 v2 EIP-3009 offers without the optional `mppx` extension, then retries with the advertised MPP Credential field or `PAYMENT-SIGNATURE`.
 
 <Tabs stateKey="wallet-provider">
 <Tab title="Direct">

--- a/src/pages/partner-integrations/mcp-sdk.mdx
+++ b/src/pages/partner-integrations/mcp-sdk.mdx
@@ -112,7 +112,7 @@ export async function paidPing() {
 
 ## Support MPP and x402 clients
 
-Register an EVM method beside your Tempo method when the agent needs to call APIs that support either native MPP or x402 exact. The same payment-aware fetch reads MPP `WWW-Authenticate` Challenges and x402 `PAYMENT-REQUIRED` Challenges, including standard x402 v2 EIP-3009 offers without the optional `mppx` extension, then retries with the matching `Authorization` or `PAYMENT-SIGNATURE` header.
+Register an EVM method beside your Tempo method when the agent needs to call APIs that support either native MPP or x402 exact. The same payment-aware fetch reads MPP `WWW-Authenticate` Challenges and x402 `PAYMENT-REQUIRED` Challenges, including standard x402 v2 EIP-3009 offers without the optional `mppx` extension, then retries with the advertised MPP Credential field or `PAYMENT-SIGNATURE`.
 
 <Tabs stateKey="wallet-provider">
 <Tab title="Direct">

--- a/src/pages/partner-integrations/vercel-ai-sdk.mdx
+++ b/src/pages/partner-integrations/vercel-ai-sdk.mdx
@@ -132,7 +132,7 @@ The `tempo({ account })` helper used above supports Tempo [charge](/payment-meth
 
 ## Support MPP and x402 clients
 
-Register an EVM method beside your Tempo method when the agent needs to call APIs that support either native MPP or x402 exact. The same payment-aware fetch reads MPP `WWW-Authenticate` Challenges and x402 `PAYMENT-REQUIRED` Challenges, including standard x402 v2 EIP-3009 offers without the optional `mppx` extension, then retries with the matching `Authorization` or `PAYMENT-SIGNATURE` header.
+Register an EVM method beside your Tempo method when the agent needs to call APIs that support either native MPP or x402 exact. The same payment-aware fetch reads MPP `WWW-Authenticate` Challenges and x402 `PAYMENT-REQUIRED` Challenges, including standard x402 v2 EIP-3009 offers without the optional `mppx` extension, then retries with the advertised MPP Credential field or `PAYMENT-SIGNATURE`.
 
 <Tabs stateKey="wallet-provider">
 <Tab title="Direct">

--- a/src/pages/payment-methods/tempo/index.mdx
+++ b/src/pages/payment-methods/tempo/index.mdx
@@ -83,16 +83,23 @@ const mppx = Mppx.create({
 })
 ```
 
-It is also possible to point the `feePayer` to a fee service that supports the [`Handler.feePayer`](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer) endpoint:
+Point `feePayer` to a fee service that supports the [`Handler.feePayer`](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer) endpoint. Use the object form to authenticate requests:
 
 ```ts
 import { Mppx, tempo } from 'mppx/server'
 
 const mppx = Mppx.create({
   methods: [tempo.charge({
-    feePayer: 'https://sponsor.example.com', // [!code hl]
+    // [!code hl:start]
+    feePayer: {
+      headers: {
+        Authorization: `Bearer ${process.env.FEE_PAYER_TOKEN!}`,
+      },
+      url: 'https://sponsor.example.com',
+    },
+    // [!code hl:end]
   })],
 })
 ```
 
-For Sessions, pass the same `feePayer` parameter to [`tempo.session`](/sdk/typescript/server/Method.tempo.session) alongside `account` and `store`. A fee payer service sponsors open, top-up, scheduled settlement, and cooperative close transactions.
+For Sessions, pass the same `feePayer` parameter to [`tempo.session`](/sdk/typescript/server/Method.tempo.session) alongside `account` and `store`. A fee payer service sponsors open, top-up, scheduled settlement, and cooperative close transactions. `mppx` applies the configured headers to every remote fee-payer request and always sets `Content-Type: application/json`.

--- a/src/pages/protocol/challenges.mdx
+++ b/src/pages/protocol/challenges.mdx
@@ -15,6 +15,7 @@ WWW-Authenticate: Payment id="qB3wErTyU7iOpAsD9fGhJk",
     method="tempo",
     intent="charge",
     expires="2025-01-15T12:05:00Z",
+    header="Payment-Authorization",
     opaque="eyJyb3V0ZSI6Ii92MS9zZWFyY2gifQ",
     request="eyJhbW91bnQiOiIxMDAwIiwiY3VycmVuY3kiOiJ1c2QifQ"
 ```
@@ -33,8 +34,10 @@ WWW-Authenticate: Payment id="qB3wErTyU7iOpAsD9fGhJk",
 
 | Parameter | Description |
 |-----------|-------------|
-| `expires` | ISO 8601 timestamp when the Challenge expires |
 | `description` | Human-readable description of what's being paid for |
+| `digest` | Request body digest used to bind a body-bearing request |
+| `expires` | ISO 8601 timestamp when the Challenge expires |
+| `header` | HTTP field for the Credential; defaults to `Authorization` when absent |
 | `opaque` | Base64url-encoded JCS JSON for server-defined correlation data |
 
 ## `request` and `opaque` encoding
@@ -95,9 +98,10 @@ Typical binding includes:
 - `request`
 - `expires`
 - `digest`
+- `header` when advertised
 - `opaque`
 
-For HMAC-bound IDs, the canonical input sequence is `realm | method | intent | request | expires | digest | opaque`. When `expires`, `digest`, or `opaque` is absent, use an empty string for that slot.
+For HMAC-bound IDs without `header`, the canonical input sequence remains `realm | method | intent | request | expires | digest | opaque`. When a Challenge advertises `header`, insert its value before the final `opaque` slot. Use an empty string for an absent optional slot.
 
 For stateless verification, use an [HMAC-bound](https://en.wikipedia.org/wiki/HMAC) Challenge ID. Stateful servers can store the expected Challenge parameters by ID and compare them when verifying the Credential.
 

--- a/src/pages/protocol/credentials.mdx
+++ b/src/pages/protocol/credentials.mdx
@@ -5,12 +5,19 @@ imageDescription: "Submit proof of payment with each request"
 
 # Credentials [Client-submitted payment proofs]
 
-A **Credential** is your response to a [Challenge](/protocol/challenges), proving that you paid or authorized the payment. Send Credentials in the `Authorization` header.
+A **Credential** is your response to a [Challenge](/protocol/challenges), proving that you paid or authorized the payment. Send Credentials in `Authorization` unless the Challenge advertises another field in its `header` parameter.
 
 ## Structure
 
 ```http
 Authorization: Payment eyJjaGFsbGVuZ2UiOnsiaWQiOiJxQjN3RXJUeVU3aU9wQXNEOWZHaEprIiwi...
+```
+
+When an endpoint also uses `Authorization` for application authentication, the server can advertise `header="Payment-Authorization"`. Keep the ordinary Credential and Payment Credential separate:
+
+```http
+Authorization: Bearer application-token
+Payment-Authorization: Payment eyJjaGFsbGVuZ2UiOnsiaWQiOiJxQjN3RXJUeVU3aU9wQXNEOWZHaEprIiwi...
 ```
 
 The Credential is a base64url-encoded JSON object:
@@ -19,6 +26,7 @@ The Credential is a base64url-encoded JSON object:
 {
   "challenge": {
     "expires": "2025-01-15T12:05:00Z",
+    "header": "Payment-Authorization",
     "id": "qB3wErTyU7iOpAsD9fGhJk",
     "intent": "charge",
     "method": "tempo",

--- a/src/pages/protocol/http-402.mdx
+++ b/src/pages/protocol/http-402.mdx
@@ -46,7 +46,7 @@ When a resource requires both **token** and **payment** authentication:
 This ordering prevents leaking payment requirements to unauthenticated clients.
 
 :::info
-Store authentication tokens in an [HTTP-only cookie](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#httponly-attribute) to prevent them from conflicting with the payment `Authorization` header and to avoid exposing the token to the client.
+With `mppx`, set `requiresAuth: true` to advertise `Payment-Authorization` for the Payment Credential while keeping application authentication in `Authorization`. Compatible clients preserve the existing application Credential when they retry the request.
 :::
 
 ## Error responses

--- a/src/pages/protocol/transports/http.mdx
+++ b/src/pages/protocol/transports/http.mdx
@@ -1,5 +1,5 @@
 ---
-description: "The HTTP transport maps MPP payment flows to standard HTTP headers—WWW-Authenticate for Challenges, Authorization for Credentials, and Payment-Receipt."
+description: "Map MPP payment flows to HTTP headers, including a separate Credential field for endpoints that also require application authentication."
 imageDescription: "Payment flows over standard HTTP headers"
 ---
 
@@ -14,7 +14,8 @@ The HTTP transport is the primary binding for MPP, using standard HTTP headers f
 | Direction | Header | Purpose |
 |-----------|--------|---------|
 | Server → Client | `WWW-Authenticate: Payment ...` | Challenge |
-| Client → Server | `Authorization: Payment ...` | Credential |
+| Client → Server | `Authorization: Payment ...` | Credential when the Challenge omits `header` |
+| Client → Server | `Payment-Authorization: Payment ...` | Credential when the Challenge sets `header="Payment-Authorization"` |
 | Server → Client | `Payment-Receipt: ...` | Receipt |
 
 ## Example flow
@@ -63,7 +64,18 @@ Content-Type: application/json
 
 ## Header encoding
 
-Challenges are encoded as [auth-params](https://www.rfc-editor.org/rfc/rfc9110#section-11.2) in `WWW-Authenticate`. The `request` and `opaque` auth-params use base64url-encoded JCS JSON strings. Credentials echo those same Challenge values inside the base64url-encoded `Authorization` payload, and Receipts use base64url-encoded JSON in `Payment-Receipt`.
+Challenges are encoded as [auth-params](https://www.rfc-editor.org/rfc/rfc9110#section-11.2) in `WWW-Authenticate`. The `request` and `opaque` auth-params use base64url-encoded JCS JSON strings. Credentials echo those same Challenge values inside the base64url-encoded Payment Credential, and Receipts use base64url-encoded JSON in `Payment-Receipt`.
+
+## Combine application authentication and payment
+
+Use a separate payment field when your endpoint needs a Bearer, Basic, or other application Credential in `Authorization`. With `mppx`, set `requiresAuth: true` on the server. The Challenge advertises `header="Payment-Authorization"`, and compatible clients attach the Payment Credential there without replacing the existing `Authorization` value.
+
+```http
+GET /api/data HTTP/1.1
+Authorization: Bearer application-token
+Host: api.example.com
+Payment-Authorization: Payment eyJjaGFsbGVuZ2UiOnsiaWQiOiJhYmMxMjMi...
+```
 
 ## Full specification
 

--- a/src/pages/protocol/transports/index.mdx
+++ b/src/pages/protocol/transports/index.mdx
@@ -20,7 +20,7 @@ MPP defines how the Payment authentication scheme operates over different transp
 
 MPP's core concepts—Challenges, Credentials, and Receipts—remain the same across transports. The encoding and delivery mechanism changes:
 
-- **HTTP** uses standard headers (`WWW-Authenticate`, `Authorization`, `Payment-Receipt`)
+- **HTTP** uses standard headers (`WWW-Authenticate`, `Authorization` or an advertised alternate Credential field, and `Payment-Receipt`)
 - **MCP** uses JSON-RPC error codes and `_meta` fields
 - **WebSocket** uses JSON message framing with an `mpp` discriminator
 

--- a/src/pages/protocol/transports/mcp.mdx
+++ b/src/pages/protocol/transports/mcp.mdx
@@ -97,7 +97,7 @@ Receipts are returned in the result `_meta`:
 | Aspect | HTTP | MCP |
 |--------|------|-----|
 | Challenge delivery | `WWW-Authenticate` header | JSON-RPC error `-32042` |
-| Credential delivery | `Authorization` header | `_meta.org.paymentauth/credential` |
+| Credential delivery | `Authorization` or the Challenge's advertised field | `_meta.org.paymentauth/credential` |
 | Receipt delivery | `Payment-Receipt` header | `_meta.org.paymentauth/receipt` |
 | Encoding | Base64url in headers | Native JSON in body |
 

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -270,7 +270,7 @@ const mppx = Mppx.create({
 })
 ```
 
-It is possible to pass a [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer) URL instead:
+Pass a [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer) URL instead. Use the object form when the service requires authentication headers:
 
 ```ts
 import { Mppx, tempo } from 'mppx/server'
@@ -278,7 +278,14 @@ import { Mppx, tempo } from 'mppx/server'
 const mppx = Mppx.create({
   methods: [tempo.charge({
     currency: '0x20c0000000000000000000000000000000000000',
-    feePayer: 'https://sponsor.example.com', // [!code focus]
+    // [!code focus:start]
+    feePayer: {
+      headers: {
+        Authorization: `Bearer ${process.env.FEE_PAYER_TOKEN!}`,
+      },
+      url: 'https://sponsor.example.com',
+    },
+    // [!code focus:end]
     recipient: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     testnet: false,
   })],
@@ -286,7 +293,7 @@ const mppx = Mppx.create({
 })
 ```
 
-When a pull-mode client submits a signed transaction, the server co-signs with the fee payer account (or delegates to the relay) before broadcasting. Push-mode clients pay their own gas, so `feePayer` is ignored for those requests. Zero-amount proof flows do not create a transaction at all.
+When a pull-mode client submits a signed transaction, the server co-signs with the fee payer account or delegates to the remote service before broadcasting. `mppx` sends the configured headers on both JSON-RPC and transaction-completion requests and reserves `Content-Type: application/json`. Push-mode clients pay their own gas, so `feePayer` is ignored for those requests. Zero-amount proof flows do not create a transaction at all.
 
 ### Optimistic verification
 

--- a/src/pages/sdk/typescript/Html.init.mdx
+++ b/src/pages/sdk/typescript/Html.init.mdx
@@ -89,7 +89,7 @@ type Context = {
   label: string
   /** The DOM element to mount your payment UI into. */
   root: HTMLElement
-  /** Submit a credential and reload the page. */
+  /** Submit a Credential in the field advertised by the Challenge, then reload the page. */
   submit: (credential: string) => Promise<void>
   /** UI text strings with defaults applied. */
   text: { expires: string; pay: string; paymentRequired: string; title: string }
@@ -163,7 +163,7 @@ The DOM element to mount your payment UI into. Append your form elements here.
 
 - **Type:** `(credential: string) => Promise<void>`
 
-Sends the Credential to the server via a Service Worker, then reloads the page. Call after creating a Credential from the Challenge.
+Sends the Credential to the server via a Service Worker, then reloads the page. The Service Worker uses the HTTP field advertised by `challenge.header`, or `Authorization` when the Challenge omits it. Call after creating a Credential from the Challenge.
 
 ### text
 

--- a/src/pages/sdk/typescript/cli.mdx
+++ b/src/pages/sdk/typescript/cli.mdx
@@ -129,7 +129,7 @@ $ mppx init --force
 
 ## Sign command
 
-Sign a payment Challenge and output the `Authorization` header value without making a request. Accepts a Challenge via `--challenge` or stdin.
+Sign a payment Challenge and output its serialized Payment Credential value without making a request. Accepts a Challenge via `--challenge` or stdin; send the result in the field advertised by `header`, or `Authorization` when omitted.
 
 ```bash [terminal]
 $ mppx sign --challenge 'Payment method="tempo-session";chain-id=4217;...'

--- a/src/pages/sdk/typescript/client/Mppx.preparePayment.mdx
+++ b/src/pages/sdk/typescript/client/Mppx.preparePayment.mdx
@@ -38,7 +38,7 @@ const paidResponse = await mppx.rawFetch('https://api.example.com/paid', paidReq
 
 `preparePayment` selects a Challenge but doesn't sign or emit Credential lifecycle events until you call `createCredential`. Use it to display payment terms, request approval, or apply a spending policy before paying.
 
-`setCredential` uses the protocol that produced the selected Challenge. It attaches `Authorization` for Payment auth, `PAYMENT-SIGNATURE` for x402, or request metadata for MCP.
+`setCredential` uses the protocol that produced the selected Challenge. It attaches a Payment Credential to `Authorization` or the alternate field advertised by the Challenge, uses `PAYMENT-SIGNATURE` for x402, and uses request metadata for MCP.
 
 Prepared payments retain transport-local state and aren't serializable. Their inspected Challenge, Challenge list, method, and wrapper object are immutable snapshots.
 

--- a/src/pages/sdk/typescript/client/Transport.http.mdx
+++ b/src/pages/sdk/typescript/client/Transport.http.mdx
@@ -54,7 +54,8 @@ const mppx = Mppx.create({
 
 - Detects payment required using the **`402` status code**
 - Extracts Challenges from the **`WWW-Authenticate` header**
-- Sends Credentials using the **`Authorization` header**
+- Sends Credentials using **`Authorization`** or the alternate field advertised by the Challenge
+- Preserves an existing non-Payment **`Authorization`** value when attaching another Credential field
 
 ## Return type
 

--- a/src/pages/sdk/typescript/core/Challenge.credentialHeader.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.credentialHeader.mdx
@@ -1,0 +1,42 @@
+---
+description: "Resolve the HTTP field where a client sends a Payment Credential for an MPP Challenge."
+imageDescription: "Keep payment and application Credentials separate"
+---
+
+# `Challenge.credentialHeader` [Resolve the Payment Credential field]
+
+Returns the HTTP field where a client sends the Credential for a Challenge.
+
+## Usage
+
+```ts twoslash
+import { Challenge } from 'mppx'
+
+const challenge = Challenge.from({
+  header: 'Payment-Authorization',
+  id: 'abc123',
+  intent: 'charge',
+  method: 'tempo',
+  realm: 'mpp.dev',
+  request: { amount: '1', currency: '0x...', recipient: '0x...' },
+})
+
+const header = Challenge.credentialHeader(challenge)
+// @log: 'Payment-Authorization'
+```
+
+## Return type
+
+```ts
+type ReturnType = string
+```
+
+Returns `challenge.header` when present, or `Authorization` when the Challenge uses the protocol default.
+
+## Parameters
+
+### challenge
+
+- **Type:** `Challenge`
+
+Challenge whose Payment Credential field you want to resolve.

--- a/src/pages/sdk/typescript/core/Challenge.deserialize.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.deserialize.mdx
@@ -29,7 +29,7 @@ const challenge = Challenge.deserialize(header, { methods: [Methods.charge] })
 type ReturnType = Challenge
 ```
 
-The deserialized Challenge object. Auth-param names are case-insensitive. `mppx` decodes `request` from its base64url-encoded JCS string and restores Unicode escaped by `Challenge.serialize`. The `opaque` auth-param remains unchanged on `Challenge.opaque`; `Challenge.deserialize` doesn't expand it into `Challenge.meta`.
+The deserialized Challenge object. Auth-param names are case-insensitive. `mppx` decodes `request` from its base64url-encoded JCS string and restores Unicode escaped by `Challenge.serialize`. The optional `header` value identifies the HTTP field for the Payment Credential. The `opaque` auth-param remains unchanged on `Challenge.opaque`; `Challenge.deserialize` doesn't expand it into `Challenge.meta`.
 
 ## Parameters
 

--- a/src/pages/sdk/typescript/core/Challenge.from.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.from.mdx
@@ -2,7 +2,7 @@
 
 Creates a Challenge from the given parameters.
 
-If `secretKey` option is provided, the Challenge ID is computed as HMAC-SHA256 over the Challenge parameters (realm|method|intent|request|expires|digest|opaque), cryptographically binding the ID to its contents. When `expires`, `digest`, or `opaque` is absent, that slot is an empty string.
+If `secretKey` is provided, the Challenge ID is computed as HMAC-SHA256 over the Challenge parameters. The legacy binding is `realm|method|intent|request|expires|digest|opaque`. A non-default `header` is inserted before the final `opaque` slot. When an optional value is absent, its slot is an empty string.
 
 Load `secretKey` from your server environment or secret manager. Do not ship it to clients.
 
@@ -68,6 +68,13 @@ Digest of the request body.
 - **Type:** `string`
 
 Expiration timestamp (ISO 8601).
+
+### header (optional)
+
+- **Type:** `string`
+- **Default:** `Authorization`
+
+HTTP field for the Payment Credential. Set `Payment-Authorization` when `Authorization` carries an application Credential. The default isn't serialized in the Challenge.
 
 ### id (when not using secretKey)
 

--- a/src/pages/sdk/typescript/core/Challenge.fromMethod.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.fromMethod.mdx
@@ -55,6 +55,13 @@ Digest of the request body.
 
 Expiration timestamp (ISO 8601).
 
+### header (optional)
+
+- **Type:** `string`
+- **Default:** `Authorization`
+
+HTTP field for the Payment Credential. Set `Payment-Authorization` when `Authorization` carries an application Credential. The default isn't serialized in the Challenge.
+
 ### id (when not using secretKey)
 
 - **Type:** `string`

--- a/src/pages/sdk/typescript/core/Challenge.serialize.mdx
+++ b/src/pages/sdk/typescript/core/Challenge.serialize.mdx
@@ -27,7 +27,7 @@ type ReturnType = string
 
 A string suitable for the WWW-Authenticate header value.
 
-The serialized string includes optional fields when present: `description`, `digest`, `expires`, and `opaque` (server-defined correlation data set via `meta` in `Challenge.from`). In HTTP headers, `request` and `opaque` are emitted as base64url-encoded JCS JSON strings.
+The serialized string includes optional fields when present: `description`, `digest`, `expires`, `header`, and `opaque` (server-defined correlation data set via `meta` in `Challenge.from`). `header="Authorization"` is omitted because `Authorization` is the protocol default. In HTTP headers, `request` and `opaque` are emitted as base64url-encoded JCS JSON strings.
 
 Characters above Latin-1 in auth-param values are escaped as `\uXXXX`, so descriptions containing smart quotes, em dashes, emoji, or other Unicode remain valid Fetch API header values. `Challenge.deserialize` restores the original text.
 

--- a/src/pages/sdk/typescript/core/Credential.deserialize.mdx
+++ b/src/pages/sdk/typescript/core/Credential.deserialize.mdx
@@ -1,6 +1,6 @@
 # `Credential.deserialize` [Deserialize a Credential from a header]
 
-Deserializes an Authorization header value to a Credential.
+Deserializes a Payment Credential header value to a Credential.
 
 ## Usage
 
@@ -27,4 +27,4 @@ The deserialized Credential object.
 
 - **Type:** `string`
 
-The Authorization header value.
+The `Authorization`, `Payment-Authorization`, or other advertised Credential field value.

--- a/src/pages/sdk/typescript/core/Credential.fromRequest.mdx
+++ b/src/pages/sdk/typescript/core/Credential.fromRequest.mdx
@@ -1,6 +1,6 @@
 # `Credential.fromRequest` [Extract a Credential from a Request]
 
-Extracts the Credential from a Request's Authorization header.
+Extracts the Credential from a Request's configured payment field.
 
 ## Usage
 
@@ -8,7 +8,9 @@ Extracts the Credential from a Request's Authorization header.
 import { Credential } from 'mppx'
 
 export async function handler(request: Request) {
-  const credential = Credential.fromRequest(request)
+  const credential = Credential.fromRequest(request, {
+    header: 'Payment-Authorization',
+  })
   // ...
 }
 ```
@@ -22,6 +24,13 @@ type ReturnType = Credential<payload>
 The deserialized Credential object.
 
 ## Parameters
+
+### options (optional)
+
+- **Type:** `{ header?: string }`
+- **Default:** `{ header: 'Authorization' }`
+
+Configures the HTTP field containing the Payment Credential.
 
 ### request
 

--- a/src/pages/sdk/typescript/core/Credential.serialize.mdx
+++ b/src/pages/sdk/typescript/core/Credential.serialize.mdx
@@ -1,6 +1,6 @@
 # `Credential.serialize` [Serialize a Credential to a header]
 
-Serializes a Credential to the Authorization header format.
+Serializes a Credential to the Payment Credential header format.
 
 ## Usage
 
@@ -30,7 +30,7 @@ const header = Credential.serialize(credential)
 type ReturnType = string
 ```
 
-A string suitable for the Authorization header value.
+A string suitable for the HTTP field advertised by `challenge.header`, or `Authorization` when the Challenge omits it.
 
 When the Credential includes an echoed Challenge, `mppx` keeps the HTTP wire format intact: `challenge.request` and `challenge.opaque` serialize as the same base64url-encoded strings that came from the Challenge header.
 

--- a/src/pages/sdk/typescript/index.mdx
+++ b/src/pages/sdk/typescript/index.mdx
@@ -45,6 +45,17 @@ $ bun add mppx
 
 Use `mppx/server` for most servers. It exports the server runtime and every built-in payment method.
 
+### x402 compatibility
+
+Use a framework-specific x402 entrypoint when you already have an official x402 route table and resource server. These wrappers preserve x402 handling and add native MPP Challenges and Credentials to the same route.
+
+| Runtime | Reference |
+|---|---|
+| Express | [`mppx/x402/express`](/sdk/typescript/x402/express) |
+| Hono | [`mppx/x402/hono`](/sdk/typescript/x402/hono) |
+| MCP | [`mppx/x402/mcp`](/sdk/typescript/x402/mcp) |
+| Next.js | [`mppx/x402/next`](/sdk/typescript/x402/next) |
+
 ### Advanced options
 
 Use lightweight entrypoints when a deployment only needs core server primitives or Stripe Shared Payment Tokens. These imports omit unrelated payment rails from the module graph.

--- a/src/pages/sdk/typescript/middlewares/express.mdx
+++ b/src/pages/sdk/typescript/middlewares/express.mdx
@@ -51,6 +51,20 @@ app.get(
 )
 ```
 
+### Body-bearing requests
+
+Register the appropriate Express body parser before a paid `POST`, `PUT`, or `PATCH` route. The middleware forwards parsed JSON and binary bodies, repeated headers, and the complete request URL to MPP verification. It omits bodies from `GET` and `HEAD` requests.
+
+```ts [server.ts]
+app.use(express.json())
+
+app.post(
+  '/premium',
+  mppx.charge({ amount: '1' }),
+  (req, res) => res.json({ accepted: req.body }),
+)
+```
+
 ### Session payments
 
 Use `mppx.session()` with `tempo.session()` to gate routes behind current v2 Sessions.
@@ -84,7 +98,7 @@ app.get(
 
 ### Identifying the payer
 
-After the middleware verifies payment, the `Authorization` header is still on the request. Parse it with `Credential.deserialize` to read the payer's identity from the `source` field—a DID such as `did:pkh:eip155:1:0x...`.
+After the middleware verifies payment, the Credential field is still on the request. It defaults to `Authorization`; use `Payment-Authorization` when the server sets `requiresAuth: true`. Parse its value with `Credential.deserialize` to read the payer's identity from the `source` field—a DID such as `did:pkh:eip155:1:0x...`.
 
 ```ts [server.ts]
 import express from 'express'

--- a/src/pages/sdk/typescript/middlewares/hono.mdx
+++ b/src/pages/sdk/typescript/middlewares/hono.mdx
@@ -84,7 +84,7 @@ app.get(
 
 ### Identifying the payer
 
-After the middleware verifies payment, the `Authorization` header is still on the request. Parse it with `Credential.deserialize` to read the payer's identity from the `source` field—a DID such as `did:pkh:eip155:1:0x...`.
+After the middleware verifies payment, the Credential field is still on the request. It defaults to `Authorization`; use `Payment-Authorization` when the server sets `requiresAuth: true`. Parse its value with `Credential.deserialize` to read the payer's identity from the `source` field—a DID such as `did:pkh:eip155:1:0x...`.
 
 ```ts [server.ts]
 import { Hono } from 'hono'

--- a/src/pages/sdk/typescript/middlewares/nextjs.mdx
+++ b/src/pages/sdk/typescript/middlewares/nextjs.mdx
@@ -76,7 +76,7 @@ export const GET =
 
 ### Identifying the payer
 
-After the handler verifies payment, the `Authorization` header is still on the request. Parse it with `Credential.deserialize` to read the payer's identity from the `source` field—a DID such as `did:pkh:eip155:1:0x...`.
+After the handler verifies payment, the Credential field is still on the request. It defaults to `Authorization`; use `Payment-Authorization` when the server sets `requiresAuth: true`. Parse its value with `Credential.deserialize` to read the payer's identity from the `source` field—a DID such as `did:pkh:eip155:1:0x...`.
 
 ```ts twoslash [app/api/premium/route.ts]
 import { Credential } from 'mppx'

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -125,6 +125,27 @@ const mppx = Mppx.create({
 })
 ```
 
+### With an authenticated remote fee payer
+
+Pass request headers with the remote service URL. `mppx` applies them to fee-payer JSON-RPC and transaction-completion requests.
+
+```ts [server.ts]
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.charge({
+      feePayer: {
+        headers: {
+          Authorization: `Bearer ${process.env.FEE_PAYER_TOKEN!}`,
+        },
+        url: 'https://sponsor.example.com',
+      },
+    }),
+  ],
+})
+```
+
 ### With machine-token payments
 
 Enable the unified first-party Tempo machineUSD route for compatible single-recipient charges. Clients use it when they hold enough machineUSD, then fall back to the requested stablecoin path when the route isn't available.
@@ -234,9 +255,9 @@ External identifier for the payment.
 
 ### feePayer (optional)
 
-- **Type:** `Account | string | true`
+- **Type:** `Account | { headers?: Readonly<Record<string, string>>; url: string } | string | true`
 
-Account or URL for sponsoring transaction fees. Pass a viem `Account` to co-sign locally, a URL string to delegate to a remote [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer), or `true` when the `account` parameter doubles as the fee payer.
+Account or remote service for sponsoring transaction fees. Pass a viem `Account` to co-sign locally, a URL string to use a remote [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer), an object with `headers` and `url` to authenticate remote requests, or `true` when the `account` parameter doubles as the fee payer. `mppx` reserves the `Content-Type` header for JSON.
 
 This setting only applies to non-zero charges. Zero-amount proof flows do not create a transaction.
 

--- a/src/pages/sdk/typescript/server/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.mdx
@@ -115,9 +115,9 @@ Decimal places for amount parsing.
 
 ### feePayer (optional)
 
-- **Type:** `Account | string | true`
+- **Type:** `Account | { headers?: Readonly<Record<string, string>>; url: string } | string | true`
 
-Account or URL for sponsoring transaction fees. Pass a viem `Account` to co-sign locally, a URL string to delegate to a remote [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer), or `true` when the `account` parameter doubles as the fee payer.
+Account or remote service for sponsoring transaction fees. Pass a viem `Account` to co-sign locally, a URL string to use a remote [fee payer service](https://docs.tempo.xyz/sdk/typescript/server/handler.feePayer), an object with `headers` and `url` to authenticate remote requests, or `true` when the `account` parameter doubles as the fee payer. `mppx` reserves the `Content-Type` header for JSON.
 
 ### getClient (optional)
 

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -245,9 +245,9 @@ Reserve contract advertised in each Challenge. Defaults to the canonical TIP-103
 
 ### feePayer (optional)
 
-- **Type:** `Account | string | true`
+- **Type:** `Account | { headers?: Readonly<Record<string, string>>; url: string } | string | true`
 
-Account or URL for sponsoring open, top-up, settlement, and close transaction fees. Pass a viem `Account` to co-sign locally, a URL string to delegate to a remote fee payer service, or `true` when the `account` parameter doubles as the fee payer.
+Account or remote service for sponsoring open, top-up, settlement, and close transaction fees. Pass a viem `Account` to co-sign locally, a URL string to use a remote fee payer service, an object with `headers` and `url` to authenticate remote requests, or `true` when the `account` parameter doubles as the fee payer. `mppx` reserves the `Content-Type` header for JSON.
 
 A remote fee payer service sponsors server-driven scheduled settlement and cooperative close transactions in addition to client-driven open and top-up transactions.
 

--- a/src/pages/sdk/typescript/server/Mppx.broadcastCredential.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.broadcastCredential.mdx
@@ -49,7 +49,7 @@ Authoritative request snapshot used by method hooks.
 
 - **Type:** `string | Credential`
 
-Serialized `Authorization` header value or parsed Credential object.
+Serialized Payment Credential field value or parsed Credential object.
 
 ### meta (optional)
 

--- a/src/pages/sdk/typescript/server/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.create.mdx
@@ -44,6 +44,25 @@ const handler = payment.charge({
 
 The shorthand applies `canOffer` and `selectOffers`, just like `payment.compose()`. Use [`Mppx.compose`](/sdk/typescript/server/Mppx.compose) when methods need different request options or one method needs multiple offers.
 
+### With application authentication
+
+Set `requiresAuth: true` when `Authorization` already carries an application Credential. The server advertises `header="Payment-Authorization"` in each Challenge, reads the Payment Credential from that field, and leaves `Authorization` available for Bearer, Basic, or another authentication scheme.
+
+```ts twoslash [server.ts]
+import { Mppx, tempo } from 'mppx/server'
+
+const payment = Mppx.create({
+  methods: [tempo.charge()],
+  requiresAuth: true,
+})
+
+const handler = payment.tempo.charge({
+  amount: '0.01',
+})
+```
+
+Compatible `mppx` clients follow the field advertised by the Challenge and preserve an existing non-Payment `Authorization` value on the retry.
+
 ### Select offers per request
 
 Use `selectOffers` to filter composed HTTP offers before the server issues Challenges. The hook receives normalized, immutable offer snapshots and a clone of the incoming request.
@@ -166,6 +185,13 @@ const payment = Mppx.create({
   // [!code focus:end]
 })
 ```
+
+### requiresAuth (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Uses `Payment-Authorization` for Payment Credentials so `Authorization` remains available for application authentication. Available with the HTTP transport.
 
 ### realm (optional)
 

--- a/src/pages/sdk/typescript/server/Mppx.validateCredential.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.validateCredential.mdx
@@ -50,7 +50,7 @@ Authoritative request snapshot used by method hooks.
 
 - **Type:** `string | Credential`
 
-Serialized `Authorization` header value or parsed Credential object.
+Serialized Payment Credential field value or parsed Credential object.
 
 ### meta (optional)
 

--- a/src/pages/sdk/typescript/server/Mppx.verifyCredential.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.verifyCredential.mdx
@@ -50,7 +50,7 @@ Authoritative request snapshot used by method verification hooks.
 
 - **Type:** `string | Credential`
 
-Serialized `Authorization` header value or parsed Credential object.
+Serialized Payment Credential field value or parsed Credential object.
 
 
 ### meta (optional)

--- a/src/pages/sdk/typescript/server/Transport.http.mdx
+++ b/src/pages/sdk/typescript/server/Transport.http.mdx
@@ -9,13 +9,16 @@ import { Mppx, tempo, Transport } from 'mppx/server'
 
 const mppx = Mppx.create({
   methods: [tempo.charge()],
-  transport: Transport.http(),
+  transport: Transport.http({
+    requiresAuth: true,
+  }),
 })
 ```
 
 ## Behavior
 
-- Reads Credentials from the `Authorization` header
+- Reads Credentials from `Authorization` by default
+- Reads Credentials from `Payment-Authorization` when `requiresAuth` is `true`
 - Issues Challenges in the `WWW-Authenticate` header with `402` status
 - Attaches Receipts in the `Payment-Receipt` header
 
@@ -24,3 +27,12 @@ const mppx = Mppx.create({
 ```ts
 type ReturnType = Transport<Request, Response>
 ```
+
+## Parameters
+
+### requiresAuth (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Reads Payment Credentials from `Payment-Authorization`. Prefer setting the same option on [`Mppx.create`](/sdk/typescript/server/Mppx.create#requiresauth-optional), which also advertises the field in generated Challenges.

--- a/src/pages/sdk/typescript/server/Transport.mcpSdk.mdx
+++ b/src/pages/sdk/typescript/server/Transport.mcpSdk.mdx
@@ -28,7 +28,7 @@ server.registerTool('premium', { description: 'A premium tool' }, async (extra) 
 
 ## Behavior
 
-- Reads Credentials from `_meta["org.paymentauth/credential"]`
+- Reads and validates Credentials from `_meta["org.paymentauth/credential"]`; malformed values are treated as absent
 - Issues Challenges as `McpError` with code `-32042` and Challenge in `error.data`
 - Attaches Receipts in `_meta["org.paymentauth/receipt"]` on tool results
 

--- a/src/pages/sdk/typescript/x402/express.mdx
+++ b/src/pages/sdk/typescript/x402/express.mdx
@@ -1,0 +1,75 @@
+---
+description: "Add MPP payments to an existing x402 Express server without replacing its routes, facilitator, hooks, or settlement."
+imageDescription: "Serve MPP and x402 clients from one Express route"
+---
+
+# `x402/express.mpp` [Add MPP to an x402 Express server]
+
+Wraps the official x402 Express middleware so one route accepts MPP and x402 Credentials.
+
+Requires `@x402/core` and `@x402/express` 2.22 or later, Express 5 or later, and viem 2.54 or later.
+
+## Usage
+
+```ts [server.ts]
+import { HTTPFacilitatorClient, type RoutesConfig, x402ResourceServer } from '@x402/core/server'
+import { ExactEvmScheme } from '@x402/evm/exact/server'
+import express from 'express'
+import { mpp } from 'mppx/x402/express'
+
+const facilitator = new HTTPFacilitatorClient({
+  url: 'https://x402.org/facilitator',
+})
+const server = new x402ResourceServer(facilitator).register(
+  'eip155:84532',
+  new ExactEvmScheme(),
+)
+const routes = {
+  'GET /api/data': {
+    accepts: {
+      network: 'eip155:84532',
+      payTo: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      price: '$0.01',
+      scheme: 'exact',
+    },
+    description: 'Premium data access',
+    mimeType: 'application/json',
+  },
+} satisfies RoutesConfig
+
+const app = express()
+app.use(mpp(routes, server, { // [!code hl]
+  secretKey: process.env.MPP_SECRET_KEY!,
+}))
+app.get('/api/data', (_request, response) => {
+  response.json({ data: 'premium content' })
+})
+```
+
+The wrapper leaves x402 response buffering, hooks, handler cancellation, verification, and settlement with the official adapter. A request containing both an MPP Credential and an x402 payment signature returns `400`.
+
+## Return type
+
+```ts
+type ReturnType = RequestHandler
+```
+
+## Parameters
+
+### config
+
+- **Type:** `{ paywallConfig?: PaywallConfig; realm?: string; secretKey: string }`
+
+MPP Challenge and optional x402 paywall settings. `secretKey` must contain at least 32 bytes.
+
+### routes
+
+- **Type:** `RoutesConfig`
+
+Existing x402 route configuration. The first extension-free EIP-3009 `exact` requirement with valid amount, asset, EVM network, name, recipient, and version fields also produces MPP Tempo and source-chain EVM Challenges.
+
+### server
+
+- **Type:** `x402ResourceServer`
+
+Existing x402 resource server used for requirement metadata, verification, and settlement.

--- a/src/pages/sdk/typescript/x402/hono.mdx
+++ b/src/pages/sdk/typescript/x402/hono.mdx
@@ -1,0 +1,71 @@
+---
+description: "Add MPP payments to an existing x402 Hono server while preserving its route configuration and payment lifecycle."
+imageDescription: "Serve MPP and x402 clients from one Hono route"
+---
+
+# `x402/hono.mpp` [Add MPP to an x402 Hono server]
+
+Wraps the official x402 Hono middleware so one route accepts MPP and x402 Credentials.
+
+Requires `@x402/core` and `@x402/hono` 2.22 or later, Hono 4.12.25 or later, and viem 2.54 or later.
+
+## Usage
+
+```ts [server.ts]
+import { HTTPFacilitatorClient, type RoutesConfig, x402ResourceServer } from '@x402/core/server'
+import { ExactEvmScheme } from '@x402/evm/exact/server'
+import { Hono } from 'hono'
+import { mpp } from 'mppx/x402/hono'
+
+const facilitator = new HTTPFacilitatorClient({
+  url: 'https://x402.org/facilitator',
+})
+const server = new x402ResourceServer(facilitator).register(
+  'eip155:84532',
+  new ExactEvmScheme(),
+)
+const routes = {
+  'GET /api/data': {
+    accepts: {
+      network: 'eip155:84532',
+      payTo: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      price: '$0.01',
+      scheme: 'exact',
+    },
+  },
+} satisfies RoutesConfig
+
+const app = new Hono()
+app.use(mpp(routes, server, { // [!code hl]
+  secretKey: process.env.MPP_SECRET_KEY!,
+}))
+app.get('/api/data', (context) => context.json({ data: 'premium content' }))
+```
+
+The wrapper leaves Hono response handling, hooks, cancellation, and post-handler x402 settlement with the official adapter.
+
+## Return type
+
+```ts
+type ReturnType = MiddlewareHandler
+```
+
+## Parameters
+
+### config
+
+- **Type:** `{ paywallConfig?: PaywallConfig; realm?: string; secretKey: string }`
+
+MPP Challenge and optional x402 paywall settings. `secretKey` must contain at least 32 bytes.
+
+### routes
+
+- **Type:** `RoutesConfig`
+
+Existing x402 route configuration. Compatible extension-free EIP-3009 `exact` requirements also produce MPP Tempo and source-chain EVM Challenges.
+
+### server
+
+- **Type:** `x402ResourceServer`
+
+Existing x402 resource server used for requirement metadata, verification, and settlement.

--- a/src/pages/sdk/typescript/x402/mcp.mdx
+++ b/src/pages/sdk/typescript/x402/mcp.mdx
@@ -1,0 +1,54 @@
+---
+description: "Add MPP payment metadata to an existing x402 MCP tool while preserving its resource server and x402 lifecycle."
+imageDescription: "Accept MPP and x402 payments in one MCP tool"
+---
+
+# `x402/mcp.mpp` [Add MPP to an x402 MCP tool]
+
+Wraps an official x402 MCP tool handler so calls can pay through MPP or x402 metadata.
+
+## Usage
+
+```ts [server.ts]
+import { x402ResourceServer } from '@x402/core/server'
+import { mpp } from 'mppx/x402/mcp'
+
+const paid = mpp(resourceServer, {
+  accepts,
+  resource: {
+    description: 'Premium search',
+    url: 'mcp://tool/search',
+  },
+  secretKey: process.env.MPP_SECRET_KEY!,
+})
+
+const search = paid(async ({ query }: { query: string }) => ({
+  content: [{ text: `result:${query}`, type: 'text' }],
+}))
+```
+
+The resource URL must use the canonical `mcp://tool/{toolName}` shape without another path segment, query, or fragment. An unpaid call returns one MCP payment error containing both MPP Challenges and the x402 payment requirements.
+
+x402 Credentials and lifecycle hooks stay with `@x402/mcp`. MPP source-chain EVM Credentials reuse the x402 resource server for verification and settlement; x402-only hooks run only for x402 calls.
+
+## Return type
+
+```ts
+type ReturnType = <arguments_ extends Record<string, unknown>>(
+  handler: PaymentWrappedHandler<arguments_>,
+) => MCPToolCallback<arguments_>
+```
+
+## Parameters
+
+### config
+
+- **Type:** `Config`
+
+Existing x402 MCP payment settings plus the MPP realm and secret. `resource.url` must match the canonical tool URL described above; `resource.description` and `resource.mimeType` remain optional. `secretKey` must contain at least 32 bytes.
+
+### resourceServer
+
+- **Type:** `x402ResourceServer`
+
+Existing x402 resource server used for requirement metadata, verification, and settlement.

--- a/src/pages/sdk/typescript/x402/next.mdx
+++ b/src/pages/sdk/typescript/x402/next.mdx
@@ -1,0 +1,93 @@
+---
+description: "Add MPP payments to existing x402 Next.js route handlers and proxies while preserving official adapter behavior."
+imageDescription: "Serve MPP and x402 clients from one Next.js route"
+---
+
+# `x402/next` [Add MPP to an x402 Next.js server]
+
+Wraps official x402 Next.js route handlers and proxies so they also accept MPP Credentials.
+
+## Usage
+
+### Wrap a route handler
+
+```ts [route.ts]
+import { HTTPFacilitatorClient, x402ResourceServer } from '@x402/core/server'
+import { ExactEvmScheme } from '@x402/evm/exact/server'
+import { mpp } from 'mppx/x402/next'
+
+const facilitator = new HTTPFacilitatorClient({
+  url: 'https://x402.org/facilitator',
+})
+const server = new x402ResourceServer(facilitator).register(
+  'eip155:84532',
+  new ExactEvmScheme(),
+)
+const route = {
+  accepts: {
+    network: 'eip155:84532',
+    payTo: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    price: '$0.01',
+    scheme: 'exact',
+  },
+}
+
+export const GET = mpp( // [!code hl]
+  () => Response.json({ data: 'premium content' }),
+  route,
+  server,
+  { secretKey: process.env.MPP_SECRET_KEY! },
+)
+```
+
+Additional Next.js route context arguments are passed to the wrapped handler unchanged.
+
+### Wrap a proxy
+
+Use `mppProxy` in `proxy.ts` when the x402 configuration protects multiple routes. Successful payments use `NextResponse.next()` continuation semantics for both protocols.
+
+```ts [proxy.ts]
+import { mppProxy } from 'mppx/x402/next'
+
+export default mppProxy(routes, server, {
+  secretKey: process.env.MPP_SECRET_KEY!,
+})
+```
+
+## Return type
+
+```ts
+type ReturnType = (request: NextRequest, ...arguments_: unknown[]) => Promise<Response> | Response
+```
+
+## Parameters
+
+### config
+
+- **Type:** `{ paywallConfig?: PaywallConfig; realm?: string; secretKey: string }`
+
+MPP Challenge and optional x402 paywall settings. `secretKey` must contain at least 32 bytes.
+
+### handler
+
+- **Type:** `(request: NextRequest, ...arguments_: unknown[]) => Promise<Response> | Response`
+
+Next.js route handler wrapped by `mpp`.
+
+### route
+
+- **Type:** `RouteConfig`
+
+x402 configuration for the wrapped route handler.
+
+### routes
+
+- **Type:** `RoutesConfig`
+
+x402 route table passed to `mppProxy`.
+
+### server
+
+- **Type:** `x402ResourceServer`
+
+Existing x402 resource server used for requirement metadata, verification, and settlement.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -836,6 +836,27 @@ export default defineConfig({
                 ],
               },
               {
+                text: "x402 compatibility",
+                items: [
+                  {
+                    text: "Express",
+                    link: "/sdk/typescript/x402/express",
+                  },
+                  {
+                    text: "Hono",
+                    link: "/sdk/typescript/x402/hono",
+                  },
+                  {
+                    text: "MCP",
+                    link: "/sdk/typescript/x402/mcp",
+                  },
+                  {
+                    text: "Next.js",
+                    link: "/sdk/typescript/x402/next",
+                  },
+                ],
+              },
+              {
                 text: "Proxy",
                 link: "/sdk/typescript/proxy",
               },
@@ -860,6 +881,10 @@ export default defineConfig({
                     text: "Challenge",
                     collapsed: true,
                     items: [
+                      {
+                        text: ".credentialHeader",
+                        link: "/sdk/typescript/core/Challenge.credentialHeader",
+                      },
                       {
                         text: ".deserialize",
                         link: "/sdk/typescript/core/Challenge.deserialize",


### PR DESCRIPTION
## Motivation

Keep the MPP documentation aligned with the latest public mppx interfaces and integration behavior.

## Summary

- Document alternate Payment Credential headers and authenticated Tempo fee-payer requests
- Add x402 compatibility references for Express, Hono, MCP, and Next.js
- Update affected protocol, SDK, middleware, partner, navigation, and generated pages
- Pin the audited mppx preview and advance the sync bookmark

## Key design considerations

- Preserve application authentication by advertising Payment-Authorization for payment Credentials
- Keep x402 verification, settlement, hooks, and framework behavior with official adapters
- Use the exact upstream preview because no post-4e4810a0 npm main snapshot is available