### PR TITLE
Add Nitro Translate to service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11027,7 +11027,34 @@ export const services: ServiceDef[] = [
       },
     ],
   },
-
+  // ── Nitro Translate (Alconost) ─────────────────────────────────────────
+  {
+    id: "nitrotranslate",
+    name: "Nitro Translate",
+    url: "https://nitrotranslate.com",
+    serviceUrl: "https://api.nitrotranslate.com",
+    description:
+      "Human translation API — submit text or files for translation by native-speaking linguists in 80+ languages, and track orders through to delivery.",
+    categories: ["web", "data"],
+    integration: "first-party",
+    tags: ["translation", "localization", "i18n", "l10n", "human-translation"],
+    docs: {
+      homepage: "https://nitrotranslate.com/translation-api-noauth",
+      apiReference: "https://api.nitrotranslate.com/openapi.json",
+    },
+    provider: { name: "Alconost Inc.", url: "https://alconost.com" },
+    realm: "nitrotranslate.com",
+    intent: "charge",
+    payments: [STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/translate",
+        desc: "Submit content for translation and create one order per target language",
+        dynamic: true,
+        amountHint: "Priced per billable character; varies by language pair and volume",
+      },
+    ],
+  },
   // ── AgentPhone (Orthogonal) ──
   {
     id: "orth-agentphone",


### PR DESCRIPTION
## Motivation

Nitro (by Alconost) is a human translation service exposed as a REST API.
Through it you can submit text or files for translation by native-speaking
linguists in 80+ languages, and track the resulting orders through to
delivery.

- **Service name:** Nitro Translate
- **Live service URL:** https://nitrotranslate.com
- **Provider URL:** https://alconost.com
- **OpenAPI or API reference URL:** https://api.nitrotranslate.com/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service — verify:

curl -s -i -X POST https://api.nitrotranslate.com/v1/translate
-H 'Content-Type: application/json'
--data-binary '{"source_language":"en","target_languages":["it"],"resource":{"type":"text/plain","data":"Hello, World!"}}'

  returns `HTTP/2 402` with `WWW-Authenticate: Payment ... realm="nitrotranslate.com", method="stripe", intent="charge"`, matching the entry's `realm` and `payments: [STRIPE_PAYMENT]`.
- [x] Public documentation and icon URLs are stable and accessible.
- [x] `pnpm generate:discovery` succeeds (142 services).
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds.

## Key design considerations

- **Integration:** first-party — served directly from api.nitrotranslate.com.
- **Payment methods and intents:** Stripe MPP, intent `charge`. Pricing is
  dynamic — priced per billable character, varies by language pair and
  volume, so the endpoint uses `dynamic`/`amountHint` per the schema.
- **Provider relationship:** I represent Alconost / Nitro Translate — the
  service is our own product.
- **Directory fit:** No existing listing in the catalog offers human
  (native-speaker) translation as a paid API — closest neighbors are AI/LLM
  translation services, but this is priced and delivered differently
  (per-character human translation vs. inference pricing).