### PR TITLE
docs: sync mppx 0.9.0

### DIFF
--- a/.mppx-docs-sync
+++ b/.mppx-docs-sync
@@ -5,5 +5,5 @@
 # When updating docs from mppx changes, bump this SHA to HEAD of mppx main
 # after incorporating the new features/changes into the docs site.
 
-mppx_version=https://pkg.pr.new/mppx@4e4810a
-mppx_sha=4e4810a0f33dc0a5a71c4ae70b9b05761be8f60b
+mppx_version=0.9.0
+mppx_sha=1f83f664e235b6cd8fe3c20e8b0430acd495a2e9

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "hono": "^4.12.27",
     "lottie-web": "^5.13.0",
     "mermaid": "^11.15.0",
-    "mppx": "https://pkg.pr.new/mppx@4e4810a",
+    "mppx": "0.9.0",
     "nuqs": "2.9.1",
     "react": "^19",
     "react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       mppx:
-        specifier: https://pkg.pr.new/mppx@4e4810a
-        version: https://pkg.pr.new/mppx@4e4810a(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
+        specifier: 0.9.0
+        version: 0.9.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
       nuqs:
         specifier: 2.9.1
         version: 2.9.1(react@19.2.7)
@@ -4118,9 +4118,8 @@ packages:
       hono:
         optional: true
 
-  mppx@https://pkg.pr.new/mppx@4e4810a:
-    resolution: {tarball: https://pkg.pr.new/mppx@4e4810a}
-    version: 0.8.19
+  mppx@0.9.0:
+    resolution: {integrity: sha512-mVSV1fdBKWCopnQ1E8uVjmilz2tIVIecGFbYITBl+SEWsRe1osTnxX7yN+aDwu9l0KWPdeAIgvSvZbaKEnahjw==}
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
@@ -9739,7 +9738,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@https://pkg.pr.new/mppx@4e4810a(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.9.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
       '@stripe/stripe-js': 9.13.0
       eventsource-parser: 3.1.1

--- a/src/pages/payment-methods/tempo/charge.mdx
+++ b/src/pages/payment-methods/tempo/charge.mdx
@@ -87,24 +87,6 @@ const result = await mppx.charge({
 
 When `feePayer` is `true`, the server adds a fee payer signature (domain `0x78`) before broadcasting. The client doesn't need gas tokens. See [fee sponsorship](/payment-methods/tempo#fee-sponsorship) for details.
 
-### With machine-token payments
-
-Set `machineTokenEnabled: true` to let compatible clients pay a single-recipient charge through Tempo's unified first-party machineUSD route.
-
-```ts twoslash
-import { Mppx, tempo } from 'mppx/server'
-
-const mppx = Mppx.create({
-  methods: [
-    tempo.charge({
-      machineTokenEnabled: true, // [!code hl]
-    }),
-  ],
-})
-```
-
-The server advertises the route in its Challenge. On Tempo mainnet or Moderato, the client uses the route when it holds enough machineUSD and the swap can execute. Otherwise, it falls back to `autoSwap` when configured, then the requested TIP-20 transfer path. Charges and Sessions use the same machineUSD deployment. The route supports `push`, `pull`, relay, and fee-sponsored settlement; split charges use the standard transfer path.
-
 ### Zero-dollar auth
 
 Set `amount: "0"` to issue an identity-only Challenge. The client returns a `proof` payload instead of `transaction` or `hash`, and the server verifies the signature against the `source` DID.
@@ -218,7 +200,7 @@ See [`tempo.charge` server reference](/sdk/typescript/server/Method.tempo.charge
 
 ## Client
 
-Use [`tempo.charge`](/sdk/typescript/client/Method.tempo.charge) with `Mppx.create` to automatically handle `402` responses. For non-zero amounts, the client signs a TIP-20 transfer and retries with the Credential. If the server enables machine-token settlement, the client tries that route first without additional client configuration. For zero-amount Challenges, it signs a proof message and retries with a `proof` payload instead.
+Use [`tempo.charge`](/sdk/typescript/client/Method.tempo.charge) with `Mppx.create` to automatically handle `402` responses. For non-zero amounts, the client signs a TIP-20 transfer and retries with the Credential. For zero-amount Challenges, it signs a proof message and retries with a `proof` payload instead.
 
 <Tabs stateKey="account-source">
 <Tab title="Accounts SDK">

--- a/src/pages/payment-methods/tempo/index.mdx
+++ b/src/pages/payment-methods/tempo/index.mdx
@@ -102,4 +102,4 @@ const mppx = Mppx.create({
 })
 ```
 
-For Sessions, pass the same `feePayer` parameter to [`tempo.session`](/sdk/typescript/server/Method.tempo.session) alongside `account` and `store`. A fee payer service sponsors open, top-up, scheduled settlement, and cooperative close transactions. `mppx` applies the configured headers to every remote fee-payer request and always sets `Content-Type: application/json`.
+For Sessions, pass the same `feePayer` parameter to [`tempo.session`](/sdk/typescript/server/Method.tempo.session) alongside `account` and `store`. A fee payer service sponsors open, top-up, scheduled settlement, and cooperative close transactions. For pull-mode charges, `mppx` sends fill requests through the configured fee-payer transport, then broadcasts the completed transaction through the chain RPC transport.

--- a/src/pages/payment-methods/tempo/session.mdx
+++ b/src/pages/payment-methods/tempo/session.mdx
@@ -91,30 +91,6 @@ Either party can close the channel. The server closes the precompile-backed chan
 
 ::::
 
-## Machine-token funding
-
-Enable Tempo's first-party machine-token route when clients can fund charge and Session payments from the same machineUSD balance.
-
-```ts twoslash
-import { Mppx, Store, tempo } from 'mppx/server'
-import { privateKeyToAccount } from 'viem/accounts'
-
-const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
-
-const mppx = Mppx.create({
-  methods: [
-    tempo.session({
-      account,
-      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
-      machineTokenEnabled: true, // [!code hl]
-      store: Store.memory(),
-    }),
-  ],
-})
-```
-
-The server still requests its payout currency and recipient. A compatible client uses machineUSD when the route is verified and its balance is sufficient, then falls back to the requested stablecoin. The selected rail remains fixed until the channel closes. Clients don't need additional machine-token configuration.
-
 ## Session Receipts
 
 Session Receipts differ from charge Receipts. The `reference` field contains the payment channel ID (a `bytes32` hash), not a transaction hash. The on-chain settlement transaction hash is only available after closing the channel.

--- a/src/pages/quickstart/server.mdx
+++ b/src/pages/quickstart/server.mdx
@@ -293,7 +293,7 @@ const mppx = Mppx.create({
 })
 ```
 
-When a pull-mode client submits a signed transaction, the server co-signs with the fee payer account or delegates to the remote service before broadcasting. `mppx` sends the configured headers on both JSON-RPC and transaction-completion requests and reserves `Content-Type: application/json`. Push-mode clients pay their own gas, so `feePayer` is ignored for those requests. Zero-amount proof flows do not create a transaction at all.
+When a pull-mode client submits a signed transaction, the server co-signs with the fee payer account or delegates the fill to the remote service. Remote fills use the configured fee-payer transport, and `mppx` broadcasts the completed transaction through the chain RPC transport. Push-mode clients pay their own gas, so `feePayer` is ignored for those requests. Zero-amount proof flows do not create a transaction at all.
 
 ### Optimistic verification
 

--- a/src/pages/sdk/typescript/client/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.charge.mdx
@@ -62,8 +62,6 @@ const response = await fetch('https://mpp.dev/api/ping/paid')
 
 For non-zero Challenges, the client returns either a `transaction` or `hash` payload depending on `mode`. For zero-amount Challenges, it always returns a `proof` payload and skips transaction construction.
 
-When a server advertises `machineTokenEnabled: true`, the client first tries the first-party Tempo machine-token route for a compatible single-recipient charge. If the account lacks enough machine tokens or the route can't execute, the client uses `autoSwap` when configured, then the requested stablecoin transfer path.
-
 ## Return type
 
 ```ts

--- a/src/pages/sdk/typescript/client/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session.mdx
@@ -196,8 +196,6 @@ When `Fetch.from` or `Mppx.create` opens a channel automatically, it keeps the n
 
 Direct Credential creation and `tempo.session.manager()` keep explicit lifecycle ownership.
 
-When the server enables machine-token funding, the client uses machineUSD if a verified route and sufficient balance are available. Otherwise, it opens the channel in the requested payment currency. The channel keeps that rail until it closes; no client option is required.
-
 ## Return type
 
 ```ts

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -127,7 +127,7 @@ const mppx = Mppx.create({
 
 ### With an authenticated remote fee payer
 
-Pass request headers with the remote service URL. `mppx` applies them to fee-payer JSON-RPC and transaction-completion requests.
+Pass request headers with the remote service URL. `mppx` sends fill requests through the configured fee-payer transport, then broadcasts the completed transaction through the chain RPC transport.
 
 ```ts [server.ts]
 import { Mppx, tempo } from 'mppx/server'
@@ -145,24 +145,6 @@ const mppx = Mppx.create({
   ],
 })
 ```
-
-### With machine-token payments
-
-Enable the unified first-party Tempo machineUSD route for compatible single-recipient charges. Clients use it when they hold enough machineUSD, then fall back to the requested stablecoin path when the route isn't available.
-
-```ts twoslash
-import { Mppx, tempo } from 'mppx/server'
-
-const mppx = Mppx.create({
-  methods: [
-    tempo.charge({
-      machineTokenEnabled: true, // [!code focus]
-    }),
-  ],
-})
-```
-
-Machine-token settlement supports Tempo mainnet and Moderato across `push`, `pull`, relay, and fee-sponsored charge flows.
 
 ### With Tempo API relay
 
@@ -302,13 +284,6 @@ Function that returns a viem client for the given chain ID. Overrides the defaul
 
 Renders a payment page when the request accepts `text/html`. Pass an object to customize the page.
 
-### machineTokenEnabled (optional)
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Advertises the unified first-party Tempo machineUSD settlement route for compatible single-recipient charges. Clients try this route before `autoSwap` or a direct transfer. Unsupported chains reject the request.
-
 ### memo (optional)
 
 - **Type:** `string`
@@ -423,12 +398,6 @@ ISO 8601 timestamp for when the payment Challenge expires.
 - **Type:** `Record<string, string>`
 
 Server-defined correlation data. `mppx` serializes it as the base64url-encoded `opaque` auth-param on the Challenge, and clients echo that same string back in the Credential.
-
-### machineTokenEnabled (optional)
-
-- **Type:** `boolean`
-
-Overrides machine-token settlement for this request. The configured method default applies when omitted.
 
 ### recipient
 

--- a/src/pages/sdk/typescript/server/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.mdx
@@ -125,13 +125,6 @@ Account or remote service for sponsoring transaction fees. Pass a viem `Account`
 
 Function that returns a viem client for the given chain ID. Overrides the default RPC configuration.
 
-### machineTokenEnabled (optional)
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Enables first-party machine-token settlement for the generated `tempo.charge` and `tempo.session` methods. Compatible clients use machineUSD when a verified route and sufficient balance are available, then fall back to the requested payment currency.
-
 ### onPaymentSuccess (optional)
 
 - **Type:** `Method.OnPaymentSuccessFn<typeof tempo.Methods.charge> & Method.OnPaymentSuccessFn<typeof tempo.Methods.session>`

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -80,30 +80,6 @@ const mppx = Mppx.create({
 })
 ```
 
-### With machine-token payments
-
-Set `machineTokenEnabled: true` to let compatible clients fund Sessions with Tempo's first-party machine token.
-
-```ts twoslash
-import { Mppx, Store, tempo } from 'mppx/server'
-import { privateKeyToAccount } from 'viem/accounts'
-
-const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
-
-const mppx = Mppx.create({
-  methods: [
-    tempo.session({
-      account,
-      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
-      machineTokenEnabled: true, // [!code focus]
-      store: Store.memory(),
-    }),
-  ],
-})
-```
-
-The client uses machineUSD when the verified route has sufficient balance. Otherwise, it opens the channel in the requested payment currency. A Session stays on its selected payment rail until the channel closes.
-
 ## Migrate from Legacy Sessions
 
 Register `tempo.session()` beside `tempo.sessionLegacy()` during migration so existing clients keep working while new clients use Sessions. This server-side migration configuration requires `mppx` 0.8.15 or earlier.
@@ -268,13 +244,6 @@ Fee token used for Session management, scheduled settlement, and cooperative clo
 - **Type:** `(parameters: { chainId?: number }) => MaybePromise<Client>`
 
 Function that returns a viem client for the given chain ID.
-
-### machineTokenEnabled (optional)
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Advertises first-party machine-token funding when the configured deployment is available on the canonical reserve. Clients use machineUSD when a verified route and sufficient balance are available, then fall back to the requested payment currency.
 
 ### minVoucherDelta (optional)
 


### PR DESCRIPTION
## Motivation

Keep the MPP documentation aligned with the public APIs and behavior in mppx 0.9.0.

## Summary

- remove machineUSD charge and Session guidance for the retired payment rail
- document hosted fee-payer fill routing and chain RPC broadcasting
- update the mppx dependency, lockfile, and sync bookmark to 0.9.0

## Key design considerations

- remove unsupported options instead of preserving migration-only examples
- track the tagged release and exact upstream commit in the sync bookmark