### PR TITLE
feat(services): add SingleFax

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -4135,6 +4135,44 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── SingleFax ──────────────────────────────────────────────────────────
+  {
+    id: "singlefax",
+    name: "SingleFax",
+    url: "https://singlefax.com",
+    serviceUrl: "https://singlefax.com",
+    description:
+      "Send a fax from an agent. HTTP 402 + Stripe Shared Payment Token, PDF upload, delivery status.",
+    categories: ["web"],
+    integration: "first-party",
+    tags: ["fax", "communications", "pdf", "physical"],
+    docs: {
+      homepage: "https://singlefax.com/agents",
+      apiReference: "https://singlefax.com/openapi.json",
+      llmsTxt: "https://singlefax.com/llms.txt",
+    },
+    provider: { name: "SingleFax", url: "https://singlefax.com" },
+    realm: "singlefax.com",
+    intent: "charge",
+    payments: [STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /api/v1/machine/faxes/validate",
+        desc: "Quote a fax send without charging",
+      },
+      {
+        route: "POST /api/v1/machine/faxes",
+        desc: "Create and pay a machine fax (HTTP 402 until a Stripe SPT is attached)",
+        dynamic: true,
+        amountHint: "From $0.99 for 10 pages, then about $0.08/page",
+      },
+      {
+        route: "GET /api/v1/machine/faxes/:request_id",
+        desc: "Poll machine fax status (statusToken query required)",
+      },
+    ],
+  },
+
   // ── Prospect Butcher Co ─────────────────────────────────────────────────
   {
     id: "prospect-butcher",


### PR DESCRIPTION
## Motivation

Pay-per-fax for autonomous agents. Live HTTP 402 + Stripe Shared Payment Token (card and Link). Distinct from PostalForm (print-and-mail).

- **Service name:** SingleFax
- **Live service URL:** https://singlefax.com/api/v1/machine/faxes
- **Provider URL:** https://singlefax.com
- **OpenAPI or API reference URL:** https://singlefax.com/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [x] `pnpm generate:discovery` succeeds.
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds.

## Key design considerations

- **Integration:** first-party
- **Payment methods and intents:** Stripe SPT only (`STRIPE_PAYMENT`, intent `charge`). No Tempo.
- **Provider relationship:** We own and operate SingleFax (`https://singlefax.com`).
- **Directory fit:** Production MPP: unpaid `POST /api/v1/machine/faxes` returns HTTP 402 + `WWW-Authenticate: Payment`. Link CLI `mpp pay` has captured a live $0.99 send. Pricing is dynamic (from $0.99 / 10 pages). Agent docs: https://singlefax.com/mpp.md

## Test plan

- [x] `pnpm generate:discovery`
- [x] `pnpm check:types`
- [x] `pnpm exec vitest run schemas/services.test.ts`
- [x] `pnpm build`


Made with [Cursor](https://cursor.com)