### PR TITLE
docs: fix style guide audit findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@resvg/resvg-wasm": "^2.6.2",
     "@stripe/stripe-js": "^9.7.0",
     "@vercel/blob": "^2.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.5.0
         version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@resvg/resvg-wasm':
         specifier: ^2.6.2
         version: 2.6.2

--- a/scripts/check-parameter-order.test.ts
+++ b/scripts/check-parameter-order.test.ts
@@ -1,0 +1,115 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REFERENCES_DIR = join(import.meta.dirname, "../src/pages/sdk/typescript");
+
+function findMdxFiles(directory: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...findMdxFiles(path));
+    else if (entry.name.endsWith(".mdx")) files.push(path);
+  }
+
+  return files;
+}
+
+function checkParameterOrder(
+  content: string,
+): Array<{ actual: string[]; expected: string[]; line: number }> {
+  const violations: Array<{
+    actual: string[];
+    expected: string[];
+    line: number;
+  }> = [];
+  const lines = content.split("\n");
+  let parameters: Array<{ line: number; name: string }> = [];
+  let inCodeFence = false;
+  let inParameters = false;
+
+  const checkSection = () => {
+    const actual = parameters.map(({ name }) => name);
+    const expected = [...actual].sort((a, b) =>
+      a.localeCompare(b, "en", { sensitivity: "base" }),
+    );
+
+    if (actual.join("\0") !== expected.join("\0")) {
+      violations.push({
+        actual,
+        expected,
+        line: parameters[0]?.line ?? 1,
+      });
+    }
+    parameters = [];
+  };
+
+  for (const [index, line] of lines.entries()) {
+    if (line.startsWith("```")) {
+      inCodeFence = !inCodeFence;
+      continue;
+    }
+    if (inCodeFence) continue;
+
+    if (line.startsWith("## ")) {
+      if (inParameters) checkSection();
+      inParameters = line.trim() === "## Parameters";
+      continue;
+    }
+    if (!inParameters) continue;
+
+    const heading = line.match(/^###\s+(.+?)\s*$/);
+    if (heading) {
+      const name = heading[1]
+        .replaceAll("`", "")
+        .replace(/\s+\([^)]*\)$/, "")
+        .trim();
+      parameters.push({ line: index + 1, name });
+    }
+  }
+
+  if (inParameters) checkSection();
+  return violations;
+}
+
+describe("TypeScript reference parameter headings", () => {
+  it("finds out-of-order headings without reading code fences", () => {
+    expect(
+      checkParameterOrder(`## Parameters
+
+### zebra
+
+\`\`\`ts
+### ignored
+\`\`\`
+
+### alpha (optional)`),
+    ).toEqual([
+      {
+        actual: ["zebra", "alpha"],
+        expected: ["alpha", "zebra"],
+        line: 3,
+      },
+    ]);
+  });
+
+  for (const file of findMdxFiles(REFERENCES_DIR)) {
+    const relative = file.slice(REFERENCES_DIR.length + 1);
+
+    it(relative, () => {
+      const violations = checkParameterOrder(readFileSync(file, "utf8"));
+      const details = violations
+        .map(
+          ({ actual, expected, line }) =>
+            `line ${line}: ${actual.join(", ")} (expected ${expected.join(", ")})`,
+        )
+        .join("\n");
+
+      expect(
+        violations,
+        `Parameter headings must be alphabetized:\n${details}`,
+      ).toHaveLength(0);
+    });
+  }
+});

--- a/src/pages/advanced/discovery.mdx
+++ b/src/pages/advanced/discovery.mdx
@@ -298,7 +298,7 @@ Optional root-level metadata about the service:
 
 ## Build manually
 
-You can author a discovery document by hand following the [discovery specification](https://paymentauth.org/draft-payment-discovery-00.html). The document is a standard OpenAPI 3.1 file with two extensions:
+You can author a discovery document by hand following the discovery specification. The document is a standard OpenAPI 3.1 file with two extensions:
 
 ::::steps
 

--- a/src/pages/blog/go-and-ruby-sdks.mdx
+++ b/src/pages/blog/go-and-ruby-sdks.mdx
@@ -10,6 +10,9 @@ imageDescription: "Process machine payments with Go and Ruby SDKs"
 publishedAt: "2026-04-21"
 ---
 
+import { Cards } from 'vocs'
+import { SpecCard } from '../../components/SpecCard'
+
 # Go and Ruby SDKs [Two new SDKs for the Machine Payments Protocol]
 
 MPP now has official SDKs for Go and Ruby. Both implement the full MPP flow: core types, payment methods, server middleware, and client transports.
@@ -172,4 +175,7 @@ Pick the SDK that fits your application, or learn more about MPP.
 - **Go**: [github.com/tempoxyz/mpp-go](https://github.com/tempoxyz/mpp-go)
 - **Ruby**: [github.com/stripe/mpp-rb](https://github.com/stripe/mpp-rb)
 - **Quickstart**: [mpp.dev/quickstart](/quickstart)
-- **IETF Specification**: [paymentauth.org](https://paymentauth.org)
+
+<Cards>
+  <SpecCard to="https://paymentauth.org" />
+</Cards>

--- a/src/pages/blog/multi-method-discovery.mdx
+++ b/src/pages/blog/multi-method-discovery.mdx
@@ -10,11 +10,14 @@ imageDescription: "Advertise multiple payment methods in one discovery document"
 publishedAt: "2026-04-28"
 ---
 
+import { Cards } from 'vocs'
+import { SpecCard } from '../../components/SpecCard'
+
 # Multi-method discovery [Advertise multiple payment methods in one discovery document]
 
 One of the core tenants of MPP's design is that it is payment-method and currency agnostic. As of date, over ten payment methods are live across the protocol, spanning stablecoins on every EVM network, cards, and even Bitcoin. As more methods have been added to the protocol, we have seen an increase in services accepting multiple payment methods, multiple currencies, and even multiple intent types on the same endpoint.
 
-Until now, MPP's [discovery extension](https://paymentauth.org/draft-payment-discovery-00.html) only described a single payment offer per route. That meant registries and clients had to dynamically hit the endpoint and parse a `402` Challenge to learn the full set of payment options. With this update to the discovery spec, servers can declare all of their payment offers ahead of time and ensure that registries always have up to date information.
+Until now, MPP's discovery extension only described a single payment offer per route. That meant registries and clients had to dynamically hit the endpoint and parse a `402` Challenge to learn the full set of payment options. With this update to the discovery spec, servers can declare all of their payment offers ahead of time and ensure that registries always have up to date information.
 
 ## What changed
 
@@ -131,4 +134,7 @@ discovery(app, mppx, {
 
 - **Discovery docs**: [mpp.dev/advanced/discovery](/advanced/discovery)
 - **Multiple payment methods guide**: [mpp.dev/guides/multiple-payment-methods](/guides/multiple-payment-methods)
-- **IETF Specification**: [paymentauth.org/draft-payment-discovery-00](https://paymentauth.org/draft-payment-discovery-00)
+
+<Cards>
+  <SpecCard to="https://paymentauth.org/draft-payment-discovery-00" />
+</Cards>

--- a/src/pages/blog/sessions-improved.mdx
+++ b/src/pages/blog/sessions-improved.mdx
@@ -10,7 +10,9 @@ imageDescription: "Pay-as-you-go billing with improved sessions"
 publishedAt: "2026-06-17"
 ---
 
-import { MermaidDiagram } from "../../components/MermaidDiagram";
+import { Cards } from 'vocs'
+import { MermaidDiagram } from '../../components/MermaidDiagram'
+import { SpecCard } from '../../components/SpecCard'
 
 # An improved sessions experience [Faster, cheaper billing and formally specified]
 
@@ -51,7 +53,7 @@ The HTTP shape is the same as every MPP flow: the server returns a `402` Challen
 
 ### A formal, cross-network intent
 
-Sessions are now a [formal MPP intent](https://github.com/tempoxyz/mpp-specs/pull/280) rather than a Tempo-only feature. The [Tempo session IETF Specification](https://paymentauth.org/draft-tempo-session-00) defines the unidirectional channel and cumulative voucher model normatively, so the same developer experience can map onto different settlement layers well beyond blockchains.
+Sessions are now a [formal MPP intent](https://github.com/tempoxyz/mpp-specs/pull/280) rather than a Tempo-only feature. The Tempo session IETF Specification defines the unidirectional channel and cumulative voucher model normatively, so the same developer experience can map onto different settlement layers well beyond blockchains.
 
 Each payment method has different mechanics, but the model is shared: open a funded session, meter usage, top up if needed, and close with unused funds returned to the client.
 
@@ -155,6 +157,9 @@ console.log(response.status)
 
 ## Learn more
 
-- [Tempo session IETF Specification](https://paymentauth.org/draft-tempo-session-00)
 - [Sessions guide](/payment-methods/tempo/session)
 - [TIP-1034](https://tips.sh/1034)
+
+<Cards>
+  <SpecCard to="https://paymentauth.org/draft-tempo-session-00" />
+</Cards>

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -3,7 +3,9 @@ description: "Answers to common questions about MPP—payment methods, settlemen
 imageDescription: "Answers to common MPP questions"
 ---
 
+import { Cards } from 'vocs'
 import { FaqStructuredData } from '../components/FaqStructuredData'
+import { SpecCard } from '../components/SpecCard'
 
 <FaqStructuredData />
 
@@ -13,7 +15,7 @@ import { FaqStructuredData } from '../components/FaqStructuredData'
 
 No. MPP is payment-method agnostic—the protocol works with any payment rail.
 
-Today, [Tempo](/payment-methods/tempo) stablecoin payments, card payments through [Card](/payment-methods/card) or [Stripe](/payment-methods/stripe), and [Lightning](/payment-methods/lightning) payments are in production. Anyone can build a [custom payment method](/payment-methods/custom) by implementing the core control flow for their payment rail. See the full list of payment methods and specifications at [paymentauth.org](https://paymentauth.org).
+Today, [Tempo](/payment-methods/tempo) stablecoin payments, card payments through [Card](/payment-methods/card) or [Stripe](/payment-methods/stripe), and [Lightning](/payment-methods/lightning) payments are in production. Anyone can build a [custom payment method](/payment-methods/custom) by implementing the core control flow for their payment rail. The specification directory lists every payment method and intent.
 
 ## Do I need a stablecoin wallet?
 
@@ -31,7 +33,7 @@ See [MPP vs x402](/mpp-vs-x402) for a full side-by-side comparison, or [Use MPP 
 - **Designed for production.** MPP supports idempotency, expiration, request-body binding (digest), and request-tampering mitigations as first-class primitives.
 - **Performant payments.** MPP's session intent enables pay-as-you-go metering for payments as small as 0.0001 USD. Sessions achieve sub-100ms latency and near-zero per-request fees by settling off-chain vouchers, enabling high-throughput applications like token streaming or content aggregation. x402 requires an on-chain transaction per request.
 - **Permissionless extensibility.** Anyone can author and publish a new payment method or intent specification without approval from a foundation or intermediary. Payment methods compete on adoption and are independently maintained.
-- **IETF standards track.** The core [Payment HTTP Authentication Scheme](https://paymentauth.org) is submitted to the IETF for standardization.
+- **IETF standards track.** The core Payment HTTP Authentication Scheme is submitted to the IETF for standardization.
 
 ## Is MPP compatible with x402?
 
@@ -93,3 +95,9 @@ Yes. MPP includes an [MCP transport binding](/protocol/transports/mcp) that maps
 ## Who is building MPP?
 
 MPP is co-authored by Tempo and Stripe. The core specification is developed in the open and designed to be extended by any payment network or provider. The [Payment HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/) is submitted to the IETF.
+
+## Specification
+
+<Cards>
+  <SpecCard to="https://paymentauth.org" />
+</Cards>

--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -88,6 +88,10 @@ Yes. See the [server quickstart](/quickstart/server) to start accepting payments
 
 The core [Payment HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/) is submitted to the IETF standards track. Payment method and intent specifications (for example, charge, session) are separate documents that anyone can author and publish independently—they do not require IETF approval. This mirrors how the web works: HTTP is standardized, but content types and authentication schemes evolve independently.
 
+<Cards>
+  <SpecCard to="https://paymentauth.org" />
+</Cards>
+
 ## Can I use MPP outside of HTTP?
 
 Yes. MPP includes an [MCP transport binding](/protocol/transports/mcp) that maps the Challenge-Credential-Receipt flow onto the Model Context Protocol. This means MCP servers can monetize tool calls directly, and agents pay autonomously without OAuth or account setup.
@@ -95,9 +99,3 @@ Yes. MPP includes an [MCP transport binding](/protocol/transports/mcp) that maps
 ## Who is building MPP?
 
 MPP is co-authored by Tempo and Stripe. The core specification is developed in the open and designed to be extended by any payment network or provider. The [Payment HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/) is submitted to the IETF.
-
-## Specification
-
-<Cards>
-  <SpecCard to="https://paymentauth.org" />
-</Cards>

--- a/src/pages/governance.mdx
+++ b/src/pages/governance.mdx
@@ -3,6 +3,9 @@ description: "An overview of how the Machine Payments Protocol is developed, mai
 imageDescription: "Shape an open, neutral standard for machine payments"
 ---
 
+import { Cards } from 'vocs'
+import { SpecCard } from '../components/SpecCard'
+
 # Governance [An overview of how the Machine Payments Protocol is developed, maintained, and extended]
 
 The Machine Payments Protocol (MPP) is an open protocol for machine-to-machine payments, co-authored by [Tempo](https://tempo.xyz) and [Stripe](https://stripe.com). MPP is neutral by design and operates independently of any single company, payment method, or rail.
@@ -13,7 +16,7 @@ Governance of MPP is split into two parts: the **core specification** and **paym
 
 The core specification defines the abstract shape of the funds flow—the `402` Payment Required exchange of a Challenge, a Credential, and a Receipt. It makes no claims or affordances to any specific payment method, and it is designed to work with any rail and currency.
 
-The core specification is published at [paymentauth.org](https://paymentauth.org) as the [Payment HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/) and submitted to the **IETF** standards track, where it continues to progress as an open, vendor-neutral standard.
+The core specification is published as the [Payment HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ryan-httpauth-payment/) and submitted to the **IETF** standards track, where it continues to progress as an open, vendor-neutral standard.
 
 As an IETF submission, the specification is governed by IETF Trust licensing under [BCP 78](https://www.rfc-editor.org/info/bcp78) and [BCP 79](https://www.rfc-editor.org/info/bcp79). Code components within the document are licensed under the Revised BSD License per the IETF Trust Legal Provisions. Anchoring the core at the IETF means no single company controls it—changes happen in the open, through the same process that standardizes the rest of the web.
 
@@ -40,3 +43,9 @@ The core spec repository's [contributing guidelines](https://github.com/tempoxyz
 - **Editorial fixes**
 
 While the core MPP specification conforms to those guidelines, individual payment methods and SDKs may have their own repositories, contribution requirements, and licensing. Treat those as canonical for each individual payment method.
+
+## Specification
+
+<Cards>
+  <SpecCard to="https://paymentauth.org" />
+</Cards>

--- a/src/pages/guides/building-with-an-llm.mdx
+++ b/src/pages/guides/building-with-an-llm.mdx
@@ -14,7 +14,7 @@ Point your coding agent at <a href="/llms-full.txt" target="_self">`llms-full.tx
 
 Copy this URL and paste it into your agent:
 
-```bash [terminal]
+```text [URL]
 https://mpp.dev/llms-full.txt
 ```
 

--- a/src/pages/mpp-vs-x402.mdx
+++ b/src/pages/mpp-vs-x402.mdx
@@ -5,6 +5,7 @@ title: "MPP vs x402: Agentic payment protocols compared"
 ---
 
 import { Card, Cards } from 'vocs'
+import { SpecCard } from '../components/SpecCard'
 
 # MPP vs x402 [How the two HTTP 402 payment protocols compare]
 
@@ -32,7 +33,7 @@ Choose **x402** when your service exclusively needs on-chain payments and its re
 | **Request binding** | Depends on the scheme and extensions | Core Challenge binding and request digest support |
 | **Idempotency** | Optional Payment Identifier extension | Challenge identity plus standard `Idempotency-Key` guidance |
 | **Error model** | Protocol-specific responses | [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) Problem Details |
-| **Standards path** | x402 Foundation specification | [Payment HTTP Authentication Scheme](https://paymentauth.org) submitted to the IETF |
+| **Standards path** | x402 Foundation specification | Payment HTTP Authentication Scheme submitted to the IETF |
 
 ## The biggest difference
 
@@ -99,4 +100,5 @@ Choose **x402** if:
   <Card title="Use MPP with x402" description="Run x402 inline with an MPP route" to="/guides/use-mpp-with-x402" />
   <Card title="Protocol overview" description="Learn the core Challenge-Credential-Receipt flow" to="/protocol" />
   <Card title="Accept pay-as-you-go payments" description="Use sessions for high-frequency APIs" to="/guides/pay-as-you-go" />
+  <SpecCard to="https://paymentauth.org" />
 </Cards>

--- a/src/pages/overview.mdx
+++ b/src/pages/overview.mdx
@@ -17,7 +17,7 @@ The Machine Payments Protocol (MPP) lets any client—agents, apps, or humans—
 
 MPP is built around a simple, extensible core and is neutral to the implementation of underlying payment flows and methods.
 
-- **Open standard built for the internet**—Built on an [open specification proposed to the IETF](https://paymentauth.org), not a proprietary API
+- **Open standard built for the internet**—Built on an open specification proposed to the IETF, not a proprietary API
 - **Designed for payments**—Idempotency, security, and Receipts are first-class primitives
 - **Works with stablecoins, cards, and bank transfers**—All payment methods can be supported through one protocol and flexible control flow
 - **Any currency**—Transact in USD, EUR, BRL, USDC.e, BTC, or any other asset

--- a/src/pages/payment-methods/card/index.mdx
+++ b/src/pages/payment-methods/card/index.mdx
@@ -7,12 +7,13 @@ imageDescription: "Accept card payments with encrypted network tokens"
 import { Cards } from 'vocs'
 import { CardChargeCard } from '../../../components/cards'
 import { MermaidDiagram } from '../../../components/MermaidDiagram'
+import { SpecCard } from '../../../components/SpecCard'
 
 # Card [Card payments via encrypted network tokens]
 
 The Card method enables payments using encrypted, single use network payment tokens and dynamic data provided by a card network for machine-initiated transactions. Payment tokens, such as those provided by [Visa Intelligent Commerce](https://developer.visa.com/capabilities/visa-intelligent-commerce), settle through existing card infrastructure, and the client and server can each use independent payment providers rather than sharing a single platform.
 
-The [`mpp-card`](https://www.npmjs.com/package/mpp-card) SDK implements the `card` method with the `charge` intent. The protocol is defined in the [Card Network Charge Intent](https://paymentauth.org/draft-card-charge-00) specification.
+The [`mpp-card`](https://www.npmjs.com/package/mpp-card) SDK implements the `card` method with the `charge` intent.
 
 ## Installation
 
@@ -57,4 +58,10 @@ $ bun add mpp-card
 
 <Cards>
   <CardChargeCard />
+</Cards>
+
+## Specification
+
+<Cards>
+  <SpecCard to="https://paymentauth.org/draft-card-charge-00" />
 </Cards>

--- a/src/pages/payment-methods/evm/index.mdx
+++ b/src/pages/payment-methods/evm/index.mdx
@@ -6,12 +6,13 @@ imageDescription: "Accept stablecoin payments on EVM chains"
 
 import { Cards } from 'vocs'
 import { EvmChargeCard } from '../../../components/cards'
+import { SpecCard } from '../../../components/SpecCard'
 
 # EVM [Stablecoin payments on EVM chains]
 
 The EVM payment method enables MPP payments using EIP-3009 token authorizations. It supports the **charge** intent for one-time stablecoin payments and can run x402 exact flows inline when x402 options are enabled.
 
-Use `evm.charge` when you want one payment method that handles native MPP EVM charge Challenges and x402 exact Challenges on the same route. Read the [EVM charge protocol spec](https://paymentauth.org/draft-evm-charge-00) for the wire format.
+Use `evm.charge` when you want one payment method that handles native MPP EVM charge Challenges and x402 exact Challenges on the same route.
 
 ## Installation
 
@@ -36,3 +37,9 @@ $ bun add mppx viem
 ## x402 compatibility
 
 Configure `x402.facilitator` on the server to return x402-compatible Challenges and accept x402 exact Credentials inline with the MPP flow. See [running x402 inline with mppx](/guides/use-mpp-with-x402#run-x402-inline-with-mppx) for more details.
+
+## Specification
+
+<Cards>
+  <SpecCard to="https://paymentauth.org/draft-evm-charge-00" />
+</Cards>

--- a/src/pages/payment-methods/lightning/session.mdx
+++ b/src/pages/payment-methods/lightning/session.mdx
@@ -98,7 +98,7 @@ Lightning has properties that make it a natural fit for session-based billing:
 Use `spark.session` to accept prepaid Lightning sessions. The method handles deposit invoice generation, preimage verification, balance tracking, and refund on close.
 
 :::info
-Session support in `@buildonspark/lightning-mpp-sdk` is coming soon. The API below shows the anticipated interface based on the [specification](https://paymentauth.org/draft-lightning-session-00).
+Session support in `@buildonspark/lightning-mpp-sdk` is coming soon. The API below shows the anticipated interface defined by the specification.
 :::
 
 ```ts

--- a/src/pages/payment-methods/nearintents/index.mdx
+++ b/src/pages/payment-methods/nearintents/index.mdx
@@ -5,12 +5,13 @@ imageDescription: "Cross-chain payments settled by NEAR Intents"
 
 import { Cards } from 'vocs'
 import { NearIntentsChargeCard } from '../../../components/cards'
+import { SpecCard } from '../../../components/SpecCard'
 
 # NEAR Intents [Cross-chain payments on 30+ chains]
 
 The NEAR Intents payment method enables **cross-chain** MPP payments settled by the [NEAR Intents](https://near-intents.org) solver network through its [1Click API](https://docs.near-intents.org/integration/distribution-channels/1click-api/about-1click-api): the client pays a source asset on whatever chain it holds funds on (Bitcoin, Solana, any major EVM chain, NEAR, and [more](https://docs.near-intents.org/resources/chain-support)), and the merchant receives an **exact amount** of its chosen asset on its chosen chain. It supports the **charge** intent for one-time payments.
 
-The implementation is provided by [`@defuse-protocol/nearintents-mpp-sdk`](https://github.com/defuse-protocol/nearintents-mpp-sdk), which extends the [`mppx`](https://github.com/tempoxyz/mpp) SDK with NEAR Intents settlement alongside built-in methods like [EVM](/payment-methods/evm) and [Tempo](/payment-methods/tempo). Read the [NEAR Intents charge protocol spec](https://paymentauth.org/draft-nearintents-charge-00) for the wire format.
+The implementation is provided by [`@defuse-protocol/nearintents-mpp-sdk`](https://github.com/defuse-protocol/nearintents-mpp-sdk), which extends the [`mppx`](https://github.com/tempoxyz/mpp) SDK with NEAR Intents settlement alongside built-in methods like [EVM](/payment-methods/evm) and [Tempo](/payment-methods/tempo).
 
 ## Installation
 
@@ -44,4 +45,10 @@ Settlement is **not trustless**: for the duration of the swap, deposits are cust
 
 <Cards>
   <NearIntentsChargeCard />
+</Cards>
+
+## Specification
+
+<Cards>
+  <SpecCard to="https://paymentauth.org/draft-nearintents-charge-00" />
 </Cards>

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -10,7 +10,7 @@ import { PaymentFlowDiagram } from "../../components/PaymentFlowDiagram";
 
 The Machine Payments Protocol (MPP) is a protocol for machine-to-machine payments. It standardizes HTTP `402` "Payment Required" with an extensible framework that works with any payment network.
 
-These docs provide a developer-friendly overview. For the full specification, see the full [IETF Specification](https://paymentauth.org).
+These docs provide a developer-friendly overview. Use the IETF Specification card below for the normative protocol.
 
 If you're evaluating HTTP payment protocols, compare [MPP vs x402](/mpp-vs-x402).
 

--- a/src/pages/protocol/transports/index.mdx
+++ b/src/pages/protocol/transports/index.mdx
@@ -3,6 +3,9 @@ description: "Map MPP Challenges, Credentials, and Receipts to HTTP headers, JSO
 imageDescription: "Payment flows over HTTP, MCP, and WebSocket transports"
 ---
 
+import { Cards } from 'vocs'
+import { SpecCard } from '../../../components/SpecCard'
+
 # Transports [HTTP, MCP, and WebSocket bindings for payment flows]
 
 MPP defines how the Payment authentication scheme operates over different transport protocols. The core protocol targets HTTP, with extensions for other transports like MCP and JSON-RPC.
@@ -12,7 +15,7 @@ MPP defines how the Payment authentication scheme operates over different transp
 | Transport | Use Case | Spec |
 |-----------|----------|------|
 | [HTTP](/protocol/transports/http) | REST APIs, web resources | [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-11) |
-| [MCP](/protocol/transports/mcp) | AI tool calls using Model Context Protocol | [MCP Transport Spec](https://paymentauth.org) |
+| [MCP](/protocol/transports/mcp) | AI tool calls using Model Context Protocol | MCP transport binding |
 | [WebSocket](/protocol/transports/websocket) | Bidirectional payment streams | [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455) |
 | JSON-RPC | Non-MCP JSON-RPC services | [JSON-RPC 2.0](https://www.jsonrpc.org/specification) |
 
@@ -25,3 +28,9 @@ MPP's core concepts—Challenges, Credentials, and Receipts—remain the same ac
 - **WebSocket** uses JSON message framing with an `mpp` discriminator
 
 Choose the transport that matches your protocol. HTTP for REST APIs, MCP for AI agent tool calls, WebSocket for bidirectional payment streams, or JSON-RPC for non-MCP JSON-RPC services.
+
+## Specification
+
+<Cards>
+  <SpecCard to="https://paymentauth.org/draft-payment-transport-mcp-00" title="MCP Transport" description="Read the MCP transport binding" />
+</Cards>

--- a/src/pages/sdk/typescript/client/McpClient.wrap.mdx
+++ b/src/pages/sdk/typescript/client/McpClient.wrap.mdx
@@ -16,19 +16,22 @@ Wraps an MCP SDK client with automatic payment handling. When a tool call return
 <Tabs stateKey="account-source">
 <Tab title="Accounts SDK">
 
-```ts
+```ts twoslash
 import { Provider } from 'accounts'
 import { Client } from '@modelcontextprotocol/sdk/client'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { McpClient, tempo } from 'mppx/mcp-sdk/client'
 
 const client = new Client({ name: 'my-client', version: '1.0.0' })
-await client.connect(transport)
+await client.connect(
+  new StreamableHTTPClientTransport(new URL('https://api.example.com/mcp')),
+)
 
 const provider = Provider.create({ mpp: false }) // Avoid double 402 handling; mppx is configured below.
 await provider.request({ method: 'wallet_connect' })
 
 const mcp = McpClient.wrap(client, {
-  methods: [tempo({
+  methods: [tempo.charge({
     account: provider.getAccount({ signable: true }),
     getClient: provider.getClient,
   })],
@@ -41,16 +44,19 @@ const result = await mcp.callTool({ name: 'premium_tool', arguments: {} })
 </Tab>
 <Tab title="viem">
 
-```ts
+```ts twoslash
 import { Client } from '@modelcontextprotocol/sdk/client'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { McpClient, tempo } from 'mppx/mcp-sdk/client'
 import { privateKeyToAccount } from 'viem/accounts'
 
 const client = new Client({ name: 'my-client', version: '1.0.0' })
-await client.connect(transport)
+await client.connect(
+  new StreamableHTTPClientTransport(new URL('https://api.example.com/mcp')),
+)
 
 const mcp = McpClient.wrap(client, {
-  methods: [tempo({ account: privateKeyToAccount('0x...') })],
+  methods: [tempo.charge({ account: privateKeyToAccount('0x...') })],
 })
 
 const result = await mcp.callTool({ name: 'premium_tool', arguments: {} })

--- a/src/pages/sdk/typescript/server/Mppx.create.mdx
+++ b/src/pages/sdk/typescript/server/Mppx.create.mdx
@@ -188,13 +188,6 @@ const payment = Mppx.create({
 })
 ```
 
-### requiresAuth (optional)
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Uses `Payment-Authorization` for Payment Credentials so `Authorization` remains available for application authentication. Available with the HTTP transport.
-
 ### realm (optional)
 
 - **Type:** `string`
@@ -210,6 +203,13 @@ const payment = Mppx.create({
   realm: 'mpp.dev', // [!code focus]
 })
 ```
+
+### requiresAuth (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Uses `Payment-Authorization` for Payment Credentials so `Authorization` remains available for application authentication. Available with the HTTP transport.
 
 ### secretKey (optional)
 

--- a/src/pages/sdk/typescript/server/Transport.mcpSdk.mdx
+++ b/src/pages/sdk/typescript/server/Transport.mcpSdk.mdx
@@ -4,7 +4,7 @@ MCP SDK transport for server-side payment handling with [`@modelcontextprotocol/
 
 ## Usage
 
-```ts
+```ts twoslash
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
 import { Mppx, tempo, Transport } from 'mppx/server'
 


### PR DESCRIPTION
## Motivation

Keep SDK references and specification links aligned with the documentation style guide and make parameter ordering enforceable.

## Summary

- validate MCP SDK examples with twoslash
- render specification links with SpecCard
- correct the URL-only shell fence
- enforce alphabetized TypeScript parameter headings

## Key design considerations

- scope parameter checks to Parameters sections and ignore fenced examples
- normalize optional and qualified parameter headings before sorting
- keep specification cards compatible with generated Markdown