### PR TITLE
Add Amazon Intelligence (Light Anchor)

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -353,7 +353,14 @@ export const services: ServiceDef[] = [
     icon: "https://amazon.lightanchor.ai/favicon.svg",
     categories: ["data", "web"],
     integration: "third-party",
-    tags: ["amazon", "ecommerce", "asin", "product-data", "listing-audit", "reviews"],
+    tags: [
+      "amazon",
+      "ecommerce",
+      "asin",
+      "product-data",
+      "listing-audit",
+      "reviews",
+    ],
     status: "active",
     docs: {
       homepage: "https://amazon.lightanchor.ai",
@@ -370,6 +377,12 @@ export const services: ServiceDef[] = [
         desc: "Unified product search: Amazon results + optional live Shopify storefront fan-out with agent-executable cart routes",
         amount: "50000",
         unitType: "search",
+      },
+      {
+        route: "POST /v1/shop/cart",
+        desc: "Build a cart on any Shopify store and return its checkout URL (payment completes on the store)",
+        amount: "50000",
+        unitType: "cart",
       },
       {
         route: "POST /v1/amazon/product",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -342,6 +342,49 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+  // ── Amazon Intelligence ───────────────────────────────────────────────
+  {
+    id: "amazon-intel",
+    name: "Amazon Intelligence",
+    url: "https://amazon.lightanchor.ai",
+    serviceUrl: "https://amazon.lightanchor.ai",
+    description:
+      "Amazon product data and verdicts for agents: live ASIN snapshots, instant listing audits (score, ranked defects, top fixes), and evidence-linked review-insight reports. Run by Light Anchor, an agency operating real Amazon brands.",
+    icon: "https://amazon.lightanchor.ai/favicon.svg",
+    categories: ["data", "web"],
+    integration: "third-party",
+    tags: ["amazon", "ecommerce", "asin", "product-data", "listing-audit", "reviews"],
+    status: "active",
+    docs: {
+      homepage: "https://amazon.lightanchor.ai",
+      llmsTxt: "https://amazon.lightanchor.ai/llms.txt",
+      apiReference: "https://amazon.lightanchor.ai/openapi.json",
+    },
+    provider: { name: "Light Anchor", url: "https://lightanchor.ai" },
+    realm: "amazon.lightanchor.ai",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/amazon/product",
+        desc: "Live product snapshot (~6s): price, availability, BSR, rating distribution, seller, images",
+        amount: "50000",
+        unitType: "request",
+      },
+      {
+        route: "POST /v1/amazon/listing-audit",
+        desc: "Instant listing audit: 0-100 score, grade, severity-ranked defects, top fixes",
+        amount: "1000000",
+        unitType: "audit",
+      },
+      {
+        route: "POST /v1/review-insights",
+        desc: "Evidence-linked review insight report (async ~3 min; poll GET /v1/review-insights/:jobId free)",
+        amount: "5000000",
+        unitType: "report",
+      },
+    ],
+  },
   // ── AgentMail ──────────────────────────────────────────────────────────
   {
     id: "agentmail",

--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -349,7 +349,7 @@ export const services: ServiceDef[] = [
     url: "https://amazon.lightanchor.ai",
     serviceUrl: "https://amazon.lightanchor.ai",
     description:
-      "Amazon product data and verdicts for agents: live ASIN snapshots, instant listing audits (score, ranked defects, top fixes), and evidence-linked review-insight reports. Run by Light Anchor, an agency operating real Amazon brands.",
+      "Product search and Amazon intelligence for agents: unified product search (Amazon results + live Shopify storefront-MCP hits with agent-executable cart routes), live ASIN snapshots, instant listing audits (score, ranked defects, top fixes), and evidence-linked review-insight reports. Run by Light Anchor, an agency operating real Amazon brands.",
     icon: "https://amazon.lightanchor.ai/favicon.svg",
     categories: ["data", "web"],
     integration: "third-party",
@@ -365,6 +365,12 @@ export const services: ServiceDef[] = [
     intent: "charge",
     payments: [TEMPO_PAYMENT],
     endpoints: [
+      {
+        route: "POST /v1/shop/search",
+        desc: "Unified product search: Amazon results + optional live Shopify storefront fan-out with agent-executable cart routes",
+        amount: "50000",
+        unitType: "search",
+      },
       {
         route: "POST /v1/amazon/product",
         desc: "Live product snapshot (~6s): price, availability, BSR, rating distribution, seller, images",


### PR DESCRIPTION
## Motivation

Product search and Amazon intelligence for agents — the first Amazon coverage in the directory, now with a unified buy-flow: agents can search across Amazon + live Shopify storefronts, then get a real checkout URL. Serves commerce, research, and shopping agents that today have no per-call, keyless way to read Amazon or route a purchase.

- **Service name:** Amazon Intelligence
- **Live service URL:** https://amazon.lightanchor.ai
- **Provider URL:** https://lightanchor.ai
- **OpenAPI or API reference URL:** https://amazon.lightanchor.ai/openapi.json

**Endpoints:** `/v1/shop/search` $0.05 (Amazon results + Shopify storefront-MCP fan-out with agent-executable routes) · `/v1/shop/cart` $0.05 (builds a real cart on any Shopify store, returns its checkout URL — payment completes on the store) · `/v1/amazon/product` $0.05 (live ASIN snapshot ~6s) · `/v1/amazon/listing-audit` $1.00 (operator-grade conversion audit) · `/v1/review-insights` $5.00 (evidence-linked review analysis, async with free polling)

## Summary

- [x] The service is live and accepts MPP payments (mainnet; multiple settled transactions).
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [x] `pnpm generate:discovery` succeeds.
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds.

## Key design considerations

- **Integration:** third-party
- **Payment methods and intents:** Tempo USDC.e, `charge` intent (one-time per call).
- **Provider relationship:** We (Light Anchor Inc) own and operate the service end to end.
- **Directory fit:** No existing listing covers Amazon or cross-store agent-executable shopping. Production details: `npx mppx validate https://amazon.lightanchor.ai` reports 0 failures (108 checks); registered on MPPScan; `/llms.txt` + `/skill.md` served from the origin; malformed inputs 422 before settlement (agents never charged for typos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
