### PR TITLE
feat: add ToolRouter service

### DIFF
--- a/schemas/services.ts
+++ b/schemas/services.ts
@@ -11227,4 +11227,37 @@ export const services: ServiceDef[] = [
       },
     ],
   },
+
+  // ── ToolRouter ──────────────────────────────────────────────────────
+  {
+    id: "toolrouter",
+    name: "ToolRouter",
+    url: "https://toolrouter.com",
+    serviceUrl: "https://api.toolrouter.com",
+    description:
+      "One MCP endpoint with hundreds of paid tools — web search, scraping, image and video generation, data lookups. Agents buy prepaid credits with MPP, then spend them per tool call.",
+    icon: "https://toolrouter.com/icon-256.png",
+    categories: ["ai", "data", "media", "search", "web"],
+    integration: "first-party",
+    tags: ["mcp", "tools", "credits", "agents", "search", "scraping", "image-generation"],
+    status: "active",
+    docs: {
+      homepage: "https://toolrouter.com/docs/billing",
+      llmsTxt: "https://toolrouter.com/llms.txt",
+      apiReference: "https://toolrouter.com/openapi.json",
+    },
+    provider: { name: "ToolRouter", url: "https://toolrouter.com" },
+    realm: "api.toolrouter.com",
+    intent: "charge",
+    payments: [STRIPE_PAYMENT],
+    endpoints: [
+      {
+        route: "POST /v1/billing/machine-topup",
+        desc: "Buy ToolRouter credits. Send a ToolRouter API key with { amount_usd } to get the 402 challenge, pay it, retry with the credential.",
+        dynamic: true,
+        amountHint: "$1 – $500 of credits plus purchase fee (5.5%, min $0.80)",
+        docs: "https://toolrouter.com/docs/billing",
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
## Motivation

ToolRouter is "OpenRouter for tools": one API key and one MCP connection to 266 hosted agent tools (web search, scraping, screenshots, SEO audits, image and video generation, lead finding, market data). Agents can get a free key and then buy credits for themselves over MPP, with no human in the loop. We recently added Jev, our intent router, to improve performance: an agent sends one plain-English request and Jev picks the right tool, skill and arguments.

- **Service name:** ToolRouter
- **Live service URL:** https://api.toolrouter.com
- **Provider URL:** https://toolrouter.com
- **OpenAPI or API reference URL:** https://api.toolrouter.com/openapi.json

## Summary

- [x] The service is live and accepts MPP payments.
- [x] This PR adds or updates its entry in `schemas/services.ts`.
- [x] Listed endpoints, prices, and payment methods match the live service.
- [x] Public documentation and icon URLs are stable and accessible.
- [x] `pnpm generate:discovery` succeeds.
- [x] `pnpm check:types` passes.
- [x] `pnpm build` succeeds.

## Key design considerations

- **Integration:** first-party
- **Payment methods and intents:** Stripe (SPT cards), `charge`. Challenges on `POST /v1/billing/machine-topup` are minted per account, so the request carries the API key from `POST /v1/auth/provision` (free).
- **Provider relationship:** We own and operate ToolRouter.
- **Directory fit:** A tool aggregator, not a duplicate of any single-provider listing. Tool calls cost from $0.005, below the $0.50 SPT floor, so agents top up credits in one payment and spend them per call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
