### PR TITLE
Enforce dynamic offer unit types

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11059,7 +11059,7 @@ export const services: ServiceDef[] = [
         desc: "Buy a fixed-duration WireGuard VPN session",
         dynamic: true,
         amountHint:
-          "$0.01 per minute; duration must be a whole number of minutes.",
+          "$0.01 per billed minute; send duration_seconds as a positive multiple of 60.",
         unitType: "minute",
       },
       {

--- a/scripts/generate-discovery.test.ts
+++ b/scripts/generate-discovery.test.ts
@@ -105,7 +105,12 @@ describe("buildPayment", () => {
 
   it("builds dynamic payment", () => {
     const result = buildPayment(
-      { route: "POST /bar", desc: "dynamic test", dynamic: true },
+      {
+        route: "POST /bar",
+        desc: "dynamic test",
+        dynamic: true,
+        unitType: "minute",
+      },
       paymentSvc({ intent: "session" }),
     );
     expect(result).toEqual({
@@ -115,6 +120,7 @@ describe("buildPayment", () => {
       currency: USDC,
       decimals: 6,
       description: "dynamic test",
+      unitType: "minute",
     });
   });
 

--- a/scripts/generate-discovery.ts
+++ b/scripts/generate-discovery.ts
@@ -90,12 +90,15 @@ export function buildPayment(
   if (ep.dynamic) {
     const dyn: Record<string, unknown> = { ...base, dynamic: true };
     if (ep.amountHint) dyn.amountHint = ep.amountHint;
+    if (ep.unitType) dyn.unitType = ep.unitType;
     return dyn;
   }
 
-  const payment: Record<string, unknown> = { ...base, amount: ep.amount };
-  if (ep.unitType) payment.unitType = ep.unitType;
-  return payment;
+  return {
+    ...base,
+    amount: ep.amount,
+    ...(ep.unitType ? { unitType: ep.unitType } : {}),
+  };
 }
 
 export function validateServices(svcs: ServiceDef[]): void {


### PR DESCRIPTION
## Motivation

TempVPN provides temporary WireGuard VPN access through a registry-owned Tempo MPP control plane. Agents can discover eligible exit nodes, buy portable fixed-duration access, or open a separate metered Session v2 stream. This update makes the directory’s dynamic fixed-session metadata unambiguous: the API receives seconds while billing is per minute.

- **Service name:** TempVPN
- **Live service URL:** https://registry.tempvpn.xyz
- **Provider URL:** https://tempvpn.xyz
- **OpenAPI or API reference URL:** https://registry.tempvpn.xyz/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [x] `pnpm generate:discovery` succeeds.
- [ ] `pnpm check:types` passes.
- [x] `pnpm build` succeeds.

This PR preserves endpoint-configured `unitType` values for dynamic payment offers and updates TempVPN’s hint to: `$0.01 per billed minute; send duration_seconds as a positive multiple of 60.`

## Key design considerations

- **Integration:** third-party
- **Payment methods and intents:** Tempo MPP; `charge` for dynamic fixed-session purchases and `session` for Session v2 metered streaming.
- **Provider relationship:** I operate TempVPN.
- **Directory fit:** TempVPN is a live production service with a public registry, MPP payment challenges, OpenAPI contract, and stable documentation. Its node discovery, portable prepaid balances, and WireGuard delivery are distinct from existing directory entries.