### PR TITLE
services: add Oblique Markets (x402 + MPP dual-rail agent APIs)

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1802,6 +1802,98 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Oblique Markets ───────────────────────────────────────────────────
+  {
+    id: "oblique-markets",
+    name: "Oblique Markets",
+    url: "https://oblique.markets",
+    serviceUrl: "https://api.oblique.markets",
+    description:
+      "Agent-to-agent API shop: x402 Bazaar market data, Base chain data, web extraction, cited research, and LLM utilities. Every paid route answers 402 with both x402 (Base and Solana USDC) and MPP Tempo (pathUSD) offers.",
+    categories: ["data", "blockchain", "web", "ai"],
+    integration: "first-party",
+    tags: ["x402", "bazaar", "base", "usdc", "agents", "market-data"],
+    status: "active",
+    docs: {
+      homepage: "https://oblique.markets",
+      llmsTxt: "https://oblique.markets/llms.txt",
+      apiReference: "https://oblique.markets/openapi.json",
+    },
+    provider: { name: "Oblique Markets", url: "https://oblique.markets" },
+    realm: "api.oblique.markets",
+    intent: "charge",
+    // Charges are denominated in pathUSD (Tempo genesis predeploy, 6 decimals), not USDC.e.
+    payments: [
+      {
+        method: "tempo",
+        currency: "0x20c0000000000000000000000000000000000000",
+        decimals: 6,
+      },
+    ],
+    endpoints: [
+      {
+        route: "GET /api/v1/paid/bazaar-pulse",
+        desc: "Live x402 Bazaar market pulse: trending services, call volumes, new listings, catalog changes",
+        amount: "2000",
+      },
+      {
+        route: "GET /api/v1/paid/bazaar-market-report",
+        desc: "Comprehensive x402 Bazaar market report from the latest daily full-catalogue snapshot",
+        amount: "500000",
+      },
+      {
+        route: "GET /api/v1/paid/base-gas-price",
+        desc: "Current Base gas price (EIP-1559 base fee and gas price) with block freshness metadata",
+        amount: "2000",
+      },
+      {
+        route: "GET /api/v1/paid/base-usdc-balance",
+        desc: "USDC balance of a Base wallet on the canonical USDC contract, atomic and formatted",
+        amount: "3000",
+      },
+      {
+        route: "POST /api/v1/paid/web-extract",
+        desc: "Extract structured JSON (title, meta description, cleaned text) from a web page",
+        amount: "30000",
+      },
+      {
+        route: "POST /api/v1/paid/sentiment",
+        desc: "Social media and news sentiment analysis",
+        amount: "50000",
+      },
+      {
+        route: "POST /api/v1/paid/answer-with-sources",
+        desc: "Answer a research question with cited web sources and a concise evidence packet",
+        amount: "650000",
+      },
+      {
+        route: "POST /api/v1/paid/company-research",
+        desc: "Company research brief with cited sources, competitors, market signals, and risks",
+        amount: "500000",
+      },
+      {
+        route: "POST /api/v1/paid/x402-endpoint-verify",
+        desc: "Verify and lint a third-party x402 endpoint's 402 challenge and protocol conformance",
+        amount: "20000",
+      },
+      {
+        route: "POST /api/v1/paid/mpp-route",
+        desc: "MPP-native catalog-first task router: top-three shortlist with prices and payment methods",
+        amount: "10000",
+      },
+      {
+        route: "POST /api/v1/paid/route-task",
+        desc: "Cross-platform task router across the MPP catalog, Apify actors, and Bazaar listings",
+        amount: "10000",
+      },
+      {
+        route: "POST /api/v1/paid/inference",
+        desc: "LLM inference proxy via OpenRouter (six-model catalog)",
+        amount: "10000",
+      },
+    ],
+  },
+
   // ── OpenAI ─────────────────────────────────────────────────────────────
   {
     id: "openai",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -1810,6 +1810,7 @@ export const services: ServiceDef[] = [
     serviceUrl: "https://api.oblique.markets",
     description:
       "Agent-to-agent API shop: x402 Bazaar market data, Base chain data, web extraction, cited research, and LLM utilities. Every paid route answers 402 with both x402 (Base and Solana USDC) and MPP Tempo (pathUSD) offers.",
+    icon: "https://oblique.markets/icon.png",
     categories: ["data", "blockchain", "web", "ai"],
     integration: "first-party",
     tags: ["x402", "bazaar", "base", "usdc", "agents", "market-data"],


### PR DESCRIPTION
## Motivation

Oblique Markets is an agent-to-agent API shop at `api.oblique.markets`. It serves autonomous agents that need paid, accountless data and utility calls: x402 Bazaar market intelligence (pulse, trending, market reports, listing lint), Base chain data (gas, USDC balances, settlement verification), web extraction, cited research (answer-with-sources, company research), task routing across the MPP catalog / Apify / Bazaar, and LLM utilities (inference, sentiment, classify, summarize, extract-json).

What makes it distinct: every paid route is **dual-rail**. A single 402 carries both an x402 offer (Base USDC, Solana USDC) and an MPP Tempo charge offer (`WWW-Authenticate: Payment ... method="tempo", intent="charge"`), so an agent on either rail can pay the same endpoint. The MPP side is native (no proxy), denominated in **pathUSD** (`0x20c0000000000000000000000000000000000000`, 6 decimals) on Tempo mainnet (chainId 4217), and settles by verifying the pathUSD transfer on-chain. The OpenAPI carries per-operation `x-payment-info` with the exact MPP charge amounts; the entry copies those.

- **Service name:** Oblique Markets
- **Live service URL:** https://api.oblique.markets
- **Provider URL:** https://oblique.markets
- **OpenAPI or API reference URL:** https://oblique.markets/openapi.json (also https://oblique.markets/llms.txt and https://oblique.markets/.well-known/x402.json for the full 77-route catalog)

## Summary

- [x] The service is live and accepts MPP payments. (Verified while preparing this PR: `GET https://api.oblique.markets/api/v1/paid/base-gas-price` returns 402 with `WWW-Authenticate: Payment id=..., realm="api.oblique.markets", method="tempo", intent="charge", request=<b64url {amount:"2000", currency:"0x20c0...0000", recipient:..., methodDetails:{chainId:4217, supportedModes:["pull"]}}>, expires=...`.)
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service. (13 representative endpoints of 77; amounts are the MPP `x-payment-info.amount` values from the live OpenAPI, cross-checked against the live 402 challenges for `base-gas-price` and `inference`.)
- [x] Public documentation and icon URLs are stable and accessible. (`llms.txt` and `openapi.json` return 200. No `icon` is listed because https://oblique.markets/icon.png currently returns 404; we will add one in a follow-up rather than link a dead URL.)
- [x] `pnpm generate:discovery` succeeds. (142 services, 1461 endpoints.)
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds. (Ran on Node v22.23 with the `engines.node >=24` warning; all stages completed — vite client/server/RSC builds, SSG "393 files generated", prune. Please treat CI on Node 24 as authoritative.)

Also ran `biome check schemas/services.ts` (clean) and the `pnpm check` pre-commit hook.

## Key design considerations

- **Integration:** first-party — Oblique Markets implements MPP natively on its own API, the same pattern as AgentMail / GovLaws / molty.cash in this file.
- **Payment methods and intents:** `tempo` / `charge` only. The entry carries an inline payment default (`method: "tempo", currency: 0x20c0...0000 (pathUSD), decimals: 6`) instead of `TEMPO_PAYMENT`, because `TEMPO_PAYMENT` is USDC.e and listing that would misstate the currency the service actually charges in. The x402 rail (Base/Solana USDC) is mentioned in the description only; it is not an MPP method.
- **Provider relationship:** We own and operate the service (the Oblique Markets team). The listing, wallets, and API are ours.
- **Directory fit:** Production since 2026-08 with external settlements on both rails; no existing listing covers x402 Bazaar market intelligence, dual-rail x402/MPP routing (`mpp-route`, `route-task`), or x402 endpoint verification. The generic utilities (inference, sentiment, web-extract) overlap in kind with other listings but are offered here as one accountless, single-402 surface for agents that already hold pathUSD or USDC — no keys, no accounts.

