### PR TITLE
fix: remove comparison CTA from homepage

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -116,9 +116,6 @@ export function LandingPage() {
               <Button className="w-full sm:w-auto" href="/quickstart/server">
                 Add payments to your API
               </Button>
-              <Button className="w-full sm:w-auto" href="/mpp-vs-x402">
-                Compare MPP vs x402
-              </Button>
             </div>
           </div>
 


### PR DESCRIPTION
## Motivation

Remove the redundant comparison CTA from the MPP homepage.

## Summary

- Remove the MPP vs x402 button from the homepage hero

## Key design considerations

- Preserve the two primary agent and API onboarding CTAs