### PR TITLE
fix(services): correct Locus signup pricing

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -876,8 +876,8 @@ export const services: ServiceDef[] = [
       // Auth
       {
         route: "POST /v1/auth/mpp-sign-up",
-        desc: "Bootstrap workspace — returns JWT and workspace ID (free)",
-        amount: "0",
+        desc: "Bootstrap workspace — returns JWT and workspace ID",
+        amount: "1000",
         unitType: "request",
       },
       { route: "GET /v1/auth/whoami", desc: "Current user and workspace info" },


### PR DESCRIPTION
## Summary

- set the Build With Locus MPP sign-up charge to 1,000 base units ($0.001 USDC.e)
- remove the incorrect “free” label from the endpoint description

## Validation

- `pnpm check:ci`
- `pnpm generate:discovery && pnpm check:types`
- `pnpm test` (9,854 tests)

Prompted by: @shekhirin