### PR TITLE
Add BentCrypto to MPP services directory

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11227,4 +11227,46 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── BentCrypto ─────────────────────────────────────────────────────────
+  {
+    categories: ["blockchain", "data"],
+    description:
+      "Pre-trade token risk intelligence for autonomous agents with evidence coverage and confidence reporting. Base Token Risk accepts MPP EVM charge payments in USDC; BentCrypto also supports x402 and MCP.",
+    docs: {
+      apiReference: "https://api.bentcrypto.com/openapi.json",
+      homepage: "https://bentcrypto.com/agent-api",
+      llmsTxt: "https://api.bentcrypto.com/llms.txt",
+    },
+    endpoints: [
+      {
+        amount: "10000",
+        desc: "Base token risk analysis",
+        route: "GET /mpp/v1/token/risk",
+        unitType: "request",
+      },
+      {
+        desc: "Free Token Risk capability and input preflight",
+        route: "GET /v1/token/risk/preflight",
+        unitType: "request",
+      },
+    ],
+    id: "bentcrypto",
+    integration: "first-party",
+    intent: "charge",
+    name: "BentCrypto",
+    payments: [
+      {
+        method: "evm",
+        currency: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        decimals: 6,
+      },
+    ],
+    provider: { name: "BentCrypto", url: "https://bentcrypto.com" },
+    realm: "api.bentcrypto.com",
+    serviceUrl: "https://api.bentcrypto.com",
+    status: "beta",
+    tags: ["token-risk", "pre-trade", "base", "usdc", "agents"],
+    url: "https://bentcrypto.com/agent-api",
+  },
 ];


### PR DESCRIPTION
## Motivation

BentCrypto provides pre-trade token risk intelligence for autonomous agents. Its first-party production MPP service exposes Base Token Risk with EVM `charge` payments in USDC and a free preflight endpoint for capability/input validation.

- **Service name:** BentCrypto
- **Live service URL:** https://api.bentcrypto.com
- **Provider URL:** https://bentcrypto.com
- **OpenAPI or API reference URL:** https://api.bentcrypto.com/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation URLs are stable and accessible. No icon URL is declared.
- [ ] `pnpm generate:discovery` succeeds — awaiting upstream Actions approval for this fork-originated PR.
- [ ] `pnpm check:types` passes — awaiting upstream Actions approval for this fork-originated PR.
- [ ] `pnpm build` succeeds — awaiting upstream Actions approval for this fork-originated PR.

## Key design considerations

- **Integration:** first-party
- **Payment methods and intents:** Base USDC using MPP `evm` with `charge`; paid Token Risk is `10000` base units ($0.01 USDC) per request.
- **Provider relationship:** BentCrypto owns and operates the listed service and canonical API origin.
- **Directory fit:** This is a live first-party MPP service for agent-facing token-risk analysis and is not a duplicate of an existing directory listing. Token Security is intentionally omitted because it is not an MPP product.

The free `GET /v1/token/risk/preflight` endpoint is listed without an amount. The paid MPP endpoint is `GET /mpp/v1/token/risk`. No production secret, payment credential, or private infrastructure identifier is included.

### Validation status

The upstream `CI` workflow is currently `action_required` with zero jobs started because GitHub requires a maintainer to approve Actions for this fork-originated PR. The Vercel status likewise requires authorization by the Tempo team and is not a BentCrypto build failure. The PR is open and mergeable, and the Changed Services bot recognizes `bentcrypto` as an added service.