### PR TITLE
Enforce dynamic offer unit types

### DIFF
--- a/scripts/generate-discovery.test.ts
+++ b/scripts/generate-discovery.test.ts
@@ -105,7 +105,12 @@ describe("buildPayment", () => {
 
   it("builds dynamic payment", () => {
     const result = buildPayment(
-      { route: "POST /bar", desc: "dynamic test", dynamic: true },
+      {
+        route: "POST /bar",
+        desc: "dynamic test",
+        dynamic: true,
+        unitType: "minute",
+      },
       paymentSvc({ intent: "session" }),
     );
     expect(result).toEqual({
@@ -115,6 +120,7 @@ describe("buildPayment", () => {
       currency: USDC,
       decimals: 6,
       description: "dynamic test",
+      unitType: "minute",
     });
   });
 

--- a/scripts/generate-discovery.ts
+++ b/scripts/generate-discovery.ts
@@ -90,12 +90,15 @@ export function buildPayment(
   if (ep.dynamic) {
     const dyn: Record<string, unknown> = { ...base, dynamic: true };
     if (ep.amountHint) dyn.amountHint = ep.amountHint;
+    if (ep.unitType) dyn.unitType = ep.unitType;
     return dyn;
   }
 
-  const payment: Record<string, unknown> = { ...base, amount: ep.amount };
-  if (ep.unitType) payment.unitType = ep.unitType;
-  return payment;
+  return {
+    ...base,
+    amount: ep.amount,
+    ...(ep.unitType ? { unitType: ep.unitType } : {}),
+  };
 }
 
 export function validateServices(svcs: ServiceDef[]): void {


### PR DESCRIPTION
## Summary

- Preserve an endpoint-configured `unitType` for dynamic payment offers.
- TempVPN fixed-session purchases accept `duration_seconds`, but bill in one-minute units; its directory offer now correctly advertises `unitType: "minute"`.
- Fixed-price offer behavior is unchanged.

## Verification

- `pnpm vitest run scripts/generate-discovery.test.ts`