### PR TITLE
docs: correct protocol and CLI references

### DIFF
--- a/src/pages/faq.mdx
+++ b/src/pages/faq.mdx
@@ -66,7 +66,7 @@ The protocol itself is free and open. There are no licensing fees for implementi
 
 ## Is it safe?
 
-MPP requires TLS 1.2+ for all connections. Challenge IDs are cryptographically bound to prevent replay attacks. The protocol never performs side effects on unpaid requests—your client only pays after verifying what it is paying for.
+MPP requires TLS 1.2+ for all connections. Cryptographically bound Challenge IDs prevent clients from modifying payment terms. Payment methods enforce replay protection separately through settlement-layer guarantees or shared replay state. The protocol never performs side effects on unpaid requests—your client only pays after verifying what it is paying for.
 
 Payments use the same security model as the underlying payment method. Stablecoin methods typically use cryptographic signatures over every transaction. Card methods typically use the provider's existing fraud and dispute infrastructure.
 

--- a/src/pages/payment-methods/lightning/index.mdx
+++ b/src/pages/payment-methods/lightning/index.mdx
@@ -7,7 +7,7 @@ imageDescription: "Instant Bitcoin payments over Lightning"
 
 The Lightning payment method enables payments using Bitcoin over the [Lightning Network](https://lightning.network) within the MPP framework. Lightning supports two intents—**charge** for one-time payments and **session** for prepaid metered access—covering everything from single API calls to high-frequency streaming billing.
 
-The implementation is provided by [`@buildonspark/lightning-mpp-sdk`](https://github.com/buildonspark/lightning-mpp-sdk), which extends the [`mppx`](https://github.com/tempoxyz/mpp) SDK with Lightning Network support alongside built-in methods like [Stripe](/payment-methods/stripe) and [Tempo](/payment-methods/tempo). The reference implementation uses [Spark](https://spark.money) for wallet and node operations, but the protocol works with any Lightning node or wallet that can create BOLT11 invoices and verify preimages.
+The implementation is provided by [`@buildonspark/lightning-mpp-sdk`](https://github.com/buildonspark/lightning-mpp-sdk), which extends the [`mppx`](https://github.com/wevm/mppx) SDK with Lightning Network support alongside built-in methods like [Stripe](/payment-methods/stripe) and [Tempo](/payment-methods/tempo). The reference implementation uses [Spark](https://spark.money) for wallet and node operations, but the protocol works with any Lightning node or wallet that can create BOLT11 invoices and verify preimages.
 
 ## Installation
 

--- a/src/pages/payment-methods/monad/index.mdx
+++ b/src/pages/payment-methods/monad/index.mdx
@@ -7,7 +7,7 @@ imageDescription: "ERC-20 token payments on Monad with push and pull settlement 
 
 The Monad payment method enables MPP payments on Monad using ERC-20 tokens. Monad supports the **charge** intent for one-time payments with two settlement modes: **push** where the client broadcasts the transfer, and **pull** where the client signs an ERC-3009 authorization for the server to broadcast.
 
-The reference implementation is provided by [`@monad-crypto/mpp`](https://github.com/monad-crypto/monad-ts), which extends [`mppx`](https://github.com/tempoxyz/mpp) with Monad-native client and server handlers.
+The reference implementation is provided by [`@monad-crypto/mpp`](https://github.com/monad-crypto/monad-ts), which extends [`mppx`](https://github.com/wevm/mppx) with Monad-native client and server handlers.
 
 ## Installation
 

--- a/src/pages/payment-methods/solana/index.mdx
+++ b/src/pages/payment-methods/solana/index.mdx
@@ -7,7 +7,7 @@ imageDescription: "Accept SOL and SPL token payments on Solana"
 
 The Solana payment method enables MPP payments on Solana using native SOL, SPL tokens, and Token-2022 assets. Solana supports two intents: **charge** for one-time payments and **session** for reserved, pay-as-you-go billing.
 
-The reference implementation is provided by [`@solana/mpp`](https://github.com/solana-foundation/mpp-sdk), which extends [`mppx`](https://github.com/tempoxyz/mpp) with Solana-native client and server handlers.
+The reference implementation is provided by [`@solana/mpp`](https://github.com/solana-foundation/mpp-sdk), which extends [`mppx`](https://github.com/wevm/mppx) with Solana-native client and server handlers.
 
 ## Installation
 

--- a/src/pages/protocol/credentials.mdx
+++ b/src/pages/protocol/credentials.mdx
@@ -52,14 +52,16 @@ The echoed Challenge keeps the original HTTP wire values. In a Credential, `chal
 | `source` | Identity of the payer (address, DID, account ID) |
 | `payload` | Method-specific payment proof |
 
-## Single-use Credentials
+## Enforce single-use Credentials
 
-Each Credential is valid for exactly one request. When processing a Credential:
+Payment proofs must be accepted at most once. Challenge binding prevents clients from modifying payment terms, but it doesn't detect reuse—each payment method must enforce replay protection separately. When processing a Credential:
 
 1. Verify the `challenge.id` matches an outstanding Challenge
 2. Verify the Challenge has not expired
 3. Verify the payment or proof using method-specific procedures
 4. Reject any replayed Credentials
+
+For Tempo zero-dollar proof Credentials, pass a shared atomic `store` to [`tempo.charge`](/sdk/typescript/server/Method.tempo.charge#store-optional). Without a store, a valid proof remains reusable until its Challenge expires.
 
 ## Tempo charge payload types
 

--- a/src/pages/protocol/index.mdx
+++ b/src/pages/protocol/index.mdx
@@ -160,6 +160,8 @@ Use the `Retry-After` header to indicate when clients can retry failed payments.
 
 Payment methods must provide single-use proof semantics. A payment proof can be used exactly once; subsequent attempts to use the same proof must be rejected.
 
+Cryptographic Challenge binding prevents modification, not reuse. Payment methods need separate replay state or settlement-layer guarantees. For Tempo zero-dollar proofs, configure a shared atomic store.
+
 ### Idempotency
 
 Servers must not perform side effects (database writes, external API calls) for requests that have not been paid. The unpaid request that triggers a `402` Challenge must not modify server state beyond recording the Challenge itself.

--- a/src/pages/protocol/receipts.mdx
+++ b/src/pages/protocol/receipts.mdx
@@ -39,9 +39,11 @@ The Receipt is a base64url-encoded JSON object.
 
 | Field | Description |
 |-------|-------------|
+| `externalId` | Optional external reference echoed from the Credential payload |
 | `method` | Payment method used |
 | `reference` | Method-specific payment reference (for example, transaction hash or invoice ID) |
 | `status` | Payment outcome (`success`) |
+| `subscriptionId` | Optional server-issued subscription identifier |
 | `timestamp` | When the payment was processed |
 
 Payment method specifications can define additional fields.

--- a/src/pages/sdk/typescript/cli.mdx
+++ b/src/pages/sdk/typescript/cli.mdx
@@ -77,6 +77,7 @@ Run `mppx validate` against both test and production versions of your server. On
 | Variable | Description |
 |----------|-------------|
 | `MPPX_ACCOUNT` | Default account name |
+| `MPPX_CONFIG` | Path to an `mppx.config.ts`, `mppx.config.js`, or `mppx.config.mjs` file |
 | `MPPX_PRIVATE_KEY` | Use a private key directly instead of the keychain |
 | `MPPX_RPC_URL` | Default RPC endpoint |
 | `MPPX_STRIPE_SECRET_KEY` | Stripe secret key for Stripe payment methods (test mode only: `sk_test_...`) |
@@ -127,22 +128,38 @@ Use `--force` to overwrite an existing config file:
 $ mppx init --force
 ```
 
-## Sign command
+### Configure payment methods
 
-Sign a payment Challenge and output its serialized Payment Credential value without making a request. Accepts a Challenge via `--challenge` or stdin; send the result in the field advertised by `header`, or `Authorization` when omitted.
+The CLI loads configuration from `--config`, then `MPPX_CONFIG`, then the nearest `mppx.config.ts`, `mppx.config.js`, or `mppx.config.mjs` file up to the project root.
 
-```bash [terminal]
-$ mppx sign --challenge 'Payment method="tempo-session";chain-id=4217;...'
+```ts twoslash [mppx.config.ts]
+import { defineConfig, resolveAccount } from 'mppx/cli'
+import { tempo } from 'mppx/client'
+
+export default defineConfig({
+  methods: [tempo({ account: await resolveAccount() })],
+})
 ```
 
+| Property | Type | Description |
+|----------|------|-------------|
+| `methods` | `Method.AnyClient[]` | Client payment methods, including third-party methods |
+| `paymentPreferences` | `PaymentPreferences` | Selection preferences when a server offers multiple methods |
+| `plugins` | `Plugin[]` | CLI integrations that configure payment methods and output |
+
+## Sign command
+
+Sign a payment Challenge and output its serialized Payment Credential value without making a request. Pass the complete `WWW-Authenticate` value with `--challenge`. Send the result in the field advertised by `header`, or `Authorization` when omitted.
+
 ```bash [terminal]
-$ echo 'Payment method="tempo-session";chain-id=4217;...' | mppx sign
+$ challenge='Payment id="abc", realm="api.example.com", method="tempo", intent="charge", request="eyJhbW91bnQiOiIwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJyZWNpcGllbnQiOiIweDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIn0"'
+$ mppx sign --challenge "$challenge"
 ```
 
 Use `--dry-run` to validate and parse a Challenge without signing:
 
 ```bash [terminal]
-$ mppx sign --challenge 'Payment method="tempo-session";...' --dry-run
+$ mppx sign --challenge "$challenge" --dry-run
 ```
 
 ## Account commands

--- a/src/pages/sdk/typescript/core/Receipt.from.mdx
+++ b/src/pages/sdk/typescript/core/Receipt.from.mdx
@@ -51,6 +51,12 @@ Method-specific reference (for example, transaction hash).
 
 Payment status.
 
+### subscriptionId (optional)
+
+- **Type:** `string`
+
+Server-issued subscription identifier for recurring payments.
+
 ### timestamp
 
 - **Type:** `string`


### PR DESCRIPTION
## Motivation

Keep protocol and CLI guidance aligned with current `mppx` schemas and behavior.

## Summary

- document all base Receipt fields and CLI configuration options
- replace invalid CLI signing examples with a parseable Payment Challenge
- distinguish Challenge binding from replay protection requirements
- correct TypeScript SDK repository links in payment method pages

## Key design considerations

- preserve the protocol requirement for single-use proofs while identifying where implementations need replay state
- remove the unsupported stdin signing path from examples until the CLI accepts piped Challenges
