### PR TITLE
Add Emboss (PDF form filling, pay per call)

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11227,4 +11227,54 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── Emboss ─────────────────────────────────────────────────────────────
+  {
+    id: "emboss",
+    name: "Emboss",
+    url: "https://api.getemboss.ai",
+    serviceUrl: "https://api.getemboss.ai",
+    description:
+      "Turn flat PDF forms into fillable forms and fill them from data or documents, paid per call.",
+    icon: "https://getemboss.ai/icon",
+    categories: ["data", "ai"],
+    integration: "third-party",
+    tags: ["pdf", "forms", "form-filling", "documents", "agents"],
+    status: "active",
+    docs: {
+      homepage: "https://getemboss.ai/docs/pay-per-call/mpp",
+      llmsTxt: "https://api.getemboss.ai/pay/llms.txt",
+      apiReference: "https://api.getemboss.ai/openapi.json",
+    },
+    provider: { name: "Emboss", url: "https://getemboss.ai" },
+    realm: "api.getemboss.ai",
+    intent: "charge",
+    payments: [TEMPO_PAYMENT, STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /pay/make-fillable",
+        desc: "Make a flat PDF fillable. Input: a PDF file.",
+        dynamic: true,
+        amountHint:
+          "$0.05 to $1.00 by page count (exact price in the 402 challenge)",
+        unitType: "request",
+      },
+      {
+        route: "POST /pay/fill-with-context",
+        desc: "Fill a PDF form from supporting context documents. Input: a PDF file plus one or more context files and/or context_text/context_urls.",
+        dynamic: true,
+        amountHint:
+          "$0.07 to $12.82 by page count and context size (exact price in the 402 challenge)",
+        unitType: "request",
+      },
+      {
+        route: "POST /pay/fill",
+        desc: "Fill a PDF form from data. Input: a PDF file plus a values JSON object mapping field names to answers.",
+        dynamic: true,
+        amountHint:
+          "$0.07 to $1.02 by page count (exact price in the 402 challenge)",
+        unitType: "request",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Motivation

Emboss is a PDF-form API that accepts MPP payments in production. Agents can make a flat PDF fillable, fill a PDF from context documents, or fill a PDF from data, paid per call with no account, using Tempo stablecoins (USDC.e) or Stripe Shared Payment Tokens. Both rails are live and verified with real payments. It fills a gap in the directory (document and form processing) rather than duplicating an existing listing.

- **Service name:** Emboss
- **Live service URL:** https://api.getemboss.ai/pay
- **Provider URL:** https://getemboss.ai
- **OpenAPI or API reference URL:** https://api.getemboss.ai/openapi.json (scoped manifest with `x-payment-info` per operation; also served at /pay/openapi.json); llms.txt at https://api.getemboss.ai/pay/llms.txt; guide at https://getemboss.ai/docs/pay-per-call/mpp

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [x] `pnpm generate:discovery` succeeds.
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds.

## Key design considerations

- **Integration:** third-party
- **Payment methods and intents:** tempo (charge, USDC.e) and stripe (charge, Shared Payment Tokens). Prices are declared `dynamic` with an `amountHint` because the quote scales with page count; the 402 challenge always carries the exact amount. Base prices: make-fillable from $0.05, fill-with-context from $0.07, fill from $0.07.
- **Provider relationship:** I own and operate the service (Emboss, Three Poplars LLC d/b/a Emboss AI). Maintainer: edwin@getemboss.ai.
- **Directory fit:** Production service serving MPP directly at api.getemboss.ai (no proxy; `url` and `serviceUrl` are the same host). No existing listing covers PDF form filling.

Note on the icon: https://getemboss.ai/icon serves a PNG (the site's Next.js app icon). Happy to publish an SVG at a fixed path if the generator prefers one.

