### PR TITLE
fix: source proxy catalog from discovery manifest

### DIFF
--- a/src/data/registry.test.ts
+++ b/src/data/registry.test.ts
@@ -25,7 +25,7 @@ describe("service registry cache", () => {
     vi.unstubAllGlobals();
   });
 
-  it("deduplicates catalog requests and uses the static catalog", async () => {
+  it("deduplicates catalog requests and uses the live catalog API", async () => {
     vi.stubGlobal("sessionStorage", createStorage());
     const fetchMock = vi.fn(async () =>
       Response.json({ services: [service("openai", "OpenAI (New)")] }),
@@ -39,7 +39,7 @@ describe("service registry cache", () => {
     ]);
 
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(fetchMock).toHaveBeenCalledWith("/services/catalog.json");
+    expect(fetchMock).toHaveBeenCalledWith("/api/services");
     expect(first).toEqual(second);
     expect(first[0]?.name).toBe("OpenAI");
   });

--- a/src/data/registry.ts
+++ b/src/data/registry.ts
@@ -8,7 +8,6 @@ import { useEffect, useState } from "react";
 
 const API_URL = "/api/services";
 const CACHE_TTL_MS = 5 * 60_000;
-const CATALOG_URL = "/services/catalog.json";
 
 // ---------------------------------------------------------------------------
 // Types (mirrors the discovery JSON Schema)
@@ -87,7 +86,7 @@ const featuredCached = new Map<
 const featuredInflight = new Map<string, Promise<FeaturedService[]>>();
 
 async function fetchCatalog(): Promise<Service[]> {
-  const res = await fetch(CATALOG_URL);
+  const res = await fetch(API_URL);
   if (!res.ok) throw new Error(`API ${res.status}: ${res.statusText}`);
   const json = await res.json();
   return json.services;

--- a/src/mpp-proxy-catalog.test.ts
+++ b/src/mpp-proxy-catalog.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeMppProxyCatalog,
+  type ServicesCatalog,
+} from "./mpp-proxy-catalog";
+
+const staticCatalog: ServicesCatalog = {
+  version: 1,
+  services: [
+    {
+      id: "openai",
+      name: "Stale OpenAI",
+      url: "https://api.openai.com",
+      serviceUrl: "https://openai.mpp.tempo.xyz",
+      description: "stale",
+      categories: ["ai"],
+      integration: "third-party",
+      tags: ["llm"],
+      methods: {},
+      endpoints: [],
+      provider: { name: "OpenAI", url: "https://openai.com" },
+    },
+    {
+      id: "external",
+      name: "External",
+      url: "https://external.example",
+      serviceUrl: "https://external.example",
+      methods: {},
+      endpoints: [],
+    },
+  ],
+};
+
+describe("MPP proxy catalog", () => {
+  it("replaces stale proxy entries and discovers new services", () => {
+    const result = mergeMppProxyCatalog(staticCatalog, {
+      services: [
+        service("openai", "OpenAI", "100"),
+        service("new-provider", "New provider", "200"),
+      ],
+    });
+
+    expect(result.services.map(({ id }) => id)).toEqual([
+      "external",
+      "openai",
+      "new-provider",
+    ]);
+    expect(result.services.find(({ id }) => id === "openai")).toMatchObject({
+      name: "OpenAI",
+      url: "https://api.openai.com",
+      tags: ["llm"],
+      endpoints: [{ payment: { amount: "100", decimals: 6 } }],
+    });
+    expect(
+      result.services.find(({ id }) => id === "new-provider"),
+    ).toMatchObject({
+      name: "New provider",
+      serviceUrl: "https://new-provider.mpp.tempo.xyz",
+      supportsCredits: true,
+    });
+  });
+
+  it("rejects an empty manifest instead of deleting the last-good catalog", () => {
+    expect(() => mergeMppProxyCatalog(staticCatalog, { services: [] })).toThrow(
+      "must contain services",
+    );
+  });
+
+  it("rejects a service whose domain does not match its id", () => {
+    const invalid = service("openai", "OpenAI", "100");
+    invalid.domain = "attacker.example";
+    expect(() =>
+      mergeMppProxyCatalog(staticCatalog, { services: [invalid] }),
+    ).toThrow("Invalid MPP proxy service");
+  });
+});
+
+function service(id: string, name: string, amount: string) {
+  return {
+    id,
+    domain: `${id}.mpp.tempo.xyz`,
+    manifest: {
+      name,
+      description: `${name} description`,
+      categories: ["ai"],
+      methods: { tempo: { intents: ["charge"], assets: ["0xasset"] } },
+      endpoints: [
+        {
+          method: "POST",
+          path: "/generate",
+          payment: {
+            intent: "charge",
+            method: "tempo",
+            amount,
+            currency: "0xasset",
+          },
+        },
+      ],
+    },
+  };
+}

--- a/src/mpp-proxy-catalog.ts
+++ b/src/mpp-proxy-catalog.ts
@@ -1,0 +1,155 @@
+import type { Category, Endpoint, Service } from "./data/registry";
+
+export const MPP_PROXY_MANIFEST_URL = "https://mpp.tempo.xyz/.well-known/mpp";
+
+type CatalogService = Service & Record<string, unknown>;
+
+export type ServicesCatalog = {
+  version: number;
+  services: CatalogService[];
+};
+
+type ProxyManifest = {
+  services: Array<{
+    domain: string;
+    id: string;
+    manifest: {
+      categories: string[];
+      description: string;
+      docs?: Service["docs"];
+      endpoints: Endpoint[];
+      methods: Service["methods"];
+      name: string;
+    };
+  }>;
+};
+
+const CATEGORIES = new Set<Category>([
+  "ai",
+  "blockchain",
+  "compute",
+  "data",
+  "media",
+  "search",
+  "social",
+  "storage",
+  "web",
+]);
+const SERVICE_ID = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+/** Replaces manually copied proxy entries with the proxy's canonical discovery manifest. */
+export function mergeMppProxyCatalog(
+  catalog: ServicesCatalog,
+  value: unknown,
+): ServicesCatalog {
+  const manifest = parseProxyManifest(value);
+  const metadata = new Map(
+    catalog.services.map((service) => [service.id, service]),
+  );
+  const nonProxyServices = catalog.services.filter(
+    (service) => !isTempoProxyService(service),
+  );
+  const proxyServices = manifest.services.map((entry) => {
+    const existing = metadata.get(entry.id);
+    const serviceUrl = `https://${entry.domain}`;
+    const docs = entry.manifest.docs ?? existing?.docs;
+    const endpoints = entry.manifest.endpoints.map((endpoint) => ({
+      ...endpoint,
+      payment: endpoint.payment
+        ? {
+            ...endpoint.payment,
+            ...(endpoint.payment.method === "tempo" &&
+            endpoint.payment.decimals === undefined
+              ? { decimals: 6 }
+              : {}),
+          }
+        : null,
+    }));
+
+    return {
+      ...existing,
+      id: entry.id,
+      name: entry.manifest.name,
+      url: existing?.url ?? docs?.homepage ?? serviceUrl,
+      serviceUrl,
+      description: entry.manifest.description,
+      categories: entry.manifest.categories as Category[],
+      integration: existing?.integration ?? "third-party",
+      tags: existing?.tags ?? entry.manifest.categories,
+      status: existing?.status ?? "active",
+      docs,
+      methods: entry.manifest.methods,
+      realm: "mpp.tempo.xyz",
+      endpoints,
+      provider:
+        existing?.provider ??
+        ({
+          name: entry.manifest.name,
+          url: docs?.homepage ?? serviceUrl,
+        } as const),
+      supportsCredits: true,
+    } satisfies CatalogService;
+  });
+
+  return { ...catalog, services: [...nonProxyServices, ...proxyServices] };
+}
+
+function isTempoProxyService(service: Service): boolean {
+  if (!service.serviceUrl) return false;
+  try {
+    const hostname = new URL(service.serviceUrl).hostname;
+    return hostname === "mpp.tempo.xyz" || hostname.endsWith(".mpp.tempo.xyz");
+  } catch {
+    return false;
+  }
+}
+
+function parseProxyManifest(value: unknown): ProxyManifest {
+  if (!value || typeof value !== "object") {
+    throw new Error("MPP proxy manifest must be an object");
+  }
+  const services = (value as { services?: unknown }).services;
+  if (!Array.isArray(services) || services.length === 0) {
+    throw new Error("MPP proxy manifest must contain services");
+  }
+  const ids = new Set<string>();
+  for (const entry of services) {
+    if (!entry || typeof entry !== "object")
+      throw new Error("Invalid MPP proxy service");
+    const candidate = entry as Record<string, unknown>;
+    const manifest = candidate.manifest as Record<string, unknown> | undefined;
+    if (
+      typeof candidate.id !== "string" ||
+      typeof candidate.domain !== "string" ||
+      !manifest ||
+      typeof manifest.name !== "string" ||
+      typeof manifest.description !== "string" ||
+      !Array.isArray(manifest.categories) ||
+      !Array.isArray(manifest.endpoints) ||
+      !manifest.methods ||
+      typeof manifest.methods !== "object"
+    ) {
+      throw new Error("Invalid MPP proxy service");
+    }
+    if (
+      !SERVICE_ID.test(candidate.id) ||
+      candidate.domain !== `${candidate.id}.mpp.tempo.xyz` ||
+      ids.has(candidate.id) ||
+      !manifest.categories.every(
+        (category) =>
+          typeof category === "string" && CATEGORIES.has(category as Category),
+      ) ||
+      !manifest.endpoints.every(
+        (endpoint) =>
+          endpoint !== null &&
+          typeof endpoint === "object" &&
+          typeof (endpoint as { method?: unknown }).method === "string" &&
+          typeof (endpoint as { path?: unknown }).path === "string",
+      )
+    ) {
+      throw new Error("Invalid MPP proxy service");
+    }
+    ids.add(candidate.id);
+  }
+  return value as ProxyManifest;
+}

--- a/src/pages/_api/api/services.ts
+++ b/src/pages/_api/api/services.ts
@@ -1,9 +1,19 @@
 import discovery from "../../../../schemas/discovery.json";
+import {
+  MPP_PROXY_MANIFEST_URL,
+  mergeMppProxyCatalog,
+  type ServicesCatalog,
+} from "../../../mpp-proxy-catalog";
 
 const CACHE_CONTROL =
   "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400";
 
-export function GET(request: Request) {
+const MANIFEST_CACHE_MS = 5 * 60_000;
+
+let cachedCatalog: { catalog: ServicesCatalog; expiresAt: number } | undefined;
+
+export async function GET(request: Request) {
+  const catalog = await liveCatalog();
   const ids = new URL(request.url).searchParams
     .get("ids")
     ?.split(",")
@@ -12,7 +22,7 @@ export function GET(request: Request) {
 
   if (ids?.length) {
     const servicesById = new Map(
-      discovery.services.map((service) => [service.id, service]),
+      catalog.services.map((service) => [service.id, service]),
     );
     const services = ids.flatMap((id) => {
       const service = servicesById.get(id);
@@ -35,7 +45,29 @@ export function GET(request: Request) {
     );
   }
 
-  return Response.json(discovery, {
+  return Response.json(catalog, {
     headers: { "Cache-Control": CACHE_CONTROL },
   });
+}
+
+async function liveCatalog(): Promise<ServicesCatalog> {
+  if (cachedCatalog && Date.now() < cachedCatalog.expiresAt) {
+    return cachedCatalog.catalog;
+  }
+  try {
+    const response = await fetch(MPP_PROXY_MANIFEST_URL, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) throw new Error(`MPP proxy manifest ${response.status}`);
+    const catalog = mergeMppProxyCatalog(
+      discovery as ServicesCatalog,
+      await response.json(),
+    );
+    cachedCatalog = { catalog, expiresAt: Date.now() + MANIFEST_CACHE_MS };
+    return catalog;
+  } catch (error) {
+    console.warn("Falling back to the checked-in MPP service catalog", error);
+    return cachedCatalog?.catalog ?? (discovery as ServicesCatalog);
+  }
 }

--- a/src/services-api.test.ts
+++ b/src/services-api.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MPP_PROXY_MANIFEST_URL } from "./mpp-proxy-catalog";
+
+describe("services API", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("serves proxy endpoints from the live manifest", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
+      Response.json({
+        services: [
+          {
+            id: "openai",
+            domain: "openai.mpp.tempo.xyz",
+            manifest: {
+              name: "Live OpenAI",
+              description: "Live description",
+              categories: ["ai"],
+              methods: {
+                tempo: { intents: ["charge"], assets: ["0xasset"] },
+              },
+              endpoints: [
+                {
+                  method: "POST",
+                  path: "/v1/responses",
+                  payment: {
+                    intent: "charge",
+                    method: "tempo",
+                    amount: "123",
+                    currency: "0xasset",
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { GET } = await import("./pages/_api/api/services");
+    const response = await GET(
+      new Request("https://mpp.dev/api/services?ids=openai"),
+    );
+    const body = (await response.json()) as {
+      services: Array<{ name: string; endpoints?: unknown }>;
+    };
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(MPP_PROXY_MANIFEST_URL);
+    expect(body.services).toEqual([
+      expect.objectContaining({ name: "Live OpenAI" }),
+    ]);
+  });
+
+  it("falls back to the checked-in catalog when the manifest is unavailable", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 503 })),
+    );
+
+    const { GET } = await import("./pages/_api/api/services");
+    const response = await GET(
+      new Request("https://mpp.dev/api/services?ids=openai"),
+    );
+    const body = (await response.json()) as { services: Array<{ id: string }> };
+
+    expect(body.services).toEqual([expect.objectContaining({ id: "openai" })]);
+  });
+});


### PR DESCRIPTION
## Summary

- make the mpp.dev services API consume the canonical mpp-proxy discovery manifest
- replace copied proxy endpoints and prices while retaining presentation metadata
- validate service IDs, domains, categories, and endpoints before accepting live data
- keep the checked-in catalog as a last-good fallback and move the browser directory to the live API

## Validation

- pnpm check:types
- focused catalog, API, and browser registry tests (8 tests)
- pnpm check:ci
- production pnpm build

Prompted by: @brendanjryan