### PR TITLE
Add Neurobird Search to the services registry

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -67,6 +67,13 @@ export const TEMPO_PAYMENT: PaymentDefaults = {
   decimals: 6,
 };
 
+/** Common payment defaults for EVM USDC services, settled via the x402 exact flow */
+export const EVM_BASE_USDC_PAYMENT: PaymentDefaults = {
+  method: "evm",
+  currency: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  decimals: 6,
+};
+
 /** Common payment defaults for Stripe MPP services */
 export const STRIPE_PAYMENT: PaymentDefaults = {
   method: "stripe",
@@ -173,6 +180,37 @@ export const services: ServiceDef[] = [
   },
 
   // ── RxAtlas ───────────────────────────────────────────────────────────
+  // ── Neurobird Search ──────────────────────────────────────────────────
+  {
+    id: "neurobird-search",
+    name: "Neurobird Search",
+    url: "https://search.neurobird.com",
+    serviceUrl: "https://search.neurobird.com",
+    description:
+      "Web search for AI agents that returns ranked results with the relevant page passages already extracted, so a follow up fetch is usually unnecessary. Results are fused across several engines with reciprocal rank fusion, and grounded answers carry quotes matched back against their source text.",
+    icon: "https://search.neurobird.com/assets/img/neurobird-logo.png",
+    categories: ["search", "ai"],
+    integration: "third-party",
+    tags: ["web-search", "rag", "agents", "mcp", "extraction", "citations"],
+    status: "active",
+    docs: {
+      homepage: "https://search.neurobird.com",
+      llmsTxt: "https://search.neurobird.com/llms.txt",
+      apiReference: "https://search.neurobird.com/openapi.json",
+    },
+    provider: { name: "Neurobird", url: "https://neurobird.com" },
+    realm: "search.neurobird.com",
+    intent: "charge",
+    payments: [EVM_BASE_USDC_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /paid/search",
+        desc: "Web search returning ranked results with page passages already extracted",
+        amount: "5000",
+        unitType: "request",
+      },
+    ],
+  },
   {
     id: "rxatlas",
     name: "RxAtlas",


### PR DESCRIPTION
## Motivation

Neurobird Search is a web search API built for agents rather than for people clicking links. One call fans out across several search engines, fuses the rankings with reciprocal rank fusion, fetches and extracts the top pages, and ranks the passages inside them, so a result arrives with the part of the page that answers the query already extracted and a follow up fetch is usually unnecessary. When a grounded answer is requested, every supporting quote is matched back against its source text and a quote that fails the match is returned marked unverified rather than silently dropped.

- **Service name:** Neurobird Search
- **Live service URL:** https://search.neurobird.com
- **Provider URL:** https://neurobird.com
- **OpenAPI or API reference URL:** https://search.neurobird.com/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [x] `pnpm generate:discovery` succeeds.
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds.

Update: I have now run the toolchain rather than leaving those three boxes on trust. On Node 23.9 / pnpm 10.22 (the repo asks for Node >= 24, so pnpm warns about the engine, and all three still complete):

```
$ pnpm generate:discovery
Generated public/services/llms.txt (143 services)
Generated schemas/discovery.json (143 services, 1457 endpoints)
Generated public/services/catalog.json (143 services)
Generated schemas/discovery.example.json (3 services)
  1078 paid, 196 dynamic, 183 free
exit 0

$ pnpm check:types      # tsc --noEmit
exit 0

$ pnpm build
vite build: built in 47.76s
[ssg] 395 files generated
exit 0
```

The generated `schemas/discovery.json` contains the entry as expected: `Neurobird Search`, `https://search.neurobird.com`, one paid endpoint `POST /paid/search`, intent `charge`, method `evm`, USDC on Base.

The only red check on this PR is Vercel, which is the fork deploy authorization your bot flagged and needs a Tempo team member. Socket Security, label, contributor guidance and changed-services all pass.

Verification of the service itself, using your own CLI:

```
$ npx mppx validate https://search.neurobird.com
Discovery (/openapi.json)
  ✓ Document found and parseable
  ✓ Valid OpenAPI structure
  ✓ Paid endpoints found (2 endpoint(s))
POST /paid/search
  ✓ Returns 402 without credentials
  ✓ WWW-Authenticate header present (Payment scheme)
  ✓ Challenge parseable (evm/charge)
  ✓ Challenge has id / realm / expires in the future
  ✓ Realm matches server hostname
  ✓ Valid recipient address
  ✓ Valid currency address (mainnet)
  ✓ Amount is valid integer string
  ✓ Has chainId (8453)
  Error Handling
  ✓ Malformed credential returns 402 (not 500)
  ✓ Error response includes fresh challenge

Summary: 31 passed, 2 skipped
```

## Key design considerations

- **Integration:** third-party
- **Payment methods and intents:** `evm` charge, USDC on Base (chainId 8453), settled through the x402 exact flow via `https://x402.org/facilitator`, which is the arrangement `evm.charge({ ..., x402: { facilitator } })` describes in the docs. This PR adds an `EVM_BASE_USDC_PAYMENT` constant alongside the existing Tempo and Stripe ones, since every current entry is Tempo or Stripe. Very happy to drop it and use a different pattern if you would rather shape EVM entries another way.
- **Provider relationship:** I own and operate the service.
- **Directory fit:** No existing entry is a duplicate. The nearest listings are SerpApi and Brave Search, which return links and snippets, and Exa. What is different here is that the passage extraction and the answer grounding happen inside the same call, and that quote verification is exposed to the caller as a per quote `verified` boolean rather than being an internal detail. Priced at $0.005 per request.
- **Disclosure:** the service is live and in production, but it is newly launched, so it has no usage history yet. Entirely reasonable if you would rather wait for that before adding it to a curated list.

Also registered on MPPScan: https://mppscan.com/server/4bf664e29dcf63d2b6f633ccb74ff9151ee4fea0e6c8465544ada55f5cc958fd
