### PR TITLE
Add VeriCite: verified U.S. legal research (MPP top-up + MCP metering)

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -122,6 +122,36 @@ export interface ServiceDef {
 
 // prettier-ignore
 export const services: ServiceDef[] = [
+  // ── VeriCite ──────────────────────────────────────────────────────────
+  {
+    id: "vericite",
+    name: "VeriCite",
+    url: "https://vericite.net",
+    serviceUrl: "https://vericite.net",
+    description:
+      "Verified U.S. legal research: hybrid case search, statutes across 52 jurisdictions, word-for-word quote verification, and dated good-law checks, metered per call over MCP.",
+    categories: ["data", "search"],
+    integration: "first-party",
+    tags: ["legal", "case-law", "statutes", "citations", "verification", "mcp"],
+    status: "active",
+    docs: {
+      homepage: "https://vericite.net",
+      llmsTxt: "https://vericite.net/llms.txt",
+    },
+    provider: { name: "Arkimedos LLC", url: "https://vericite.net" },
+    realm: "vericite-agent-topup",
+    intent: "charge",
+    payments: [STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /api/agent/topup",
+        desc: "Fund a prepaid research balance ($1-$500). Tool calls over MCP at https://vericite.net/mcp are then metered per call: basic lookups free, metered calls $0.01-$0.25, dossier download $0.50.",
+        dynamic: true,
+        amountHint: "$1-$500 top-up; per-call prices stated before each charge",
+        docs: "https://vericite.net/llms.txt",
+      },
+    ],
+  },
   // ── Apex DB ───────────────────────────────────────────────────────────
   {
     id: "apex-db",


### PR DESCRIPTION
## Motivation

VeriCite is a legal-research service for AI agents: hybrid search over 10.78M
U.S. judicial opinions, statutes across 52 jurisdictions, deterministic
word-for-word quote verification with pincite locators, and dated good-law
checks. Agents fund a prepaid balance through the MPP endpoint and are then
metered per tool call over MCP, with every price stated before the charge.

- **Service name:** VeriCite
- **Live service URL:** https://vericite.net/api/agent/topup
- **Provider URL:** https://vericite.net
- **OpenAPI or API reference URL:** https://vericite.net/llms.txt

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [x] `pnpm generate:discovery` succeeds.
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds.

## Key design considerations

- **Integration:** first-party
- **Payment methods and intents:** stripe (SPT cards), charge intent, on the
  prepaid top-up endpoint; per-call metering rides bearer tokens over MCP.
- **Provider relationship:** We (Arkimedos LLC) own and operate the service.
- **Directory fit:** Production-ready; no existing listing offers quote-level
  verification of U.S. case law with pincite locators.
