### PR TITLE
Add Weftly to the service directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11227,4 +11227,72 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── Weftly ─────────────────────────────────────────────────────────────
+  {
+    id: "weftly",
+    name: "Weftly",
+    url: "https://weftly.ai",
+    serviceUrl: "https://api.weftly.ai",
+    description:
+      "Pay-per-job AI media processing — transcribe, summarize, find and cut clips, and publish videos to YouTube.",
+    icon: "https://chat.weftly.ai/brand/weftly-icon.svg",
+    categories: ["ai", "media"],
+    integration: "first-party",
+    tags: ["transcription", "summarization", "video", "audio", "clips", "youtube", "whisper"],
+    status: "active",
+    docs: {
+      homepage: "https://weftly.ai",
+      llmsTxt: "https://api.weftly.ai/llms.txt",
+      apiReference: "https://api.weftly.ai/openapi.json",
+    },
+    provider: { name: "Weftly", url: "https://weftly.ai" },
+    realm: "api.weftly.ai",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT, STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /api/test",
+        desc: "MPP smoke test",
+        amount: "10000",
+        unitType: "request",
+      },
+      {
+        route: "POST /api/v1/sessions",
+        desc: "Create a session (free, identity only)",
+      },
+      {
+        route: "POST /api/v1/jobs",
+        desc: "Create a transcribe, summarize, find_clips, or clip-extraction job",
+        dynamic: true,
+        amountHint: "$0.50 – $2.00 by job type and media",
+      },
+      {
+        route: "GET /api/v1/jobs/:job_id/upload-url",
+        desc: "Get a presigned upload URL (upload-based jobs)",
+        dynamic: true,
+        amountHint: "$0.50 – $2.00 by job type and media",
+      },
+      {
+        route: "POST /api/v1/jobs/:job_id/complete-upload",
+        desc: "Confirm upload and start processing (transcribe, summarize, find_clips)",
+        dynamic: true,
+        amountHint: "$0.50 – $2.00 by job type and media",
+      },
+      {
+        route: "POST /api/v1/jobs/:job_id/process",
+        desc: "Verify payment and start processing (extract_clip, extract_vertical_clip, publish_youtube)",
+        dynamic: true,
+        amountHint: "$0.50 – $1.75",
+      },
+      {
+        route: "GET /api/v1/jobs/:job_id",
+        desc: "Get job status and outputs",
+      },
+      {
+        route: "GET /api/v1/jobs/:job_id/outputs/:role/download",
+        desc: "Download a job output (transcript, summary, clip video, clip candidates)",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Motivation

Weftly is a pay-per-job AI media processing API — transcribe, summarize, find/cut clips, and publish videos to YouTube. Serves independent journalists and small newsrooms self-processing their own audio/video.

- **Service name:** Weftly
- **Live service URL:** https://api.weftly.ai
- **Provider URL:** https://weftly.ai
- **OpenAPI or API reference URL:** https://api.weftly.ai/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [ ] `pnpm generate:discovery` succeeds. (not run locally — pnpm/corepack signature verification failed in my environment; entry follows the existing `ServiceDef` shape exactly)
- [ ] `pnpm check:types` passes. (same as above)
- [ ] `pnpm build` succeeds. (same as above)

## Key design considerations

- **Integration:** first-party — we operate api.weftly.ai directly.
- **Payment methods and intents:** dual-rail, `charge` intent. Tempo USDC.e (mainnet) and Stripe MPP (card, via Shared Payment Tokens for agent callers). `payments: [TEMPO_PAYMENT, STRIPE_PAYMENT]`.
- **Provider relationship:** we own and operate the service.
- **Directory fit:** distinct from existing transcription/AI listings — Weftly is a full pipeline (upload → Whisper transcript → optional Claude summary/clip-finding → ffmpeg cut/normalize → optional YouTube publish), not a raw model wrapper. Pricing is per-job ($0.50–$2.00 depending on job type and media), not per-token.

Prices and endpoints pulled directly from our pricing SSOT (`weftly-worker/src/core/config/pricing.ts`) as of this PR. Happy to adjust format/detail to match directory conventions.