### PR TITLE
feat(services): add Agent Failure Archive

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -344,6 +344,73 @@ export const services: ServiceDef[] = [
   },
   // ── AgentMail ──────────────────────────────────────────────────────────
   {
+    id: "agent-failure-archive",
+    name: "Agent Failure Archive",
+    url: "https://desktop-ai2ata5-1.tailfeb765.ts.net",
+    serviceUrl: "https://desktop-ai2ata5-1.tailfeb765.ts.net",
+    description:
+      "186 post-mortems from eight months of running a multi-session agent system, and a free check that audits your own conclusions against them.",
+
+    categories: ["ai", "data"],
+    integration: "first-party",
+    tags: [
+      "post-mortems",
+      "incidents",
+      "debugging",
+      "reliability",
+      "observability",
+      "measurement",
+    ],
+    docs: {
+      homepage: "https://github.com/HanbeenMoon/agent-failure-archive",
+      llmsTxt: "https://desktop-ai2ata5-1.tailfeb765.ts.net/llms.txt",
+      apiReference: "https://desktop-ai2ata5-1.tailfeb765.ts.net/openapi.json",
+    },
+    provider: {
+      name: "Agent Failure Archive",
+      url: "https://github.com/HanbeenMoon/agent-failure-archive",
+    },
+    realm: "desktop-ai2ata5-1.tailfeb765.ts.net",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /precheck",
+        desc: "Which of nine documented self-deception patterns a conclusion trips",
+      },
+      {
+        route: "GET /contents",
+        desc: "Every case title, tagged by the trap it illustrates",
+      },
+      { route: "GET /sample", desc: "Two complete post-mortems" },
+      {
+        route: "GET /mpp/search",
+        desc: "Three post-mortems matching a symptom, with root cause and fix",
+        amount: "10000",
+      },
+      {
+        route: "GET /mpp/audit",
+        desc: "Full audit of a claim, with the incident behind each check",
+        amount: "20000",
+      },
+      {
+        route: "GET /mpp/brief",
+        desc: "Pre-flight risk brief before an irreversible action",
+        amount: "50000",
+      },
+      {
+        route: "GET /mpp/research",
+        desc: "107 measurement failures from trying to measure one person with embeddings",
+        amount: "250000",
+      },
+      {
+        route: "GET /mpp/archive",
+        desc: "Every one of the 186 cases in one response",
+        amount: "1000000",
+      },
+    ],
+  },
+  {
     id: "agentmail",
     name: "AgentMail",
     url: "https://mpp.api.agentmail.to",


### PR DESCRIPTION
## Motivation

An archive of 186 post-mortems from running a multi-session AI agent system in production for eight months, sold per call. Not curated best practices: these are incidents as they were logged, with the numbers measured at the time. A repair routine whose runner ticked 26,662 times over 22.7 hours and performed zero repairs. A watcher that exited 0 for days after its credentials expired. A store of 4,279 files that was 2,273 unique sessions plus re-dumps, inflating every count 2.3x.

107 of the 186 are measurement failures from a long attempt to measure one person's language against the general language: null results with no positive control, dose-response arms where the same parameter turned out to be two different treatments, detectors whose output was identical whether the signal was present or not.

The free `precheck` endpoint is the part agents use day to day. Give it a conclusion, or paste a paragraph of findings, and it returns which of nine documented self-deception patterns each claim trips. Deterministic, no model in the loop, so the same input always returns the same answer and prose containing no claims returns empty rather than inventing findings.

- **Service name:** Agent Failure Archive
- **Live service URL:** https://desktop-ai2ata5-1.tailfeb765.ts.net
- **Provider URL:** https://github.com/HanbeenMoon/agent-failure-archive
- **OpenAPI or API reference URL:** https://desktop-ai2ata5-1.tailfeb765.ts.net/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [x] `pnpm generate:discovery` succeeds.
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds.

`generate:discovery` reports 142 services and 1457 endpoints after the change; `build` generated 393 files. Only `schemas/services.ts` is modified, the generated artifacts are gitignored.

## Key design considerations

- **Integration:** first-party. I operate the service.
- **Payment methods and intents:** `TEMPO_PAYMENT`, intent `charge`. The five paid routes live under `/mpp/*` and return `WWW-Authenticate: Payment id=… method="tempo" intent="charge" request="…"`. The same content is also served over x402 on Base under the unprefixed paths, which is why the MPP routes carry the prefix rather than replacing them.
- **Provider relationship:** I own and operate it. It runs on my own hardware behind a Tailscale funnel, which is why the hostname looks the way it does.
- **Directory fit:** nothing in the directory currently sells recorded operational failures, and the free claim-checking endpoint has no duplicate that I could find. Independently verified: registering the origin with MPPscan accepted 14 of 19 routes, the five rejections being the x402-only paths that legitimately do not speak MPP.

## Honest limits

Settlement has not been exercised end to end, because that needs a funded payer and I have not had one. Challenges are issued correctly and the recipient address is live on Tempo, but if someone hits a settlement bug I would rather hear about it than have claimed otherwise here. Payment attempts are logged so a failed first purchase leaves a reason behind.

This is one operator's system, so the corpus is prior art rather than a general sample. Coverage skews toward multi-session coordination, hook and cron wiring, retrieval pipelines, and scheduled repair.
