### PR TITLE
docs: document MACH funding

### DIFF
--- a/.mppx-docs-sync
+++ b/.mppx-docs-sync
@@ -5,5 +5,5 @@
 # When updating docs from mppx changes, bump this SHA to HEAD of mppx main
 # after incorporating the new features/changes into the docs site.
 
-mppx_version=0.0.0-main-20260904175203
-mppx_sha=f494ffd58ed1ff6cba393fd6ee4e6931c285baf8
+mppx_version=https://pkg.pr.new/mppx@869
+mppx_sha=151dd1a75b360bf6f1e27fac549444fbf6fd3937

--- a/.mppx-docs-sync
+++ b/.mppx-docs-sync
@@ -6,4 +6,4 @@
 # after incorporating the new features/changes into the docs site.
 
 mppx_version=https://pkg.pr.new/mppx@869
-mppx_sha=151dd1a75b360bf6f1e27fac549444fbf6fd3937
+mppx_sha=ad5c8285dfee820416ae503c552a388da507f071

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "hono": "^4.12.27",
     "lottie-web": "^5.13.0",
     "mermaid": "^11.15.0",
-    "mppx": "0.0.0-main-20260904175203",
+    "mppx": "https://pkg.pr.new/mppx@869",
     "nuqs": "2.9.1",
     "react": "^19",
     "react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       mppx:
-        specifier: 0.0.0-main-20260904175203
-        version: 0.0.0-main-20260904175203(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
+        specifier: https://pkg.pr.new/mppx@869
+        version: https://pkg.pr.new/mppx@869(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3))
       nuqs:
         specifier: 2.9.1
         version: 2.9.1(react@19.2.7)
@@ -4098,8 +4098,28 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
-  mppx@0.0.0-main-20260904175203:
-    resolution: {integrity: sha512-pBW7iXfEVdluJahXMaVrCQi1bbDpxu+WUdEkKFNPN3Lc8dkqnUibd+fLg183FomoLYYjjRmbJcIQWdSOlBTKZQ==}
+  mppx@0.7.0:
+    resolution: {integrity: sha512-qOHQjD75wSHSZeXutngPXou8NEMIOw6RhZ/lQbo2JmDQWfOi40pLGpqXgHgwIjw4YcJHClFsI7mFXBK3Nj5WCQ==}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.25.0'
+      elysia: '>=1'
+      express: '>=5'
+      hono: '>=4.12.18'
+      viem: '>=2.51.0'
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+      elysia:
+        optional: true
+      express:
+        optional: true
+      hono:
+        optional: true
+
+  mppx@https://pkg.pr.new/mppx@869:
+    resolution: {tarball: https://pkg.pr.new/mppx@869}
+    version: 0.9.2
     hasBin: true
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.25.0'
@@ -4133,25 +4153,6 @@ packages:
       hono:
         optional: true
       next:
-        optional: true
-
-  mppx@0.7.0:
-    resolution: {integrity: sha512-qOHQjD75wSHSZeXutngPXou8NEMIOw6RhZ/lQbo2JmDQWfOi40pLGpqXgHgwIjw4YcJHClFsI7mFXBK3Nj5WCQ==}
-    hasBin: true
-    peerDependencies:
-      '@modelcontextprotocol/sdk': '>=1.25.0'
-      elysia: '>=1'
-      express: '>=5'
-      hono: '>=4.12.18'
-      viem: '>=2.51.0'
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-      elysia:
-        optional: true
-      express:
-        optional: true
-      hono:
         optional: true
 
   ms@2.1.3:
@@ -9721,12 +9722,11 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.0.0-main-20260904175203(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
-      '@stripe/stripe-js': 9.13.0
-      eventsource-parser: 3.1.1
+      '@stripe/stripe-js': 9.7.0
+      incur: 0.4.26
       ox: 0.14.33(typescript@6.0.3)(zod@4.4.3)
-      structured-headers: 2.0.3
       viem: 2.54.0(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -9736,11 +9736,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.7.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
+  mppx@https://pkg.pr.new/mppx@869(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.27)(typescript@6.0.3)(viem@2.54.0(typescript@6.0.3)(zod@4.4.3)):
     dependencies:
-      '@stripe/stripe-js': 9.7.0
-      incur: 0.4.26
+      '@stripe/stripe-js': 9.13.0
+      eventsource-parser: 3.1.1
       ox: 0.14.33(typescript@6.0.3)(zod@4.4.3)
+      structured-headers: 2.0.3
       viem: 2.54.0(typescript@6.0.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:

--- a/src/pages/payment-methods/tempo/charge.mdx
+++ b/src/pages/payment-methods/tempo/charge.mdx
@@ -87,6 +87,24 @@ const result = await mppx.charge({
 
 When `feePayer` is `true`, the server adds a fee payer signature (domain `0x78`) before broadcasting. The client doesn't need gas tokens. See [fee sponsorship](/payment-methods/tempo#fee-sponsorship) for details.
 
+### With MACH funding
+
+Set `machineTokenEnabled: true` to let compatible clients fund a single-recipient stablecoin charge with MACH. Keep `currency` set to the token the recipient receives.
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.charge({
+      machineTokenEnabled: true, // [!code hl]
+    }),
+  ],
+})
+```
+
+The server advertises the option in its Challenge. The client uses MACH only when it verifies the configured swapper route and has sufficient balance. Otherwise, it pays the stablecoin requested by the Challenge. Split charges use the standard stablecoin path.
+
 ### Zero-dollar auth
 
 Set `amount: "0"` to issue an identity-only Challenge. The client returns a `proof` payload instead of `transaction` or `hash`, and the server verifies the signature against the `source` DID.
@@ -200,9 +218,7 @@ See [`tempo.charge` server reference](/sdk/typescript/server/Method.tempo.charge
 
 ## Client
 
-Use [`tempo.charge`](/sdk/typescript/client/Method.tempo.charge) with `Mppx.create` to automatically handle `402` responses. For non-zero amounts, the client signs a TIP-20 transfer and retries with the Credential. For zero-amount Challenges, it signs a proof message and retries with a `proof` payload instead.
-
-The client also supports MACH charges. It automatically pays transaction fees with a funded supported stablecoin, so a payer doesn't need additional MACH for fees. Use [`mach`](/sdk/typescript/tempo.mach) from `mppx/tempo` to resolve the deployed address on Tempo mainnet or Moderato testnet.
+Use [`tempo.charge`](/sdk/typescript/client/Method.tempo.charge) with `Mppx.create` to automatically handle `402` responses. For non-zero amounts, the client signs a TIP-20 transfer and retries with the Credential. When the server advertises MACH funding, the client can route MACH through the configured swapper without additional client configuration. For zero-amount Challenges, it signs a proof message and retries with a `proof` payload instead.
 
 <Tabs stateKey="account-source">
 <Tab title="Accounts SDK">

--- a/src/pages/payment-methods/tempo/session.mdx
+++ b/src/pages/payment-methods/tempo/session.mdx
@@ -91,6 +91,30 @@ Either party can close the channel. The server closes the precompile-backed chan
 
 ::::
 
+## MACH funding
+
+Set `machineTokenEnabled: true` to let compatible clients fund Sessions with MACH while keeping the server's requested stablecoin as the settlement currency.
+
+```ts twoslash
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      machineTokenEnabled: true, // [!code hl]
+      store: Store.memory(),
+    }),
+  ],
+})
+```
+
+The client uses MACH only when it verifies the configured router and has sufficient balance. Otherwise, it opens the channel in the requested stablecoin. The selected rail remains fixed until the channel closes.
+
 ## Session Receipts
 
 Session Receipts differ from charge Receipts. The `reference` field contains the payment channel ID (a `bytes32` hash), not a transaction hash. The on-chain settlement transaction hash is only available after closing the channel.

--- a/src/pages/sdk/typescript/client/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.charge.mdx
@@ -62,7 +62,7 @@ const response = await fetch('https://mpp.dev/api/ping/paid')
 
 For non-zero Challenges, the client returns either a `transaction` or `hash` payload depending on `mode`. For zero-amount Challenges, it always returns a `proof` payload and skips transaction construction.
 
-For MACH charges, the client automatically selects a funded supported stablecoin for transaction fees. Import [`mach`](/sdk/typescript/tempo.mach) from `mppx/tempo` when you need the deployed token address and metadata.
+When a server advertises `machineTokenEnabled: true`, the client first tries the configured MACH swapper for a compatible single-recipient charge. If the account lacks sufficient MACH or the route can't execute, the client uses `autoSwap` when configured, then pays the stablecoin requested by the Challenge. No client option is required.
 
 ## Return type
 

--- a/src/pages/sdk/typescript/client/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/client/Method.tempo.session.mdx
@@ -196,6 +196,8 @@ When `Fetch.from` or `Mppx.create` opens a channel automatically, it keeps the n
 
 Direct Credential creation and `tempo.session.manager()` keep explicit lifecycle ownership.
 
+When the server advertises MACH funding, the client uses MACH if a verified route and sufficient balance are available. Otherwise, it opens the channel in the requested stablecoin. The channel keeps that rail until it closes; no client option is required.
+
 ## Return type
 
 ```ts

--- a/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.charge.mdx
@@ -146,6 +146,24 @@ const mppx = Mppx.create({
 })
 ```
 
+### With MACH funding
+
+Keep the charge currency set to the stablecoin the recipient receives, then enable the configured MACH swapper for compatible clients.
+
+```ts twoslash
+import { Mppx, tempo } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.charge({
+      machineTokenEnabled: true, // [!code focus]
+    }),
+  ],
+})
+```
+
+The client uses MACH when the route is verified and its balance is sufficient. Otherwise, it pays the stablecoin requested by the Challenge. Split charges use the standard stablecoin path.
+
 ### With Tempo API relay
 
 Delegate Tempo charge validation and finalization to Tempo API. The relay preserves this method's Challenge configuration and needs an API key with the `mpp:write` scope. It broadcasts `pull` Credentials and recognizes `push` Credentials as already broadcast.
@@ -284,6 +302,13 @@ Function that returns a viem client for the given chain ID. Overrides the defaul
 
 Renders a payment page when the request accepts `text/html`. Pass an object to customize the page.
 
+### machineTokenEnabled (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Advertises the configured MACH settlement route for compatible single-recipient charges. Clients try MACH before `autoSwap` or the requested stablecoin transfer. Unsupported chains reject the request.
+
 ### memo (optional)
 
 - **Type:** `string`
@@ -398,6 +423,12 @@ ISO 8601 timestamp for when the payment Challenge expires.
 - **Type:** `Record<string, string>`
 
 Server-defined correlation data. `mppx` serializes it as the base64url-encoded `opaque` auth-param on the Challenge, and clients echo that same string back in the Credential.
+
+### machineTokenEnabled (optional)
+
+- **Type:** `boolean`
+
+Overrides MACH settlement for this request. The configured method default applies when omitted.
 
 ### recipient
 

--- a/src/pages/sdk/typescript/server/Method.tempo.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.mdx
@@ -125,6 +125,13 @@ Account or remote service for sponsoring transaction fees. Pass a viem `Account`
 
 Function that returns a viem client for the given chain ID. Overrides the default RPC configuration.
 
+### machineTokenEnabled (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Enables MACH funding for the generated `tempo.charge` and `tempo.session` methods. Compatible clients use MACH when a verified route and sufficient balance are available, then fall back to the requested stablecoin.
+
 ### onPaymentSuccess (optional)
 
 - **Type:** `Method.OnPaymentSuccessFn<typeof tempo.Methods.charge> & Method.OnPaymentSuccessFn<typeof tempo.Methods.session>`

--- a/src/pages/sdk/typescript/server/Method.tempo.session.mdx
+++ b/src/pages/sdk/typescript/server/Method.tempo.session.mdx
@@ -80,6 +80,30 @@ const mppx = Mppx.create({
 })
 ```
 
+### With MACH funding
+
+Keep the Session currency set to the stablecoin the recipient receives, then enable MACH funding for compatible clients.
+
+```ts twoslash
+import { Mppx, Store, tempo } from 'mppx/server'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      currency: '0x20c0000000000000000000000000000000000000', // pathUSD on Tempo
+      machineTokenEnabled: true, // [!code focus]
+      store: Store.memory(),
+    }),
+  ],
+})
+```
+
+The client uses MACH when the route is verified and its balance is sufficient. Otherwise, it opens the channel in the requested stablecoin. A Session stays on its selected payment rail until it closes.
+
 ## Migrate from Legacy Sessions
 
 Register `tempo.session()` beside `tempo.sessionLegacy()` during migration so existing clients keep working while new clients use Sessions. This server-side migration configuration requires `mppx` 0.8.15 or earlier.
@@ -246,6 +270,13 @@ Fee token used for Session management, scheduled settlement, and cooperative clo
 - **Type:** `(parameters: { chainId?: number }) => MaybePromise<Client>`
 
 Function that returns a viem client for the given chain ID.
+
+### machineTokenEnabled (optional)
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Advertises MACH funding when the configured router is available. Clients use MACH when a verified route and sufficient balance are available, then fall back to the requested stablecoin.
 
 ### minVoucherDelta (optional)
 

--- a/src/pages/sdk/typescript/tempo.mach.mdx
+++ b/src/pages/sdk/typescript/tempo.mach.mdx
@@ -18,7 +18,7 @@ console.log(token.symbol)
 // @log: MACH
 ```
 
-When a Tempo charge requests MACH, the `mppx` client automatically selects a funded supported stablecoin for transaction fees. The payer doesn't need to hold extra MACH for fees.
+Use this helper for balances, spending limits, and display. Keep the server's payment currency set to the stablecoin the recipient receives. To accept MACH-funded payments, set `machineTokenEnabled: true` on the Tempo server method; compatible clients route MACH through the configured swapper.
 
 ## Return type
 


### PR DESCRIPTION
## Why

Document MACH as an opt-in funding rail through the configured swapper instead of a directly requested charge currency. This tracks wevm/mppx#869.

## What

- document `machineTokenEnabled` for Tempo charges and Sessions
- keep settlement currencies as stablecoins and describe MACH routing and fallback behavior
- retain `tempo.mach` for token metadata, balances, limits, and display
- validate examples against the mppx #869 preview