### PR TITLE
feat: add Bimini Sonar service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -780,6 +780,65 @@ export const services: ServiceDef[] = [
     ],
   },
 
+  // ── Bimini Sonar ───────────────────────────────────────────────────────
+  {
+    id: "bimini-sonar",
+    name: "Bimini Sonar",
+    url: "https://sonar.bimini.one",
+    serviceUrl: "https://sonar.bimini.one",
+    description:
+      "Daily forward-looking market assessment — Tailwind, Headwind or Crosswind — with a transparent chain of reasoning, plus the economic events and central-bank transcripts behind it. Paid per call, no account or API key.",
+    categories: ["data"],
+    integration: "first-party",
+    tags: [
+      "finance",
+      "macro",
+      "economics",
+      "market-data",
+      "central-banks",
+      "analysis",
+    ],
+    status: "active",
+    docs: {
+      homepage: "https://sonar.bimini.one/agents",
+      apiReference: "https://sonar.bimini.one/openapi.json",
+    },
+    provider: { name: "Bimini One, Inc.", url: "https://bimini.one" },
+    realm: "sonar.bimini.one",
+    intent: "charge",
+    payments: [STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "GET /api/data/economic-events",
+        desc: "Economic releases with a directional assessment and supporting analysis",
+        amount: "100",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/data/transcripts",
+        desc: "Central-bank speeches and testimony with a directional assessment",
+        amount: "300",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/data/briefs/:external_id",
+        desc: "Full daily intelligence brief body",
+        amount: "633",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/data/briefs",
+        desc: "Brief catalogue — free",
+        unitType: "request",
+      },
+      {
+        route: "GET /api/data",
+        desc: "Discovery manifest — endpoints, live prices and return shapes",
+        unitType: "request",
+      },
+    ],
+  },
+
   // ── Browserbase ────────────────────────────────────────────────────────
   {
     id: "browserbase",


### PR DESCRIPTION
Motivation

Service: Bimini Sonar — Agent Data API
Live URL: https://sonar.bimini.one/agents
Provider: Bimini One, Inc. — https://bimini.one
API documentation (OpenAPI 3.1): https://sonar.bimini.one/openapi.json
Human-readable manifest: https://sonar.bimini.one/api/data

Bimini Sonar publishes a daily forward-looking assessment of monetary and credit conditions — Tailwind, Headwind or Crosswind — together with the transparent chain of reasoning behind it, and the underlying economic releases and central-bank transcripts.

This is not a raw data feed. Prices, releases and transcripts are already commodity inputs an agent can get anywhere. What is sold here is the directional judgement and the reasoning that produced it: each economic release and transcript carries a plain-language assessment of what it means for conditions, and each daily brief carries an explicit chain of logic connecting the day's events to that read. That is the part an agent cannot derive from the raw inputs, and it is why this is a useful addition rather than another wrapper over public data.

Pricing is flat per call, deliberately sized for repeated lookups rather than bulk export. There is no account, no API key and no subscription — an agent discovers the manifest, requests an endpoint, pays the 402 challenge and receives the data with a receipt.

Summary

- [x] Service accepts MPP payments — live and verified with a real settled charge
- [x] Entry added to schemas/services.ts
- [x] Listed endpoints, prices and payment methods match the live service
- [x] Documentation URLs resolve
- [x] Build passes

Design considerations

First-party or third-party? First-party. Bimini One, Inc. operates the service and submitted this entry.

Supported payment methods. Stripe Shared Payment Token — card and link, declared via the existing STRIPE_PAYMENT constant. The 402 advertises realm="sonar.bimini.one", intent="charge". Endpoint amounts are in base units (cents, per decimals: 2). A USDC rail is built and currently disabled; we'll submit an update if and when it's switched on rather than list something that isn't live.

Provider relationship. We are the provider.

Why include it? The directory is mostly infrastructure and raw data. This is analysis with a stated methodology and a reasoning trail attached to every item — a category that's thin here, and one where per-call pricing is a natural fit, since an agent typically wants today's read rather than a standing subscription. The free discovery manifest and free brief catalogue let an agent evaluate the service and browse the full backlist before spending anything.

Verification. The rail is proven, not aspirational: a real card payment settled end to end on 2026-09-10 and is visible in our metering. Endpoints return 402 with a well-formed WWW-Authenticate: Payment challenge; paying and retrying returns 200 with a Payment-Receipt.