### PR TITLE
feat(services): add ToolRouter

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11227,4 +11227,37 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── ToolRouter ──────────────────────────────────────────────────────
+  {
+    id: "toolrouter",
+    name: "ToolRouter",
+    url: "https://toolrouter.com",
+    serviceUrl: "https://api.toolrouter.com",
+    description:
+      "One MCP endpoint with hundreds of paid tools — web search, scraping, image and video generation, data lookups. Agents buy prepaid credits with MPP, then spend them per tool call.",
+    icon: "https://toolrouter.com/icon-256.png",
+    categories: ["ai", "data", "media", "search", "web"],
+    integration: "first-party",
+    tags: ["mcp", "tools", "credits", "agents", "search", "scraping", "image-generation"],
+    status: "active",
+    docs: {
+      homepage: "https://toolrouter.com/docs/billing",
+      llmsTxt: "https://toolrouter.com/llms.txt",
+      apiReference: "https://toolrouter.com/openapi.json",
+    },
+    provider: { name: "ToolRouter", url: "https://toolrouter.com" },
+    realm: "api.toolrouter.com",
+    intent: "charge",
+    payments: [STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/billing/machine-topup",
+        desc: "Buy ToolRouter credits. Send a ToolRouter API key with { amount_usd } to get the 402 challenge, pay it, retry with the credential.",
+        dynamic: true,
+        amountHint: "$1 – $500 of credits plus purchase fee (5.5%, min $0.80)",
+        docs: "https://toolrouter.com/docs/billing",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Motivation

ToolRouter (https://toolrouter.com) is an MCP gateway that gives an agent one endpoint with hundreds of paid tools: web search, scraping, image/video generation, data lookups, and more. Tool calls are metered against prepaid credits. This entry lists the MPP endpoint that lets an agent buy those credits itself, with no human, browser, or hosted checkout in the loop.

- **Service name:** ToolRouter
- **Live service URL:** https://api.toolrouter.com/v1/billing/machine-topup
- **Provider URL:** https://toolrouter.com
- **OpenAPI or API reference URL:** https://toolrouter.com/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [ ] `pnpm generate:discovery` succeeds. (not run locally; relying on CI)
- [ ] `pnpm check:types` passes. (not run locally; relying on CI)
- [ ] `pnpm build` succeeds. (not run locally; relying on CI)

## Key design considerations

- **Integration:** first-party
- **Payment methods and intents:** `stripe` / `charge`. Cards (and Link) through a Stripe profile. Realm `api.toolrouter.com`.
- **Provider relationship:** I own and operate ToolRouter (Humanleap Ltd).
- **Directory fit:** Different shape from the per-request listings: the paid resource is a credit top-up, and the credits are then spent across the whole tool catalog at $0.005+ per call. Card payments have a $0.50 floor so per-call MPP isn't viable; a single MPP charge funding many calls is the workable pattern for card rails.

### Flow note for reviewers

The challenge is minted for a specific ToolRouter account, so the first request needs a ToolRouter API key:

```
POST /v1/billing/machine-topup
Authorization: Bearer <ToolRouter API key>
{ "amount_usd": 5 }
→ 402, WWW-Authenticate: Payment id="…" realm="api.toolrouter.com" method="stripe" intent="charge" …
```

Pay the challenge, retry with the payment credential (no API key needed on the retry), get 200 plus `Payment-Receipt`. A cold request with no API key returns 401, not 402. Amounts are $1–$500 of credits; the charge adds the purchase fee (5.5%, minimum $0.80), e.g. $5 of credits charges $5.80.

The "machine payments" section on https://toolrouter.com/docs/billing is merged to our staging and will be on production shortly; the page itself is live now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)